### PR TITLE
Enable proper cyclic tab navigation in the visualizer.

### DIFF
--- a/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
+++ b/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
@@ -4,8 +4,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:custom="clr-namespace:Roslyn.SyntaxVisualizer.Control"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="300">
     <Grid Margin="5"

--- a/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
+++ b/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
@@ -5,9 +5,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:custom="clr-namespace:Roslyn.SyntaxVisualizer.Control"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="300">
-    <Grid Margin="5">
+    <Grid Margin="5"
+          KeyboardNavigation.TabNavigation="Cycle">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -110,7 +112,7 @@
                     <Label Grid.Row="2" Grid.Column="1" Name="kindValueLabel" Padding="5,2,5,2"/>
                 </Grid>
             </Border>
-            <WindowsFormsHost Grid.Row="1" Name="windowsFormsHost" Padding="5" />
+            <WindowsFormsHost Grid.Row="1" x:Name="windowsFormsHost" Padding="0" />
         </Grid>
     </Grid>
 </UserControl>

--- a/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
+++ b/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
@@ -72,7 +72,14 @@ namespace Roslyn.SyntaxVisualizer.Control
                 ToolbarVisible = false,
                 CommandsVisibleIfAvailable = false
             };
-            windowsFormsHost.Child = _propertyGrid;
+            var tabStopPanel = new TabStopPanel(windowsFormsHost)
+            {
+                PropertyGrid = _propertyGrid,
+                BorderStyle = System.Windows.Forms.BorderStyle.None,
+                Padding = System.Windows.Forms.Padding.Empty,
+                Margin = System.Windows.Forms.Padding.Empty
+            };
+            windowsFormsHost.Child = tabStopPanel;
         }
 
         public void Clear()

--- a/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/TabStopPanel.cs
+++ b/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/TabStopPanel.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Windows.Forms;
+using System.Windows.Input;
+using System.Windows.Interop;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    /// <summary>
+    /// Routes tab events from WinForms to WPF when the bottom or top of the form is reached,
+    /// so that cyclic tab movement works correctly.
+    /// </summary>
+    internal class TabStopPanel : Panel
+    {
+        private readonly HwndHost _wpfHost;
+        private PropertyGrid _propertyGrid;
+        public TabStopPanel(HwndHost wpfHost)
+        {
+            _wpfHost = wpfHost;
+        }
+
+        public PropertyGrid PropertyGrid
+        {
+            get => _propertyGrid;
+            set
+            {
+                if (_propertyGrid != null)
+                {
+                    throw new ArgumentException("Cannot initialize PropertyGrid twice", nameof(value));
+                }
+
+                _propertyGrid = value;
+                Controls.Add(_propertyGrid);
+            }
+        }
+        protected override bool ProcessDialogKey(Keys keyData)
+        {
+            if (base.ProcessDialogKey(keyData))
+            {
+                return true;
+            }
+            else if ((keyData & (Keys.Alt | Keys.Control)) == Keys.None)
+            {
+                var keyCode = keyData & Keys.KeyCode;
+                if (keyCode == Keys.Tab)
+                {
+                    IKeyboardInputSink sink = _wpfHost;
+                    return sink.KeyboardInputSite.OnNoMoreTabStops(new TraversalRequest((keyData & Keys.Shift) == Keys.None ?
+                        FocusNavigationDirection.Next : FocusNavigationDirection.Previous));
+                }
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes bug [483427](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/483427) in VSO. This adds a component that routes tabs from WinForms to WPF, as WinForms intercepts the Tab and Shift+Tab commands before WPF can see them. Also enables cyclic navigation in the syntax visualizer itself.