### PR TITLE
Syntax Visualizer accessibility - selected tree item in Syntax Tree is not visible in HC white theme

### DIFF
--- a/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
+++ b/src/Tools/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
@@ -35,6 +35,8 @@ namespace Roslyn.SyntaxVisualizer.Control
 
         #region Private State
         private TreeViewItem _currentSelection;
+        private Brush _previousForeground;
+        private Brush _previousBackground;
         private bool _isNavigatingFromSourceToTree;
         private bool _isNavigatingFromTreeToSource;
         private readonly System.Windows.Forms.PropertyGrid _propertyGrid;
@@ -656,7 +658,21 @@ namespace Roslyn.SyntaxVisualizer.Control
         {
             if (treeView.SelectedItem != null)
             {
+                if (_previousBackground != null)
+                {
+                    _currentSelection.Background = _previousBackground;
+                }
+
+                if (_previousForeground != null)
+                {
+                    _currentSelection.Foreground = _previousForeground;
+                }
+
                 _currentSelection = (TreeViewItem)treeView.SelectedItem;
+                _previousBackground = _currentSelection.Background;
+                _previousForeground = _currentSelection.Foreground;
+                _currentSelection.Foreground = SystemColors.HighlightTextBrush;
+                _currentSelection.Background = SystemColors.HighlightBrush;
             }
         }
 


### PR DESCRIPTION
Fixes bug https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=483440 

In HC White mode, when selecting an item in the Syntax Tree pane of the Syntax Visualizer, both the text and the background were dark so the text could not be read.