### PR TITLE
updating vssdk to use Microsoft.CodeAnalysis.Workspaces.MSBuild

### DIFF
--- a/src/Templates/VS2017/ProjectTemplates/CSharp/ConsoleApplication/ConsoleApplication.csproj
+++ b/src/Templates/VS2017/ProjectTemplates/CSharp/ConsoleApplication/ConsoleApplication.csproj
@@ -3,13 +3,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net461</TargetFramework>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.3.409" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.409" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="[2.6.0]" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="[2.6.1]"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/VS2017/ProjectTemplates/CSharp/ConsoleApplication/Program.cs
+++ b/src/Templates/VS2017/ProjectTemplates/CSharp/ConsoleApplication/Program.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -13,9 +16,75 @@ namespace $safeprojectname$
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
-            var workspace = MSBuildWorkspace.Create();
+            // Attempt to set the version of MSBuild.
+            var visualStudioInstances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
+            var instance = visualStudioInstances.Length == 1
+                // If there is only one instance of MSBuild on this machine, set that as the one to use.
+                ? visualStudioInstances[0]
+                // Handle selecting the version of MSBuild you want to use.
+                : SelectVisualStudioInstance(visualStudioInstances);
+
+            Console.WriteLine($"Using MSBuild at '{instance.MSBuildPath}' to load projects.");
+
+            // NOTE: Be sure to register an instance with the MSBuildLocator 
+            //       before calling MSBuildWorkspace.Create()
+            //       otherwise, MSBuildWorkspace won't MEF compose.
+            MSBuildLocator.RegisterInstance(instance);
+            
+            using (var workspace = MSBuildWorkspace.Create())
+            {
+                // Print message for WorkspaceFailed event to help diagnosing project load failures.
+                workspace.WorkspaceFailed += (o, e) => Console.WriteLine(e.Diagnostic.Message);
+
+                var solutionPath = args[0];
+                Console.WriteLine($"Loading solution '{solutionPath}'");
+
+                // Attach progress reporter so we print projects as they are loaded.
+                var solution = await workspace.OpenSolutionAsync(solutionPath, new ConsoleProgressReporter());
+                Console.WriteLine($"Finished loading solution '{solutionPath}'");
+
+                // TODO: Do analysis on the projects in the loaded solution
+            }
+        }
+        
+                private static VisualStudioInstance SelectVisualStudioInstance(VisualStudioInstance[] visualStudioInstances)
+        {
+            Console.WriteLine("Multiple installs of MSBuild detected please select one:");
+            for (int i = 0; i < visualStudioInstances.Length; i++)
+            {
+                Console.WriteLine($"Instance {i + 1}");
+                Console.WriteLine($"    Name: {visualStudioInstances[i].Name}");
+                Console.WriteLine($"    Version: {visualStudioInstances[i].Version}");
+                Console.WriteLine($"    MSBuild Path: {visualStudioInstances[i].MSBuildPath}");
+            }
+
+            while (true)
+            {
+                var userResponse = Console.ReadLine();
+                if (int.TryParse(userResponse, out int instanceNumber) &&
+                    instanceNumber > 0 &&
+                    instanceNumber <= visualStudioInstances.Length)
+                {
+                    return visualStudioInstances[instanceNumber - 1];
+                }
+                Console.WriteLine("Input not accepted, try again.");
+            }
+        }
+
+        private class ConsoleProgressReporter : IProgress<ProjectLoadProgress>
+        {
+            public void Report(ProjectLoadProgress loadProgress)
+            {
+                var projectDisplay = Path.GetFileName(loadProgress.FilePath);
+                if (loadProgress.TargetFramework != null)
+                {
+                    projectDisplay += $" ({loadProgress.TargetFramework})";
+                }
+
+                Console.WriteLine($"{loadProgress.Operation,-15} {loadProgress.ElapsedTime,-15:m\\:ss\\.fffffff} {projectDisplay}");
+            }
         }
     }
 }

--- a/src/Templates/VS2017/ProjectTemplates/CSharp/ConsoleApplication/Program.cs
+++ b/src/Templates/VS2017/ProjectTemplates/CSharp/ConsoleApplication/Program.cs
@@ -49,7 +49,7 @@ namespace $safeprojectname$
             }
         }
         
