### PR TITLE
Add name property to horizontal thumb in Syntax Visualizer for accessibility

### DIFF
--- a/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
+++ b/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
@@ -87,7 +87,7 @@
                 </ContextMenu>
             </TreeView.ContextMenu>
         </TreeView>
-        <GridSplitter Grid.Row="2" AutomationProperties.Name ="Horizontal" ResizeDirection="Rows" HorizontalAlignment="Stretch" Height="5"/>
+        <GridSplitter Grid.Row="2" AutomationProperties.Name="Horizontal" ResizeDirection="Rows" HorizontalAlignment="Stretch" Height="5"/>
         <Grid Grid.Row="3">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>

--- a/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
+++ b/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
@@ -86,7 +86,7 @@
                 </ContextMenu>
             </TreeView.ContextMenu>
         </TreeView>
-        <GridSplitter Grid.Row="2" ResizeDirection="Rows" HorizontalAlignment="Stretch" Height="5"/>
+        <GridSplitter Grid.Row="2" AutomationProperties.Name ="Horizontal" ResizeDirection="Rows" HorizontalAlignment="Stretch" Height="5"/>
         <Grid Grid.Row="3">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>


### PR DESCRIPTION
The name property is empty for the horizontal thumb, which is on the bottom of the syntax tree item page of the Syntax visualizer pane.  This PR adds the name for the horizontal thumb so it can be displayed and read by the screen reader.