### PR TITLE
create unique template id names for item templates

### DIFF
--- a/src/Templates/VS2017/ItemTemplates/CSharp/Analyzer/CSharpAnalyzer.vstemplate
+++ b/src/Templates/VS2017/ItemTemplates/CSharp/Analyzer/CSharpAnalyzer.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
-    <TemplateID>Microsoft.CSharp.Class</TemplateID>
+    <TemplateID>Microsoft.CodeAnalysis.CSharp.Analyzer</TemplateID>
     <DefaultName>Analyzer.cs</DefaultName>
     <Name>Analyzer</Name>
     <Description>Create a C# diagnostic analyzer.</Description>

--- a/src/Templates/VS2017/ItemTemplates/CSharp/CodeFix/CSharpCodeFix.vstemplate
+++ b/src/Templates/VS2017/ItemTemplates/CSharp/CodeFix/CSharpCodeFix.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
-    <TemplateID>Microsoft.CSharp.Class</TemplateID>
+    <TemplateID>Microsoft.CodeAnalysis.CSharp.CodeFix</TemplateID>
     <DefaultName>CodeFix.cs</DefaultName>
     <Name>CodeFix</Name>
     <Description>Create a C# code fix.</Description>

--- a/src/Templates/VS2017/ItemTemplates/CSharp/Refactoring/CSharpRefactoring.vstemplate
+++ b/src/Templates/VS2017/ItemTemplates/CSharp/Refactoring/CSharpRefactoring.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
-    <TemplateID>Microsoft.CSharp.Class</TemplateID>
+    <TemplateID>Microsoft.CodeAnalysis.CSharp.Refactoring</TemplateID>
     <DefaultName>Refactoring.cs</DefaultName>
     <Name>Refactoring</Name>
     <Description>Create a C# code refactoring.</Description>

--- a/src/Templates/VS2017/ItemTemplates/VisualBasic/Analyzer/VBAnalyzer.vstemplate
+++ b/src/Templates/VS2017/ItemTemplates/VisualBasic/Analyzer/VBAnalyzer.vstemplate
@@ -1,7 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
-    <!-- The TemplateID needs to be one of those recognized by VS in order for the ItemTemplate to appear in a portable project-->
-    <TemplateID>Microsoft.VisualBasic.Internal.AssemblyInfo</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.CodeAnalysis.Analyzer</TemplateID>
     <DefaultName>Analyzer.vb</DefaultName>
     <Name>Analyzer</Name>
     <Description>Create a Visual Basic diagnostic analyzer.</Description>

--- a/src/Templates/VS2017/ItemTemplates/VisualBasic/CodeFix/VBCodeFix.vstemplate
+++ b/src/Templates/VS2017/ItemTemplates/VisualBasic/CodeFix/VBCodeFix.vstemplate
@@ -1,7 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
-    <!-- The TemplateID needs to be one of those recognized by VS in order for the ItemTemplate to appear in a portable project-->
-    <TemplateID>Microsoft.VisualBasic.Internal.AssemblyInfo</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.CodeAnalysis.CodeFix</TemplateID>
     <DefaultName>CodeFix.vb</DefaultName>
     <Name>CodeFix</Name>
     <Description>Create a Visual Basic code fix.</Description>

--- a/src/Templates/VS2017/ItemTemplates/VisualBasic/Refactoring/VBRefactoring.vstemplate
+++ b/src/Templates/VS2017/ItemTemplates/VisualBasic/Refactoring/VBRefactoring.vstemplate
@@ -1,7 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
   <TemplateData>
-    <!-- The TemplateID needs to be one of those recognized by VS in order for the ItemTemplate to appear in a portable project-->
-    <TemplateID>Microsoft.VisualBasic.Internal.AssemblyInfo</TemplateID>
+    <TemplateID>Microsoft.VisualBasic.CodeAnalysis.Refactoring</TemplateID>
     <DefaultName>Refactoring.vb</DefaultName>
     <Name>Refactoring</Name>
     <Description>Create a Visual Basic refactoring.</Description>


### PR DESCRIPTION
Previously these needed to be non-unique to appear in the PCL item template list.  This is not necessary in netstandard project items.

fixes https://github.com/dotnet/roslyn-sdk/issues/97