-                private static VisualStudioInstance SelectVisualStudioInstance(VisualStudioInstance[] visualStudioInstances)
+        private static VisualStudioInstance SelectVisualStudioInstance(VisualStudioInstance[] visualStudioInstances)
         {
             Console.WriteLine("Multiple installs of MSBuild detected please select one:");
             for (int i = 0; i < visualStudioInstances.Length; i++)

--- a/src/Templates/VS2017/ProjectTemplates/VisualBasic/ConsoleApplication/ConsoleApplication.vbproj
+++ b/src/Templates/VS2017/ProjectTemplates/VisualBasic/ConsoleApplication/ConsoleApplication.vbproj
@@ -2,14 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <RootNamespace>$safeprojectname$</RootNamespace>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.3.409" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.409" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="[2.6.0]" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.8.2" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="[2.6.1]" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/VS2017/ProjectTemplates/VisualBasic/ConsoleApplication/Module1.vb
+++ b/src/Templates/VS2017/ProjectTemplates/VisualBasic/ConsoleApplication/Module1.vb
@@ -55,7 +55,7 @@ Module $safeprojectname$
         While True
             Dim userResponse = Console.ReadLine()
             Dim instanceNumber As Integer = 0
-            If (Integer.TryParse(userResponse, instanceNumber) AndAlso instanceNumber > 0 AndAlso instanceNumber <= visualStudioInstances.Length) Then
+            If Integer.TryParse(userResponse, instanceNumber) AndAlso instanceNumber > 0 AndAlso instanceNumber <= visualStudioInstances.Length Then
                 Return visualStudioInstances(instanceNumber - 1)
             End If
             Console.WriteLine("Input not accepted, try again.")

--- a/src/Templates/VS2017/ProjectTemplates/VisualBasic/ConsoleApplication/Module1.vb
+++ b/src/Templates/VS2017/ProjectTemplates/VisualBasic/ConsoleApplication/Module1.vb
@@ -1,7 +1,10 @@
 ﻿Imports System
 Imports System.Collections.Generic
+Imports System.IO
 Imports System.Linq
 Imports System.Text
+Imports System.Threading.Tasks
+Imports Microsoft.Build.Locator
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
@@ -11,8 +14,67 @@ Imports Microsoft.CodeAnalysis.Text
 
 Module $safeprojectname$
 
-    Sub Main()
-        Dim workspace = MSBuildWorkspace.Create
+    Sub Main(args As String())
+        ' Attempt to set the version of MSBuild.
+        Dim visualStudioInstances = MSBuildLocator.QueryVisualStudioInstances().ToArray()
+        Dim instance = If(visualStudioInstances.Length = 1, visualStudioInstances(0), SelectVisualStudioInstance(visualStudioInstances))
+
+        Console.WriteLine($"Using MSBuild at '{instance.MSBuildPath}' to load projects.")
+
+        ' NOTE: Be sure to register an instance with the MSBuildLocator 
+        '       before calling MSBuildWorkspace.Create()
+        '       otherwise, MSBuildWorkspace won't MEF compose.
+        MSBuildLocator.RegisterInstance(instance)
+
+        Using workspace = MSBuildWorkspace.Create()
+            ' Print message for WorkspaceFailed event to help diagnosing project load failures.
+            AddHandler workspace.WorkspaceFailed, Sub(o, e)
+                                                      Console.WriteLine(e.Diagnostic.Message)
+                                                  End Sub
+
+            Dim solutionPath = args(0)
+            Console.WriteLine($"Loading solution '{solutionPath}'")
+
+            ' Attach progress reporter so we print projects as they are loaded.
+            Dim solution = workspace.OpenSolutionAsync(solutionPath, New ConsoleProgressReporter()).GetAwaiter.GetResult
+            Console.WriteLine($"Finished loading solution '{solutionPath}'")
+
+            ' TODO: Do analysis on the projects in the loaded solution
+        End Using
     End Sub
+
+    Function SelectVisualStudioInstance(visualStudioInstances As VisualStudioInstance()) As VisualStudioInstance
+        Console.WriteLine("Multiple installs of MSBuild detected please select one:")
+        For index = 0 To visualStudioInstances.Length
+            Console.WriteLine($"Instance {index + 1}")
+            Console.WriteLine($"    Name: {visualStudioInstances(index).Name}")
+            Console.WriteLine($"    Version: {visualStudioInstances(index).Version}")
+            Console.WriteLine($"    MSBuild Path: {visualStudioInstances(index).MSBuildPath}")
+        Next
+
+        While True
+            Dim userResponse = Console.ReadLine()
+            Dim instanceNumber As Integer = 0
+            If (Integer.TryParse(userResponse, instanceNumber) AndAlso instanceNumber > 0 AndAlso instanceNumber <= visualStudioInstances.Length) Then
+                Return visualStudioInstances(instanceNumber - 1)
+            End If
+            Console.WriteLine("Input not accepted, try again.")
+        End While
+
+        Return Nothing
+    End Function
+
+    Private Class ConsoleProgressReporter
+        Implements IProgress(Of ProjectLoadProgress)
+
+        Public Sub Report(loadProgress As ProjectLoadProgress) Implements IProgress(Of ProjectLoadProgress).Report
+            Dim projectDisplay = Path.GetFileName(loadProgress.FilePath)
+            If loadProgress.TargetFramework IsNot Nothing Then
+                projectDisplay += $" ({loadProgress.TargetFramework})"
+            End If
+
+            Console.WriteLine($"{loadProgress.Operation,-15} {loadProgress.ElapsedTime,-15:m\:ss\.fffffff} {projectDisplay}")
+        End Sub
+    End Class
 
 End Module


### PR DESCRIPTION
Updating the templates to use Microsoft.CodeAnalysis.Workspaces.MSBuild.  This depends on 2.9 version of the roslyn packages being placed on nuget.