### PR TITLE
Add diagnostic and code fix verification helpers

### DIFF
--- a/Samples.sln
+++ b/Samples.sln
@@ -115,6 +115,8 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "VisualBasicToCSharpConverte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SolutionExplorer", "samples\CSharp\SolutionExplorer\SolutionExplorer.csproj", "{B0474F4F-A6A9-4F10-BC49-CE2957201DBB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.UnitTestFramework.Test", "samples\Shared\UnitTestFramework.Test\Roslyn.UnitTestFramework.Test.csproj", "{04DABE2E-7230-4992-8E8B-F6BEACB11AA5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -281,6 +283,10 @@ Global
 		{B0474F4F-A6A9-4F10-BC49-CE2957201DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0474F4F-A6A9-4F10-BC49-CE2957201DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0474F4F-A6A9-4F10-BC49-CE2957201DBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{04DABE2E-7230-4992-8E8B-F6BEACB11AA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{04DABE2E-7230-4992-8E8B-F6BEACB11AA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{04DABE2E-7230-4992-8E8B-F6BEACB11AA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{04DABE2E-7230-4992-8E8B-F6BEACB11AA5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -339,6 +345,7 @@ Global
 		{ECB83742-8023-4609-B139-D7B78DD66ED9} = {8E1C9AEC-6EF1-43A8-A378-52C5C0E40532}
 		{5B7D7569-B5EE-4C01-9AFA-BC1958588160} = {8E1C9AEC-6EF1-43A8-A378-52C5C0E40532}
 		{B0474F4F-A6A9-4F10-BC49-CE2957201DBB} = {C3FB27E9-C8EE-4F76-B0AA-7CD67A7E652B}
+		{04DABE2E-7230-4992-8E8B-F6BEACB11AA5} = {A54A1AB7-DBD6-4C31-A22E-C53674137C53}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B849838B-3D7A-4B6B-BE07-285DCB1588F4}

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,25 @@
+﻿Roslyn SDK uses third-party libraries or other resources that may be
+distributed under licenses different than the Roslyn SDK software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention. Post an issue or email us:
+
+           dotnet@microsoft.com
+
+The attached notices are provided for information only.
+
+License notice for StyleCop Analyzers
+-------------------------------------
+
+Copyright (c) Tunnel Vision Laboratories, LLC. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+these files except in compliance with the License. You may obtain a copy of the
+License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/samples/CSharp/ConvertToConditional/ConvertToConditional.Test/ConvertToConditional.Test.csproj
+++ b/samples/CSharp/ConvertToConditional/ConvertToConditional.Test/ConvertToConditional.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/samples/Shared/UnitTestFramework.Test/CSharpSyntaxTreeDiagnosticAnalyzer.cs
+++ b/samples/Shared/UnitTestFramework.Test/CSharpSyntaxTreeDiagnosticAnalyzer.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Roslyn.UnitTestFramework.Test
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class CSharpSyntaxTreeDiagnosticAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "TEST01";
+        public static readonly LocalizableString Title = "Test title";
+        public static readonly LocalizableString MessageFormat = "Semicolons should be {0} by a space";
+        public static readonly string Category = "Test";
+        public static readonly DiagnosticSeverity DefaultSeverity = DiagnosticSeverity.Warning;
+        public static readonly bool IsEnabledByDefault = true;
+        public static readonly LocalizableString Description = "Test description";
+        public static readonly string HelpLinkUri = "https://github.com/dotnet/roslyn-sdk";
+        public static readonly ImmutableArray<string> CustomTags = ImmutableArray.Create(WellKnownDiagnosticTags.Unnecessary);
+
+        private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DefaultSeverity, IsEnabledByDefault, Description, HelpLinkUri, CustomTags.ToArray());
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxTreeAction(HandleSyntaxTree);
+        }
+
+        private static void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
+        {
+            SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
+            foreach (SyntaxToken token in root.DescendantTokens())
+            {
+                switch (token.Kind())
+                {
+                case SyntaxKind.SemicolonToken:
+                    HandleSemicolonToken(context, token);
+                    break;
+
+                default:
+                    break;
+                }
+            }
+        }
+
+        private static void HandleSemicolonToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
+        {
+            // check for a following space
+            bool missingFollowingSpace = true;
+            if (token.HasTrailingTrivia)
+            {
+                if (token.TrailingTrivia.First().IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    missingFollowingSpace = false;
+                }
+            }
+
+            if (missingFollowingSpace)
+            {
+                // semicolon should{} be {followed} by a space
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.InsertFollowing, "followed"));
+            }
+        }
+
+        internal static class TokenSpacingProperties
+        {
+            internal const string LocationKey = "location";
+            internal const string ActionKey = "action";
+            internal const string LocationFollowing = "following";
+            internal const string ActionInsert = "insert";
+
+            internal static ImmutableDictionary<string, string> InsertFollowing { get; } =
+                ImmutableDictionary<string, string>.Empty
+                    .SetItem(LocationKey, LocationFollowing)
+                    .SetItem(ActionKey, ActionInsert);
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework.Test/DiagnosticVerifierTest.cs
+++ b/samples/Shared/UnitTestFramework.Test/DiagnosticVerifierTest.cs
@@ -1,0 +1,453 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+using Xunit.Sdk;
+using static Roslyn.UnitTestFramework.DiagnosticVerifier<Roslyn.UnitTestFramework.Test.CSharpSyntaxTreeDiagnosticAnalyzer>;
+
+namespace Roslyn.UnitTestFramework.Test
+{
+    /// <summary>
+    /// This class verifies that <see cref="DiagnosticVerifier{TAnalyzer}"/> will correctly report failing tests.
+    /// </summary>
+    public class DiagnosticVerifierTest
+    {
+        [Fact]
+        public async Task TestExpectedDiagnosticMissingAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    void MethodName()
+    {
+        ;
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic();
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Mismatch between number of diagnostics returned, expected \"1\" actual \"0\"", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestValidBehaviorAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithLocation(7, 33);
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestValidBehaviorUncheckedLineAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithLocation(0, 33);
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestValidBehaviorUncheckedColumnAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithLocation(7, 0);
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestValidBehaviorWithFullSpanAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithSpan(7, 33, 7, 34);
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestUnexpectedLocationForProjectDiagnosticAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            // By failing to include a location, the verified thinks we're only trying to verify a project diagnostic.
+            DiagnosticResult expected = Diagnostic().WithArguments("followed");
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Expected:\nA project diagnostic with No location\nActual:\n", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestUnexpectedMessageAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"", ex.Message);
+            Assert.Contains("warning TEST01", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestUnexpectedAnalyzerErrorAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    void MethodName()
+    {
+        ;
+    }
+}
+";
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await DiagnosticVerifier<ErrorThrowingAnalyzer>.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Mismatch between number of diagnostics returned, expected \"0\" actual \"2\"", ex.Message);
+            Assert.Contains("error AD0001", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestUnexpectedCompilerErrorAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    Int32 PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithLocation(7, 33);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Mismatch between number of diagnostics returned, expected \"1\" actual \"2\"", ex.Message);
+            Assert.Contains("error CS0246", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestUnexpectedCompilerWarningAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    Int32 PropertyName
+    {
+        ///
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithLocation(8, 33);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Mismatch between number of diagnostics returned, expected \"1\" actual \"2\"", ex.Message);
+            Assert.Contains("error CS0246", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestInvalidDiagnosticIdAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticDescriptor descriptor = new DiagnosticDescriptor("SA9999", "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+            DiagnosticResult expected = Diagnostic(descriptor).WithLocation(7, 33);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith($"Expected diagnostic id to be \"SA9999\" was \"{CSharpSyntaxTreeDiagnosticAnalyzer.DiagnosticId}\"", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestInvalidSeverityAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(7, 33).WithSeverity(DiagnosticSeverity.Error);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Expected diagnostic severity to be \"Error\" was \"Warning\"", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestIncorrectLocationLine1Async()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithLocation(8, 33);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Expected diagnostic to start on line \"8\" was actually on line \"7\"", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestIncorrectLocationLine2Async()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+        set{this.property = value;}
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("followed").WithLocation(7, 33),
+                Diagnostic().WithArguments("followed").WithLocation(7, 34),
+            };
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Expected diagnostic to start on line \"7\" was actually on line \"8\"", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestIncorrectLocationColumnAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithLocation(7, 34);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Expected diagnostic to start at column \"34\" was actually at column \"33\"", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestIncorrectLocationEndColumnAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("followed").WithSpan(7, 33, 7, 35);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Expected diagnostic to end at column \"35\" was actually at column \"34\"", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestIncorrectMessageAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("bogus argument").WithLocation(7, 33);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Expected diagnostic message to be ", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestIncorrectAdditionalLocationAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    int property;
+    int PropertyName
+    {
+        get{return this.property;}
+    }
+}
+";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("bogus argument").WithLocation(7, 33).WithLocation(8, 34);
+
+            XunitException ex = await Assert.ThrowsAnyAsync<XunitException>(
+                async () =>
+                {
+                    await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            Assert.StartsWith("Expected 1 additional locations but got 0 for Diagnostic", ex.Message);
+        }
+
+        private class ErrorThrowingAnalyzer : CSharpSyntaxTreeDiagnosticAnalyzer
+        {
+            private static readonly Action<SyntaxNodeAnalysisContext> BlockAction = HandleBlock;
+
+            /// <inheritdoc/>
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterSyntaxNodeAction(BlockAction, SyntaxKind.Block);
+            }
+
+            private static void HandleBlock(SyntaxNodeAnalysisContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework.Test/Roslyn.UnitTestFramework.Test.csproj
+++ b/samples/Shared/UnitTestFramework.Test/Roslyn.UnitTestFramework.Test.csproj
@@ -1,0 +1,40 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+      Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+      not report warnings for missing comments.
+
+      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      CS1712: Type parameter 'parameter' has no matching typeparam tag in the XML comment for 'Type_or_member' (but other type parameters do)
+    -->
+    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>7.2</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UnitTestFramework\Roslyn.UnitTestFramework.csproj" />
+  </ItemGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard1.5'">
+      <PropertyGroup>
+        <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+</Project>

--- a/samples/Shared/UnitTestFramework/CodeActionProviderTestFixture.cs
+++ b/samples/Shared/UnitTestFramework/CodeActionProviderTestFixture.cs
@@ -23,9 +23,13 @@ namespace Roslyn.UnitTestFramework
             // find these assemblies in the running process
             string[] simpleNames = { "mscorlib", "System.Core", "System" };
 
+#if !NETSTANDARD1_5
             IEnumerable<PortableExecutableReference> references = AppDomain.CurrentDomain.GetAssemblies()
                 .Where(a => simpleNames.Contains(a.GetName().Name, StringComparer.OrdinalIgnoreCase))
                 .Select(a => MetadataReference.CreateFromFile(a.Location));
+#else
+            IEnumerable<PortableExecutableReference> references = Enumerable.Empty<PortableExecutableReference>();
+#endif
 
             return new AdhocWorkspace().CurrentSolution
                 .AddProject(projectId, "TestProject", "TestProject", LanguageName)

--- a/samples/Shared/UnitTestFramework/CodeFixVerifier`2.cs
+++ b/samples/Shared/UnitTestFramework/CodeFixVerifier`2.cs
@@ -46,6 +46,27 @@ namespace Roslyn.UnitTestFramework
             return test.RunAsync(cancellationToken);
         }
 
+        public static Task VerifyVisualBasicDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken = default)
+            => DiagnosticVerifier<TAnalyzer>.VerifyVisualBasicDiagnosticAsync(source, expected, cancellationToken);
+
+        public static Task VerifyVisualBasicDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken = default)
+            => DiagnosticVerifier<TAnalyzer>.VerifyVisualBasicDiagnosticAsync(source, expected, cancellationToken);
+
+        public static Task VerifyVisualBasicFixAsync(string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken = default)
+            => VerifyVisualBasicFixAsync(source, new[] { expected }, fixedSource, cancellationToken);
+
+        public static Task VerifyVisualBasicFixAsync(string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken = default)
+        {
+            VisualBasicTest test = new VisualBasicTest
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
         public class CSharpTest : DiagnosticVerifier<TAnalyzer>.CSharpTest
         {
             protected override IEnumerable<CodeFixProvider> GetCodeFixProviders()

--- a/samples/Shared/UnitTestFramework/CodeFixVerifier`2.cs
+++ b/samples/Shared/UnitTestFramework/CodeFixVerifier`2.cs
@@ -25,16 +25,16 @@ namespace Roslyn.UnitTestFramework
         public static DiagnosticResult CompilerError(string errorIdentifier)
             => DiagnosticVerifier<TAnalyzer>.CompilerError(errorIdentifier);
 
-        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
+        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken = default)
             => DiagnosticVerifier<TAnalyzer>.VerifyCSharpDiagnosticAsync(source, expected, cancellationToken);
 
-        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken = default)
             => DiagnosticVerifier<TAnalyzer>.VerifyCSharpDiagnosticAsync(source, expected, cancellationToken);
 
-        public static Task VerifyCSharpFixAsync(string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
+        public static Task VerifyCSharpFixAsync(string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken = default)
             => VerifyCSharpFixAsync(source, new[] { expected }, fixedSource, cancellationToken);
 
-        public static Task VerifyCSharpFixAsync(string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        public static Task VerifyCSharpFixAsync(string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken = default)
         {
             CSharpTest test = new CSharpTest
             {

--- a/samples/Shared/UnitTestFramework/CodeFixVerifier`2.cs
+++ b/samples/Shared/UnitTestFramework/CodeFixVerifier`2.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Roslyn.UnitTestFramework
+{
+    public static class CodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public static DiagnosticResult[] EmptyDiagnosticResults
+            => DiagnosticVerifier<TAnalyzer>.EmptyDiagnosticResults;
+
+        public static DiagnosticResult Diagnostic(string diagnosticId = null)
+            => DiagnosticVerifier<TAnalyzer>.Diagnostic(diagnosticId);
+
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => DiagnosticVerifier<TAnalyzer>.Diagnostic(descriptor);
+
+        public static DiagnosticResult CompilerError(string errorIdentifier)
+            => DiagnosticVerifier<TAnalyzer>.CompilerError(errorIdentifier);
+
+        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
+            => DiagnosticVerifier<TAnalyzer>.VerifyCSharpDiagnosticAsync(source, expected, cancellationToken);
+
+        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+            => DiagnosticVerifier<TAnalyzer>.VerifyCSharpDiagnosticAsync(source, expected, cancellationToken);
+
+        public static Task VerifyCSharpFixAsync(string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
+            => VerifyCSharpFixAsync(source, new[] { expected }, fixedSource, cancellationToken);
+
+        public static Task VerifyCSharpFixAsync(string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            CSharpTest test = new CSharpTest
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        public class CSharpTest : DiagnosticVerifier<TAnalyzer>.CSharpTest
+        {
+            protected override IEnumerable<CodeFixProvider> GetCodeFixProviders()
+                => new[] { new TCodeFix() };
+        }
+
+        public class VisualBasicTest : DiagnosticVerifier<TAnalyzer>.VisualBasicTest
+        {
+            protected override IEnumerable<CodeFixProvider> GetCodeFixProviders()
+                => new[] { new TCodeFix() };
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework/CustomDiagnosticVerifier`1.cs
+++ b/samples/Shared/UnitTestFramework/CustomDiagnosticVerifier`1.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Roslyn.UnitTestFramework
+{
+    public static class CustomDiagnosticVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public static DiagnosticResult[] EmptyDiagnosticResults
+            => DiagnosticVerifier<TAnalyzer>.EmptyDiagnosticResults;
+
+        public static DiagnosticResult Diagnostic(string diagnosticId = null)
+            => DiagnosticVerifier<TAnalyzer>.Diagnostic(diagnosticId);
+
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => DiagnosticVerifier<TAnalyzer>.Diagnostic(descriptor);
+
+        public static DiagnosticResult CompilerError(string errorIdentifier)
+            => DiagnosticVerifier<TAnalyzer>.CompilerError(errorIdentifier);
+    }
+}

--- a/samples/Shared/UnitTestFramework/DiagnosticResult.cs
+++ b/samples/Shared/UnitTestFramework/DiagnosticResult.cs
@@ -16,6 +16,7 @@ namespace Roslyn.UnitTestFramework
         private static readonly object[] EmptyArguments = new object[0];
 
         private ImmutableArray<FileLinePositionSpan> _spans;
+        private bool _suppressMessage;
         private string _message;
 
         public DiagnosticResult(string id, DiagnosticSeverity severity)
@@ -57,6 +58,11 @@ namespace Roslyn.UnitTestFramework
         {
             get
             {
+                if (_suppressMessage)
+                {
+                    return null;
+                }
+
                 if (_message != null)
                 {
                     return _message;
@@ -109,6 +115,7 @@ namespace Roslyn.UnitTestFramework
         {
             DiagnosticResult result = this;
             result._message = message;
+            result._suppressMessage = message is null;
             return result;
         }
 
@@ -159,18 +166,9 @@ namespace Roslyn.UnitTestFramework
 
         private DiagnosticResult AppendSpan(FileLinePositionSpan span)
         {
-            ImmutableArray<FileLinePositionSpan> newSpans = Spans.Add(span);
-
-            // clone the object, so that the fluent syntax will work on immutable objects.
-            return new DiagnosticResult
-            {
-                Id = Id,
-                _message = _message,
-                MessageFormat = MessageFormat,
-                MessageArguments = MessageArguments,
-                Severity = Severity,
-                _spans = newSpans,
-            };
+            DiagnosticResult result = this;
+            result._spans = Spans.Add(span);
+            return result;
         }
     }
 }

--- a/samples/Shared/UnitTestFramework/DiagnosticResult.cs
+++ b/samples/Shared/UnitTestFramework/DiagnosticResult.cs
@@ -1,0 +1,176 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Roslyn.UnitTestFramework
+{
+    /// <summary>
+    /// Structure that stores information about a <see cref="Diagnostic"/> appearing in a source.
+    /// </summary>
+    public struct DiagnosticResult
+    {
+        private const string DefaultPath = "Test0.cs";
+
+        private static readonly object[] EmptyArguments = new object[0];
+
+        private ImmutableArray<FileLinePositionSpan> _spans;
+        private string _message;
+
+        public DiagnosticResult(string id, DiagnosticSeverity severity)
+            : this()
+        {
+            Id = id;
+            Severity = severity;
+        }
+
+        public DiagnosticResult(DiagnosticDescriptor descriptor)
+            : this()
+        {
+            Id = descriptor.Id;
+            Severity = descriptor.DefaultSeverity;
+            MessageFormat = descriptor.MessageFormat;
+        }
+
+        public ImmutableArray<FileLinePositionSpan> Spans
+        {
+            get
+            {
+                return _spans.IsDefault ? ImmutableArray<FileLinePositionSpan>.Empty : _spans;
+            }
+        }
+
+        public DiagnosticSeverity Severity
+        {
+            get;
+            private set;
+        }
+
+        public string Id
+        {
+            get;
+            private set;
+        }
+
+        public string Message
+        {
+            get
+            {
+                if (_message != null)
+                {
+                    return _message;
+                }
+
+                if (MessageFormat != null)
+                {
+                    return string.Format(MessageFormat.ToString(), MessageArguments ?? EmptyArguments);
+                }
+
+                return null;
+            }
+        }
+
+        public LocalizableString MessageFormat
+        {
+            get;
+            private set;
+        }
+
+        public object[] MessageArguments
+        {
+            get;
+            private set;
+        }
+
+        public bool HasLocation
+        {
+            get
+            {
+                return (_spans != null) && (_spans.Length > 0);
+            }
+        }
+
+        public DiagnosticResult WithSeverity(DiagnosticSeverity severity)
+        {
+            DiagnosticResult result = this;
+            result.Severity = severity;
+            return result;
+        }
+
+        public DiagnosticResult WithArguments(params object[] arguments)
+        {
+            DiagnosticResult result = this;
+            result.MessageArguments = arguments;
+            return result;
+        }
+
+        public DiagnosticResult WithMessage(string message)
+        {
+            DiagnosticResult result = this;
+            result._message = message;
+            return result;
+        }
+
+        public DiagnosticResult WithMessageFormat(LocalizableString messageFormat)
+        {
+            DiagnosticResult result = this;
+            result.MessageFormat = messageFormat;
+            return result;
+        }
+
+        public DiagnosticResult WithLocation(int line, int column)
+        {
+            return WithLocation(DefaultPath, line, column);
+        }
+
+        public DiagnosticResult WithLocation(string path, int line, int column)
+        {
+            LinePosition linePosition = new LinePosition(line, column);
+
+            return AppendSpan(new FileLinePositionSpan(path, linePosition, linePosition));
+        }
+
+        public DiagnosticResult WithSpan(int startLine, int startColumn, int endLine, int endColumn)
+        {
+            return WithSpan(DefaultPath, startLine, startColumn, endLine, endColumn);
+        }
+
+        public DiagnosticResult WithSpan(string path, int startLine, int startColumn, int endLine, int endColumn)
+        {
+            return AppendSpan(new FileLinePositionSpan(path, new LinePosition(startLine, startColumn), new LinePosition(endLine, endColumn)));
+        }
+
+        public DiagnosticResult WithLineOffset(int offset)
+        {
+            DiagnosticResult result = this;
+            ImmutableArray<FileLinePositionSpan>.Builder spansBuilder = result._spans.ToBuilder();
+            for (int i = 0; i < result._spans.Length; i++)
+            {
+                LinePosition newStartLinePosition = new LinePosition(result._spans[i].StartLinePosition.Line + offset, result._spans[i].StartLinePosition.Character);
+                LinePosition newEndLinePosition = new LinePosition(result._spans[i].EndLinePosition.Line + offset, result._spans[i].EndLinePosition.Character);
+
+                spansBuilder[i] = new FileLinePositionSpan(result._spans[i].Path, newStartLinePosition, newEndLinePosition);
+            }
+
+            result._spans = spansBuilder.MoveToImmutable();
+            return result;
+        }
+
+        private DiagnosticResult AppendSpan(FileLinePositionSpan span)
+        {
+            ImmutableArray<FileLinePositionSpan> newSpans = _spans.Add(span);
+
+            // clone the object, so that the fluent syntax will work on immutable objects.
+            return new DiagnosticResult
+            {
+                Id = Id,
+                _message = _message,
+                MessageFormat = MessageFormat,
+                MessageArguments = MessageArguments,
+                Severity = Severity,
+                _spans = newSpans,
+            };
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework/DiagnosticResult.cs
+++ b/samples/Shared/UnitTestFramework/DiagnosticResult.cs
@@ -145,12 +145,12 @@ namespace Roslyn.UnitTestFramework
         {
             DiagnosticResult result = this;
             ImmutableArray<FileLinePositionSpan>.Builder spansBuilder = result._spans.ToBuilder();
-            for (int i = 0; i < result._spans.Length; i++)
+            for (int i = 0; i < result.Spans.Length; i++)
             {
-                LinePosition newStartLinePosition = new LinePosition(result._spans[i].StartLinePosition.Line + offset, result._spans[i].StartLinePosition.Character);
-                LinePosition newEndLinePosition = new LinePosition(result._spans[i].EndLinePosition.Line + offset, result._spans[i].EndLinePosition.Character);
+                LinePosition newStartLinePosition = new LinePosition(result.Spans[i].StartLinePosition.Line + offset, result.Spans[i].StartLinePosition.Character);
+                LinePosition newEndLinePosition = new LinePosition(result.Spans[i].EndLinePosition.Line + offset, result.Spans[i].EndLinePosition.Character);
 
-                spansBuilder[i] = new FileLinePositionSpan(result._spans[i].Path, newStartLinePosition, newEndLinePosition);
+                spansBuilder[i] = new FileLinePositionSpan(result.Spans[i].Path, newStartLinePosition, newEndLinePosition);
             }
 
             result._spans = spansBuilder.MoveToImmutable();
@@ -159,7 +159,7 @@ namespace Roslyn.UnitTestFramework
 
         private DiagnosticResult AppendSpan(FileLinePositionSpan span)
         {
-            ImmutableArray<FileLinePositionSpan> newSpans = _spans.Add(span);
+            ImmutableArray<FileLinePositionSpan> newSpans = Spans.Add(span);
 
             // clone the object, so that the fluent syntax will work on immutable objects.
             return new DiagnosticResult

--- a/samples/Shared/UnitTestFramework/DiagnosticVerifier`1.cs
+++ b/samples/Shared/UnitTestFramework/DiagnosticVerifier`1.cs
@@ -54,6 +54,20 @@ namespace Roslyn.UnitTestFramework
             return test.RunAsync(cancellationToken);
         }
 
+        public static Task VerifyVisualBasicDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken = default)
+            => VerifyVisualBasicDiagnosticAsync(source, new[] { expected }, cancellationToken);
+
+        public static Task VerifyVisualBasicDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken = default)
+        {
+            VisualBasicTest test = new VisualBasicTest
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
         public class CSharpTest : GenericAnalyzerTest
         {
             public override string Language => LanguageNames.CSharp;

--- a/samples/Shared/UnitTestFramework/DiagnosticVerifier`1.cs
+++ b/samples/Shared/UnitTestFramework/DiagnosticVerifier`1.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Roslyn.UnitTestFramework
+{
+    public static class DiagnosticVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public static DiagnosticResult[] EmptyDiagnosticResults { get; } = { };
+
+        public static DiagnosticResult Diagnostic(string diagnosticId = null)
+        {
+            TAnalyzer analyzer = new TAnalyzer();
+            ImmutableArray<DiagnosticDescriptor> supportedDiagnostics = analyzer.SupportedDiagnostics;
+            if (diagnosticId is null)
+            {
+                return Diagnostic(supportedDiagnostics.Single());
+            }
+            else
+            {
+                return Diagnostic(supportedDiagnostics.Single(i => i.Id == diagnosticId));
+            }
+        }
+
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+        {
+            return new DiagnosticResult(descriptor);
+        }
+
+        public static DiagnosticResult CompilerError(string errorIdentifier)
+        {
+            return new DiagnosticResult(errorIdentifier, DiagnosticSeverity.Error);
+        }
+
+        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
+            => VerifyCSharpDiagnosticAsync(source, new[] { expected }, cancellationToken);
+
+        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        {
+            CSharpTest test = new CSharpTest
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        public class CSharpTest : GenericAnalyzerTest
+        {
+            public override string Language => LanguageNames.CSharp;
+
+            protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()
+                => new[] { new TAnalyzer() };
+
+            protected override IEnumerable<CodeFixProvider> GetCodeFixProviders()
+                => Enumerable.Empty<CodeFixProvider>();
+        }
+
+        public class VisualBasicTest : GenericAnalyzerTest
+        {
+            public override string Language => LanguageNames.VisualBasic;
+
+            protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()
+                => new[] { new TAnalyzer() };
+
+            protected override IEnumerable<CodeFixProvider> GetCodeFixProviders()
+                => Enumerable.Empty<CodeFixProvider>();
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework/DiagnosticVerifier`1.cs
+++ b/samples/Shared/UnitTestFramework/DiagnosticVerifier`1.cs
@@ -40,10 +40,10 @@ namespace Roslyn.UnitTestFramework
             return new DiagnosticResult(errorIdentifier, DiagnosticSeverity.Error);
         }
 
-        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
+        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken = default)
             => VerifyCSharpDiagnosticAsync(source, new[] { expected }, cancellationToken);
 
-        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        public static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken = default)
         {
             CSharpTest test = new CSharpTest
             {

--- a/samples/Shared/UnitTestFramework/DictionaryExtensions.cs
+++ b/samples/Shared/UnitTestFramework/DictionaryExtensions.cs
@@ -21,5 +21,11 @@ namespace Roslyn.UnitTestFramework
 
         public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<TValue> function)
             => dictionary.GetOrAdd(key, _ => function());
+
+        public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey key, out TValue value)
+        {
+            key = pair.Key;
+            value = pair.Value;
+        }
     }
 }

--- a/samples/Shared/UnitTestFramework/GenericAnalyzerTest.cs
+++ b/samples/Shared/UnitTestFramework/GenericAnalyzerTest.cs
@@ -1,0 +1,1254 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Xunit;
+
+#if !NETSTANDARD1_5
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Composition;
+#endif
+
+namespace Roslyn.UnitTestFramework
+{
+    public abstract class GenericAnalyzerTest
+    {
+        private const int DefaultNumberOfIncrementalIterations = -1000;
+
+        private static readonly string DefaultFilePathPrefix = "Test";
+        private static readonly string CSharpDefaultFileExt = "cs";
+        private static readonly string VisualBasicDefaultExt = "vb";
+        private static readonly string CSharpDefaultFilePath = DefaultFilePathPrefix + 0 + "." + CSharpDefaultFileExt;
+        private static readonly string VisualBasicDefaultFilePath = DefaultFilePathPrefix + 0 + "." + VisualBasicDefaultExt;
+        private static readonly string TestProjectName = "TestProject";
+
+#if !NETSTANDARD1_5
+        private static readonly Lazy<IExportProviderFactory> ExportProviderFactory;
+
+        static GenericAnalyzerTest()
+        {
+            ExportProviderFactory = new Lazy<IExportProviderFactory>(
+                () =>
+                {
+                    AttributedPartDiscovery discovery = new AttributedPartDiscovery(Resolver.DefaultInstance, isNonPublicSupported: true);
+                    DiscoveredParts parts = Task.Run(() => discovery.CreatePartsAsync(MefHostServices.DefaultAssemblies)).GetAwaiter().GetResult();
+                    ComposableCatalog catalog = ComposableCatalog.Create(Resolver.DefaultInstance).AddParts(parts);
+
+                    CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
+                    RuntimeComposition runtimeComposition = RuntimeComposition.CreateRuntimeComposition(configuration);
+                    return runtimeComposition.CreateExportProviderFactory();
+                },
+                LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+#endif
+
+        /// <summary>
+        /// Gets the language name used for the test.
+        /// </summary>
+        /// <value>
+        /// The language name used for the test.
+        /// </value>
+        public abstract string Language
+        {
+            get;
+        }
+
+        public string TestCode
+        {
+            set
+            {
+                Assert.Empty(TestSources);
+                if (value != null)
+                {
+                    TestSources.Add(value);
+                }
+            }
+        }
+
+        public List<string> TestSources { get; } = new List<string>();
+
+        public Dictionary<string, string> XmlReferences { get; } = new Dictionary<string, string>();
+
+        public List<DiagnosticResult> ExpectedDiagnostics { get; } = new List<DiagnosticResult>();
+
+        public List<DiagnosticResult> RemainingDiagnostics { get; } = new List<DiagnosticResult>();
+
+        public List<DiagnosticResult> BatchRemainingDiagnostics { get; } = new List<DiagnosticResult>();
+
+        public List<string> DisabledDiagnostics { get; } = new List<string>();
+
+        public int? CodeFixIndex { get; set; }
+
+        public string FixedCode
+        {
+            set
+            {
+                Assert.Empty(FixedSources);
+                if (value != null)
+                {
+                    FixedSources.Add(value);
+                }
+            }
+        }
+
+        public List<string> FixedSources { get; } = new List<string>();
+
+        public string BatchFixedCode
+        {
+            set
+            {
+                Assert.Empty(BatchFixedSources);
+                if (value != null)
+                {
+                    BatchFixedSources.Add(value);
+                }
+            }
+        }
+
+        public List<string> BatchFixedSources { get; } = new List<string>();
+
+        public int? NumberOfIncrementalIterations { get; set; }
+
+        public int? NumberOfFixAllIterations { get; set; }
+
+        public bool AllowNewCompilerDiagnostics { get; set; } = false;
+
+        public List<Func<OptionSet, OptionSet>> OptionsTransforms { get; } = new List<Func<OptionSet, OptionSet>>();
+
+        public List<Func<Solution, ProjectId, Solution>> SolutionTransforms { get; } = new List<Func<Solution, ProjectId, Solution>>();
+
+        public async Task RunAsync(CancellationToken cancellationToken)
+        {
+            Assert.NotEmpty(TestSources);
+
+            DiagnosticResult[] expected = ExpectedDiagnostics.ToArray();
+            await VerifyDiagnosticsAsync(TestSources.ToArray(), expected, filenames: null, cancellationToken).ConfigureAwait(false);
+            if (HasFixableDiagnostics())
+            {
+                DiagnosticResult[] remainingDiagnostics = FixedSources.SequenceEqual(TestSources) ? expected : RemainingDiagnostics.ToArray();
+                await VerifyDiagnosticsAsync(FixedSources.ToArray(), remainingDiagnostics, filenames: null, cancellationToken).ConfigureAwait(false);
+                if (BatchFixedSources.Any())
+                {
+                    DiagnosticResult[] batchRemainingDiagnostics = BatchFixedSources.SequenceEqual(TestSources) ? expected : BatchRemainingDiagnostics.ToArray();
+                    await VerifyDiagnosticsAsync(BatchFixedSources.ToArray(), batchRemainingDiagnostics, filenames: null, cancellationToken).ConfigureAwait(false);
+                }
+
+                await VerifyFixAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Gets the analyzers being tested.
+        /// </summary>
+        /// <returns>
+        /// New instances of all the analyzers being tested.
+        /// </returns>
+        protected abstract IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers();
+
+        /// <summary>
+        /// Returns the code fixes being tested - to be implemented in non-abstract class.
+        /// </summary>
+        /// <returns>The <see cref="CodeFixProvider"/> to be used for C# code.</returns>
+        protected abstract IEnumerable<CodeFixProvider> GetCodeFixProviders();
+
+        private bool HasFixableDiagnostics()
+        {
+            CodeFixProvider[] fixers = GetCodeFixProviders().ToArray();
+            if (HasFixableDiagnosticsCore())
+            {
+                if (FixedSources.Count > 0)
+                {
+                    return true;
+                }
+
+                Assert.Empty(RemainingDiagnostics);
+                Assert.Empty(BatchRemainingDiagnostics);
+                return false;
+            }
+
+            Assert.True(FixedSources.Count == 0
+                || (FixedSources.Count == 1 && string.IsNullOrEmpty(FixedSources[0]))
+                || FixedSources.SequenceEqual(TestSources));
+            Assert.True(BatchFixedSources.Count == 0
+                || (BatchFixedSources.Count == 1 && string.IsNullOrEmpty(BatchFixedSources[0]))
+                || BatchFixedSources.SequenceEqual(TestSources));
+            Assert.Empty(RemainingDiagnostics);
+            Assert.Empty(BatchRemainingDiagnostics);
+            return false;
+
+            // Local function
+            bool HasFixableDiagnosticsCore()
+            {
+                return ExpectedDiagnostics.Any(diagnostic => fixers.Any(fixer => fixer.FixableDiagnosticIds.Contains(diagnostic.Id)));
+            }
+        }
+
+        private static bool IsSubjectToExclusion(DiagnosticResult result)
+        {
+            if (result.Id.StartsWith("CS", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (result.Id.StartsWith("AD", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (result.Spans.Length == 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// General method that gets a collection of actual <see cref="Diagnostic"/>s found in the source after the
+        /// analyzer is run, then verifies each of them.
+        /// </summary>
+        /// <param name="sources">An array of strings to create source documents from to run the analyzers on.</param>
+        /// <param name="expected">A collection of <see cref="DiagnosticResult"/>s that should appear after the analyzer
+        /// is run on the sources.</param>
+        /// <param name="filenames">The filenames or null if the default filename should be used.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        private async Task VerifyDiagnosticsAsync(string[] sources, DiagnosticResult[] expected, string[] filenames, CancellationToken cancellationToken)
+        {
+            ImmutableArray<DiagnosticAnalyzer> analyzers = GetDiagnosticAnalyzers().ToImmutableArray();
+            VerifyDiagnosticResults(await GetSortedDiagnosticsAsync(sources, analyzers, filenames, cancellationToken).ConfigureAwait(false), analyzers, expected);
+
+            // If filenames is null we want to test for exclusions too
+            if (filenames == null)
+            {
+                // Also check if the analyzer honors exclusions
+                if (expected.Any(IsSubjectToExclusion))
+                {
+                    // Diagnostics reported by the compiler and analyzer diagnostics which don't have a location will
+                    // still be reported. We also insert a new line at the beginning so we have to move all diagnostic
+                    // locations which have a specific position down by one line.
+                    DiagnosticResult[] expectedResults = expected
+                        .Where(x => !IsSubjectToExclusion(x))
+                        .Select(x => x.WithLineOffset(1))
+                        .ToArray();
+
+                    VerifyDiagnosticResults(await GetSortedDiagnosticsAsync(sources.Select(x => " // <auto-generated>\r\n" + x).ToArray(), analyzers, null, cancellationToken).ConfigureAwait(false), analyzers, expectedResults);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Given an analyzer and a collection of documents to apply it to, run the analyzer and gather an array of
+        /// diagnostics found. The returned diagnostics are then ordered by location in the source documents.
+        /// </summary>
+        /// <param name="analyzers">The analyzer to run on the documents.</param>
+        /// <param name="documents">The <see cref="Document"/>s that the analyzer will be run on.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
+        /// <returns>A collection of <see cref="Diagnostic"/>s that surfaced in the source code, sorted by
+        /// <see cref="Diagnostic.Location"/>.</returns>
+        protected static async Task<ImmutableArray<Diagnostic>> GetSortedDiagnosticsFromDocumentsAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, Document[] documents, CancellationToken cancellationToken)
+        {
+            HashSet<Project> projects = new HashSet<Project>();
+            foreach (Document document in documents)
+            {
+                projects.Add(document.Project);
+            }
+
+            ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+            foreach (Project project in projects)
+            {
+                Compilation compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, project.AnalyzerOptions, cancellationToken);
+                ImmutableArray<Diagnostic> compilerDiagnostics = compilation.GetDiagnostics(cancellationToken);
+                IEnumerable<Diagnostic> compilerErrors = compilerDiagnostics.Where(i => i.Severity == DiagnosticSeverity.Error);
+                ImmutableArray<Diagnostic> diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+                ImmutableArray<Diagnostic> allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync().ConfigureAwait(false);
+                IEnumerable<Diagnostic> failureDiagnostics = allDiagnostics.Where(diagnostic => diagnostic.Id == "AD0001");
+                foreach (Diagnostic diag in diags.Concat(compilerErrors).Concat(failureDiagnostics))
+                {
+                    if (diag.Location == Location.None || diag.Location.IsInMetadata)
+                    {
+                        diagnostics.Add(diag);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < documents.Length; i++)
+                        {
+                            Document document = documents[i];
+                            SyntaxTree tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                            if (tree == diag.Location.SourceTree)
+                            {
+                                diagnostics.Add(diag);
+                            }
+                        }
+                    }
+                }
+            }
+
+            Diagnostic[] results = SortDistinctDiagnostics(diagnostics);
+            return results.ToImmutableArray();
+        }
+
+        /// <summary>
+        /// Sort <see cref="Diagnostic"/>s by location in source document.
+        /// </summary>
+        /// <param name="diagnostics">A collection of <see cref="Diagnostic"/>s to be sorted.</param>
+        /// <returns>A collection containing the input <paramref name="diagnostics"/>, sorted by
+        /// <see cref="Diagnostic.Location"/> and <see cref="Diagnostic.Id"/>.</returns>
+        private static Diagnostic[] SortDistinctDiagnostics(IEnumerable<Diagnostic> diagnostics)
+        {
+            return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ThenBy(d => d.Id).ToArray();
+        }
+
+        /// <summary>
+        /// Given classes in the form of strings, their language, and an <see cref="DiagnosticAnalyzer"/> to apply to
+        /// it, return the <see cref="Diagnostic"/>s found in the string after converting it to a
+        /// <see cref="Document"/>.
+        /// </summary>
+        /// <param name="sources">Classes in the form of strings.</param>
+        /// <param name="analyzers">The analyzers to be run on the sources.</param>
+        /// <param name="filenames">The filenames or <see langword="null"/> if the default filename should be used.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
+        /// <returns>A collection of <see cref="Diagnostic"/>s that surfaced in the source code, sorted by
+        /// <see cref="Diagnostic.Location"/>.</returns>
+        private Task<ImmutableArray<Diagnostic>> GetSortedDiagnosticsAsync(string[] sources, ImmutableArray<DiagnosticAnalyzer> analyzers, string[] filenames, CancellationToken cancellationToken)
+        {
+            return GetSortedDiagnosticsFromDocumentsAsync(analyzers, GetDocuments(sources, filenames), cancellationToken);
+        }
+
+        /// <summary>
+        /// Given an array of strings as sources and a language, turn them into a <see cref="Project"/> and return the
+        /// documents and spans of it.
+        /// </summary>
+        /// <param name="sources">Classes in the form of strings.</param>
+        /// <param name="filenames">The filenames or <see langword="null"/> if the default filename should be used.</param>
+        /// <returns>A collection of <see cref="Document"/>s representing the sources.</returns>
+        private Document[] GetDocuments(string[] sources, string[] filenames)
+        {
+            if (Language != LanguageNames.CSharp && Language != LanguageNames.VisualBasic)
+            {
+                throw new ArgumentException("Unsupported Language");
+            }
+
+            Project project = CreateProject(sources, Language, filenames);
+            Document[] documents = project.Documents.ToArray();
+
+            if (sources.Length != documents.Length)
+            {
+                throw new InvalidOperationException("Amount of sources did not match amount of Documents created");
+            }
+
+            return documents;
+        }
+
+        /// <summary>
+        /// Create a project using the input strings as sources.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method first creates a <see cref="Project"/> by calling <see cref="CreateProjectImpl"/>, and then
+        /// applies compilation options to the project by calling <see cref="ApplyCompilationOptions"/>.</para>
+        /// </remarks>
+        /// <param name="sources">Classes in the form of strings.</param>
+        /// <param name="language">The language the source classes are in. Values may be taken from the
+        /// <see cref="LanguageNames"/> class.</param>
+        /// <param name="filenames">The filenames or <see langword="null"/> if the default filename should be used.</param>
+        /// <returns>A <see cref="Project"/> created out of the <see cref="Document"/>s created from the source
+        /// strings.</returns>
+        protected Project CreateProject(string[] sources, string language = LanguageNames.CSharp, string[] filenames = null)
+        {
+            Project project = CreateProjectImpl(sources, language, filenames);
+            return ApplyCompilationOptions(project);
+        }
+
+        /// <summary>
+        /// Create a project using the input strings as sources.
+        /// </summary>
+        /// <param name="sources">Classes in the form of strings.</param>
+        /// <param name="language">The language the source classes are in. Values may be taken from the
+        /// <see cref="LanguageNames"/> class.</param>
+        /// <param name="filenames">The filenames or <see langword="null"/> if the default filename should be used.</param>
+        /// <returns>A <see cref="Project"/> created out of the <see cref="Document"/>s created from the source
+        /// strings.</returns>
+        protected virtual Project CreateProjectImpl(string[] sources, string language, string[] filenames)
+        {
+            string fileNamePrefix = DefaultFilePathPrefix;
+            string fileExt = language == LanguageNames.CSharp ? CSharpDefaultFileExt : VisualBasicDefaultExt;
+
+            ProjectId projectId = ProjectId.CreateNewId(debugName: TestProjectName);
+            Solution solution = CreateSolution(projectId, language);
+
+            int count = 0;
+            for (int i = 0; i < sources.Length; i++)
+            {
+                string source = sources[i];
+                string newFileName = filenames?[i] ?? fileNamePrefix + count + "." + fileExt;
+                DocumentId documentId = DocumentId.CreateNewId(projectId, debugName: newFileName);
+                solution = solution.AddDocument(documentId, newFileName, SourceText.From(source));
+                count++;
+            }
+
+            return solution.GetProject(projectId);
+        }
+
+        /// <summary>
+        /// Applies compilation options to a project.
+        /// </summary>
+        /// <remarks>
+        /// <para>The default implementation configures the project by enabling all supported diagnostics of analyzers
+        /// included in <see cref="GetDiagnosticAnalyzers"/> as well as <c>AD0001</c>. After configuring these
+        /// diagnostics, any diagnostic IDs indicated in <see cref="DisabledDiagnostics"/> are explicitly suppressed
+        /// using <see cref="ReportDiagnostic.Suppress"/>.</para>
+        /// </remarks>
+        /// <param name="project">The project.</param>
+        /// <returns>The modified project.</returns>
+        protected virtual Project ApplyCompilationOptions(Project project)
+        {
+            IEnumerable<DiagnosticAnalyzer> analyzers = GetDiagnosticAnalyzers();
+
+            Dictionary<string, ReportDiagnostic> supportedDiagnosticsSpecificOptions = new Dictionary<string, ReportDiagnostic>();
+            foreach (DiagnosticAnalyzer analyzer in analyzers)
+            {
+                foreach (DiagnosticDescriptor diagnostic in analyzer.SupportedDiagnostics)
+                {
+                    // make sure the analyzers we are testing are enabled
+                    supportedDiagnosticsSpecificOptions[diagnostic.Id] = ReportDiagnostic.Default;
+                }
+            }
+
+            // Report exceptions during the analysis process as errors
+            supportedDiagnosticsSpecificOptions.Add("AD0001", ReportDiagnostic.Error);
+
+            foreach (string id in DisabledDiagnostics)
+            {
+                supportedDiagnosticsSpecificOptions[id] = ReportDiagnostic.Suppress;
+            }
+
+            // update the project compilation options
+            ImmutableDictionary<string, ReportDiagnostic> modifiedSpecificDiagnosticOptions = supportedDiagnosticsSpecificOptions.ToImmutableDictionary().SetItems(project.CompilationOptions.SpecificDiagnosticOptions);
+            CompilationOptions modifiedCompilationOptions = project.CompilationOptions.WithSpecificDiagnosticOptions(modifiedSpecificDiagnosticOptions);
+
+            Solution solution = project.Solution.WithProjectCompilationOptions(project.Id, modifiedCompilationOptions);
+            return solution.GetProject(project.Id);
+        }
+
+        public static AdhocWorkspace CreateWorkspace()
+        {
+#if NETSTANDARD1_5
+            return new AdhocWorkspace();
+#else
+            ExportProvider exportProvider = ExportProviderFactory.Value.CreateExportProvider();
+            MefV1HostServices host = MefV1HostServices.Create(exportProvider.AsExportProvider());
+            return new AdhocWorkspace(host);
+#endif
+        }
+
+        /// <summary>
+        /// Creates a solution that will be used as parent for the sources that need to be checked.
+        /// </summary>
+        /// <param name="projectId">The project identifier to use.</param>
+        /// <param name="language">The language for which the solution is being created.</param>
+        /// <returns>The created solution.</returns>
+        protected virtual Solution CreateSolution(ProjectId projectId, string language)
+        {
+            CompilationOptions compilationOptions = language == LanguageNames.CSharp
+                ? (CompilationOptions)new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true)
+                : new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+
+            TestXmlReferenceResolver xmlReferenceResolver = new TestXmlReferenceResolver();
+            foreach (KeyValuePair<string, string> xmlReference in XmlReferences)
+            {
+                xmlReferenceResolver.XmlReferences.Add(xmlReference.Key, xmlReference.Value);
+            }
+
+            compilationOptions = compilationOptions.WithXmlReferenceResolver(xmlReferenceResolver);
+
+            Solution solution = CreateWorkspace()
+                .CurrentSolution
+                .AddProject(projectId, TestProjectName, TestProjectName, language)
+                .WithProjectCompilationOptions(projectId, compilationOptions)
+                .AddMetadataReference(projectId, MetadataReferences.CorlibReference)
+                .AddMetadataReference(projectId, MetadataReferences.SystemReference)
+                .AddMetadataReference(projectId, MetadataReferences.SystemCoreReference)
+                .AddMetadataReference(projectId, MetadataReferences.CSharpSymbolsReference)
+                .AddMetadataReference(projectId, MetadataReferences.CodeAnalysisReference);
+
+            if (MetadataReferences.SystemRuntimeReference != null)
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReferences.SystemRuntimeReference);
+            }
+
+            if (MetadataReferences.SystemValueTupleReference != null)
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReferences.SystemValueTupleReference);
+            }
+
+            foreach (Func<OptionSet, OptionSet> transform in OptionsTransforms)
+            {
+                solution.Workspace.Options = transform(solution.Workspace.Options);
+            }
+
+            ParseOptions parseOptions = solution.GetProject(projectId).ParseOptions;
+            solution = solution.WithProjectParseOptions(projectId, parseOptions.WithDocumentationMode(DocumentationMode.Diagnose));
+
+            foreach (Func<Solution, ProjectId, Solution> transform in SolutionTransforms)
+            {
+                solution = transform(solution, projectId);
+            }
+
+            return solution;
+        }
+
+        /// <summary>
+        /// Checks each of the actual <see cref="Diagnostic"/>s found and compares them with the corresponding
+        /// <see cref="DiagnosticResult"/> in the array of expected results. <see cref="Diagnostic"/>s are considered
+        /// equal only if the <see cref="DiagnosticResult.Spans"/>, <see cref="DiagnosticResult.Id"/>,
+        /// <see cref="DiagnosticResult.Severity"/>, and <see cref="DiagnosticResult.Message"/> of the
+        /// <see cref="DiagnosticResult"/> match the actual <see cref="Diagnostic"/>.
+        /// </summary>
+        /// <param name="actualResults">The <see cref="Diagnostic"/>s found by the compiler after running the analyzer
+        /// on the source code.</param>
+        /// <param name="analyzers">The analyzers that have been run on the sources.</param>
+        /// <param name="expectedResults">A collection of <see cref="DiagnosticResult"/>s describing the expected
+        /// diagnostics for the sources.</param>
+        private static void VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, ImmutableArray<DiagnosticAnalyzer> analyzers, DiagnosticResult[] expectedResults)
+        {
+            int expectedCount = expectedResults.Length;
+            int actualCount = actualResults.Count();
+
+            if (expectedCount != actualCount)
+            {
+                string diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzers, actualResults.ToArray()) : "    NONE.";
+
+                Assert.True(
+                    false,
+                    string.Format("Mismatch between number of diagnostics returned, expected \"{0}\" actual \"{1}\"\r\n\r\nDiagnostics:\r\n{2}\r\n", expectedCount, actualCount, diagnosticsOutput));
+            }
+
+            for (int i = 0; i < expectedResults.Length; i++)
+            {
+                Diagnostic actual = actualResults.ElementAt(i);
+                DiagnosticResult expected = expectedResults[i];
+
+                if (!expected.HasLocation)
+                {
+                    if (actual.Location != Location.None)
+                    {
+                        string message =
+                            string.Format(
+                                "Expected:\nA project diagnostic with No location\nActual:\n{0}",
+                                FormatDiagnostics(analyzers, actual));
+                        Assert.True(false, message);
+                    }
+                }
+                else
+                {
+                    VerifyDiagnosticLocation(analyzers, actual, actual.Location, expected.Spans.First());
+                    Location[] additionalLocations = actual.AdditionalLocations.ToArray();
+
+                    if (additionalLocations.Length != expected.Spans.Length - 1)
+                    {
+                        Assert.True(
+                            false,
+                            string.Format(
+                                "Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
+                                expected.Spans.Length - 1,
+                                additionalLocations.Length,
+                                FormatDiagnostics(analyzers, actual)));
+                    }
+
+                    for (int j = 0; j < additionalLocations.Length; ++j)
+                    {
+                        VerifyDiagnosticLocation(analyzers, actual, additionalLocations[j], expected.Spans[j + 1]);
+                    }
+                }
+
+                if (actual.Id != expected.Id)
+                {
+                    string message =
+                        string.Format(
+                            "Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                            expected.Id,
+                            actual.Id,
+                            FormatDiagnostics(analyzers, actual));
+                    Assert.True(false, message);
+                }
+
+                if (actual.Severity != expected.Severity)
+                {
+                    string message =
+                        string.Format(
+                            "Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                            expected.Severity,
+                            actual.Severity,
+                            FormatDiagnostics(analyzers, actual));
+                    Assert.True(false, message);
+                }
+
+                if (actual.GetMessage() != expected.Message)
+                {
+                    string message =
+                        string.Format(
+                            "Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                            expected.Message,
+                            actual.GetMessage(),
+                            FormatDiagnostics(analyzers, actual));
+                    Assert.True(false, message);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper method to <see cref="VerifyDiagnosticResults"/> that checks the location of a
+        /// <see cref="Diagnostic"/> and compares it with the location described by a
+        /// <see cref="FileLinePositionSpan"/>.
+        /// </summary>
+        /// <param name="analyzers">The analyzer that have been run on the sources.</param>
+        /// <param name="diagnostic">The diagnostic that was found in the code.</param>
+        /// <param name="actual">The location of the diagnostic found in the code.</param>
+        /// <param name="expected">The <see cref="FileLinePositionSpan"/> describing the expected location of the
+        /// diagnostic.</param>
+        private static void VerifyDiagnosticLocation(ImmutableArray<DiagnosticAnalyzer> analyzers, Diagnostic diagnostic, Location actual, FileLinePositionSpan expected)
+        {
+            FileLinePositionSpan actualSpan = actual.GetLineSpan();
+
+            string message =
+                string.Format(
+                    "Expected diagnostic to be in file \"{0}\" was actually in file \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                    expected.Path,
+                    actualSpan.Path,
+                    FormatDiagnostics(analyzers, diagnostic));
+            Assert.True(
+                actualSpan.Path == expected.Path || (actualSpan.Path != null && actualSpan.Path.Contains("Test0.") && expected.Path.Contains("Test.")),
+                message);
+
+            LinePosition actualStartLinePosition = actualSpan.StartLinePosition;
+            LinePosition actualEndLinePosition = actualSpan.EndLinePosition;
+
+            VerifyLinePosition(analyzers, diagnostic, actualSpan.StartLinePosition, expected.StartLinePosition, "start");
+            if (expected.StartLinePosition < expected.EndLinePosition)
+            {
+                VerifyLinePosition(analyzers, diagnostic, actualSpan.EndLinePosition, expected.EndLinePosition, "end");
+            }
+        }
+
+        private static void VerifyLinePosition(ImmutableArray<DiagnosticAnalyzer> analyzers, Diagnostic diagnostic, LinePosition actualLinePosition, LinePosition expectedLinePosition, string positionText)
+        {
+            // Only check the line position if it matters
+            if (expectedLinePosition.Line > 0)
+            {
+                Assert.True(
+                    (actualLinePosition.Line + 1) == expectedLinePosition.Line,
+                    string.Format(
+                        "Expected diagnostic to {0} on line \"{1}\" was actually on line \"{2}\"\r\n\r\nDiagnostic:\r\n    {3}\r\n",
+                        positionText,
+                        expectedLinePosition.Line,
+                        actualLinePosition.Line + 1,
+                        FormatDiagnostics(analyzers, diagnostic)));
+            }
+
+            // Only check the column position if it matters
+            if (expectedLinePosition.Character > 0)
+            {
+                Assert.True(
+                    (actualLinePosition.Character + 1) == expectedLinePosition.Character,
+                    string.Format(
+                        "Expected diagnostic to {0} at column \"{1}\" was actually at column \"{2}\"\r\n\r\nDiagnostic:\r\n    {3}\r\n",
+                        positionText,
+                        expectedLinePosition.Character,
+                        actualLinePosition.Character + 1,
+                        FormatDiagnostics(analyzers, diagnostic)));
+            }
+        }
+
+        /// <summary>
+        /// Helper method to format a <see cref="Diagnostic"/> into an easily readable string.
+        /// </summary>
+        /// <param name="analyzers">The analyzers that this verifier tests.</param>
+        /// <param name="diagnostics">A collection of <see cref="Diagnostic"/>s to be formatted.</param>
+        /// <returns>The <paramref name="diagnostics"/> formatted as a string.</returns>
+        private static string FormatDiagnostics(ImmutableArray<DiagnosticAnalyzer> analyzers, params Diagnostic[] diagnostics)
+        {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < diagnostics.Length; ++i)
+            {
+                string diagnosticsId = diagnostics[i].Id;
+
+                builder.Append("// ").AppendLine(diagnostics[i].ToString());
+
+                DiagnosticAnalyzer applicableAnalyzer = analyzers.FirstOrDefault(a => a.SupportedDiagnostics.Any(dd => dd.Id == diagnosticsId));
+                if (applicableAnalyzer != null)
+                {
+                    Type analyzerType = applicableAnalyzer.GetType();
+
+                    Location location = diagnostics[i].Location;
+                    if (location == Location.None)
+                    {
+                        builder.AppendFormat("GetGlobalResult({0}.{1})", analyzerType.Name, diagnosticsId);
+                    }
+                    else
+                    {
+                        Assert.True(
+                            location.IsInSource,
+                            string.Format("Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata:\r\n{0}", diagnostics[i]));
+
+                        string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs") ? "GetCSharpResultAt" : "GetBasicResultAt";
+                        LinePosition linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
+
+                        builder.AppendFormat(
+                            "{0}({1}, {2}, {3}.{4})",
+                            resultMethodName,
+                            linePosition.Line + 1,
+                            linePosition.Character + 1,
+                            analyzerType.Name,
+                            diagnosticsId);
+                    }
+
+                    if (i != diagnostics.Length - 1)
+                    {
+                        builder.Append(',');
+                    }
+
+                    builder.AppendLine();
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Called to test a C# code fix when applied on the input source as a string.
+        /// </summary>
+        /// <param name="oldFileNames">An array of file names in the project before the code fix was applied.</param>
+        /// <param name="newFileNames">An array of file names in the project after the code fix was applied.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        protected async Task VerifyFixAsync(string[] oldFileNames = null, string[] newFileNames = null, CancellationToken cancellationToken = default)
+        {
+            string[] oldSources = TestSources.ToArray();
+            string[] newSources = FixedSources.ToArray();
+            string[] batchNewSources = BatchFixedSources.Any() ? BatchFixedSources.ToArray() : newSources;
+
+            int numberOfIncrementalIterations;
+            int numberOfFixAllIterations;
+            if (NumberOfIncrementalIterations != null)
+            {
+                numberOfIncrementalIterations = NumberOfIncrementalIterations.Value;
+            }
+            else
+            {
+                if (!HasAnyChange(oldSources, newSources, oldFileNames, newFileNames))
+                {
+                    numberOfIncrementalIterations = 0;
+                }
+                else
+                {
+                    numberOfIncrementalIterations = DefaultNumberOfIncrementalIterations;
+                }
+            }
+
+            if (NumberOfFixAllIterations != null)
+            {
+                numberOfFixAllIterations = NumberOfFixAllIterations.Value;
+            }
+            else
+            {
+                if (!HasAnyChange(oldSources, batchNewSources, oldFileNames, newFileNames))
+                {
+                    numberOfFixAllIterations = 0;
+                }
+                else
+                {
+                    numberOfFixAllIterations = 1;
+                }
+            }
+
+            ConfiguredTaskAwaitable t1 = VerifyFixpublicAsync(Language, GetDiagnosticAnalyzers().ToImmutableArray(), GetCodeFixProviders().ToImmutableArray(), oldSources, newSources, oldFileNames, newFileNames, numberOfIncrementalIterations, FixEachAnalyzerDiagnosticAsync, cancellationToken).ConfigureAwait(false);
+
+            ImmutableArray<FixAllProvider> fixAllProvider = GetCodeFixProviders().Select(codeFixProvider => codeFixProvider.GetFixAllProvider()).Where(codeFixProvider => codeFixProvider != null).ToImmutableArray();
+
+            if (fixAllProvider.IsEmpty)
+            {
+                await t1;
+            }
+            else
+            {
+                if (Debugger.IsAttached)
+                {
+                    await t1;
+                }
+
+                ConfiguredTaskAwaitable t2 = VerifyFixpublicAsync(LanguageNames.CSharp, GetDiagnosticAnalyzers().ToImmutableArray(), GetCodeFixProviders().ToImmutableArray(), oldSources, batchNewSources ?? newSources, oldFileNames, newFileNames, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
+                if (Debugger.IsAttached)
+                {
+                    await t2;
+                }
+
+                ConfiguredTaskAwaitable t3 = VerifyFixpublicAsync(LanguageNames.CSharp, GetDiagnosticAnalyzers().ToImmutableArray(), GetCodeFixProviders().ToImmutableArray(), oldSources, batchNewSources ?? newSources, oldFileNames, newFileNames, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInProjectAsync, cancellationToken).ConfigureAwait(false);
+                if (Debugger.IsAttached)
+                {
+                    await t3;
+                }
+
+                ConfiguredTaskAwaitable t4 = VerifyFixpublicAsync(LanguageNames.CSharp, GetDiagnosticAnalyzers().ToImmutableArray(), GetCodeFixProviders().ToImmutableArray(), oldSources, batchNewSources ?? newSources, oldFileNames, newFileNames, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInSolutionAsync, cancellationToken).ConfigureAwait(false);
+                if (Debugger.IsAttached)
+                {
+                    await t4;
+                }
+
+                if (!Debugger.IsAttached)
+                {
+                    // Allow the operations to run in parallel
+                    await t1;
+                    await t2;
+                    await t3;
+                    await t4;
+                }
+            }
+        }
+
+        private async Task VerifyFixpublicAsync(
+            string language,
+            ImmutableArray<DiagnosticAnalyzer> analyzers,
+            ImmutableArray<CodeFixProvider> codeFixProviders,
+            string[] oldSources,
+            string[] newSources,
+            string[] oldFileNames,
+            string[] newFileNames,
+            int numberOfIterations,
+            Func<ImmutableArray<DiagnosticAnalyzer>, ImmutableArray<CodeFixProvider>, int?, Project, int, CancellationToken, Task<Project>> getFixedProject,
+            CancellationToken cancellationToken)
+        {
+            if (oldFileNames != null)
+            {
+                // Make sure the test case is consistent regarding the number of sources and file names before the code fix
+                Assert.Equal($"{oldSources.Length} old file names", $"{oldFileNames.Length} old file names");
+            }
+
+            if (newFileNames != null)
+            {
+                // Make sure the test case is consistent regarding the number of sources and file names after the code fix
+                Assert.Equal($"{newSources.Length} new file names", $"{newFileNames.Length} new file names");
+            }
+
+            Project project = CreateProject(oldSources, language, oldFileNames);
+            ImmutableArray<Diagnostic> compilerDiagnostics = await GetCompilerDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
+
+            project = await getFixedProject(analyzers, codeFixProviders, CodeFixIndex, project, numberOfIterations, cancellationToken).ConfigureAwait(false);
+
+            IEnumerable<Diagnostic> newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false));
+
+            // Check if applying the code fix introduced any new compiler diagnostics
+            if (!AllowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
+            {
+                // Format and get the compiler diagnostics again so that the locations make sense in the output
+                project = await ReformatProjectDocumentsAsync(project, cancellationToken).ConfigureAwait(false);
+                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false));
+
+                StringBuilder message = new StringBuilder();
+                message.Append("Fix introduced new compiler diagnostics:\r\n");
+                newCompilerDiagnostics.Aggregate(message, (sb, d) => sb.Append(d.ToString()).Append("\r\n"));
+                foreach (Document document in project.Documents)
+                {
+                    message.Append("\r\n").Append(document.Name).Append(":\r\n");
+                    message.Append((await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false)).ToFullString());
+                    message.Append("\r\n");
+                }
+
+                Assert.True(false, message.ToString());
+            }
+
+            // After applying all of the code fixes, compare the resulting string to the inputted one
+            Document[] updatedDocuments = project.Documents.ToArray();
+
+            Assert.Equal($"{newSources.Length} documents", $"{updatedDocuments.Length} documents");
+
+            for (int i = 0; i < updatedDocuments.Length; i++)
+            {
+                string actual = await GetStringFromDocumentAsync(updatedDocuments[i], cancellationToken).ConfigureAwait(false);
+                Assert.Equal(newSources[i], actual);
+
+                if (newFileNames != null)
+                {
+                    Assert.Equal(newFileNames[i], updatedDocuments[i].Name);
+                }
+            }
+        }
+
+        private static bool HasAnyChange(string[] oldSources, string[] newSources, string[] oldFileNames, string[] newFileNames)
+        {
+            if (!oldSources.SequenceEqual(newSources))
+            {
+                return true;
+            }
+
+            if (oldFileNames != null && newFileNames != null && !oldFileNames.SequenceEqual(newFileNames))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static async Task<Project> FixEachAnalyzerDiagnosticAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableArray<CodeFixProvider> codeFixProviders, int? codeFixIndex, Project project, int numberOfIterations, CancellationToken cancellationToken)
+        {
+            CodeFixProvider codeFixProvider = codeFixProviders.Single();
+
+            int expectedNumberOfIterations = numberOfIterations;
+            if (numberOfIterations < 0)
+            {
+                numberOfIterations = -numberOfIterations;
+            }
+
+            ImmutableArray<Diagnostic> previousDiagnostics = ImmutableArray.Create<Diagnostic>();
+
+            bool done;
+            do
+            {
+                ImmutableArray<Diagnostic> analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzers, project.Documents.ToArray(), cancellationToken).ConfigureAwait(false);
+                if (analyzerDiagnostics.Length == 0)
+                {
+                    break;
+                }
+
+                if (!AreDiagnosticsDifferent(analyzerDiagnostics, previousDiagnostics))
+                {
+                    break;
+                }
+
+                if (--numberOfIterations < -1)
+                {
+                    Assert.True(false, "The upper limit for the number of code fix iterations was exceeded");
+                }
+
+                previousDiagnostics = analyzerDiagnostics;
+
+                done = true;
+                bool anyActions = false;
+                foreach (Diagnostic diagnostic in analyzerDiagnostics)
+                {
+                    if (!codeFixProvider.FixableDiagnosticIds.Contains(diagnostic.Id))
+                    {
+                        // do not pass unsupported diagnostics to a code fix provider
+                        continue;
+                    }
+
+                    List<CodeAction> actions = new List<CodeAction>();
+                    CodeFixContext context = new CodeFixContext(project.GetDocument(diagnostic.Location.SourceTree), diagnostic, (a, d) => actions.Add(a), cancellationToken);
+                    await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+
+                    if (actions.Count > 0)
+                    {
+                        anyActions = true;
+
+                        Project fixedProject = await ApplyFixAsync(project, actions.ElementAt(codeFixIndex.GetValueOrDefault(0)), cancellationToken).ConfigureAwait(false);
+                        if (fixedProject != project)
+                        {
+                            done = false;
+
+                            project = await RecreateProjectDocumentsAsync(fixedProject, cancellationToken).ConfigureAwait(false);
+                            break;
+                        }
+                    }
+                }
+
+                if (!anyActions)
+                {
+                    Assert.True(done);
+
+                    // Avoid counting iterations that do not provide any code actions
+                    numberOfIterations++;
+                }
+            }
+            while (!done);
+
+            if (expectedNumberOfIterations >= 0)
+            {
+                Assert.Equal($"{expectedNumberOfIterations} iterations", $"{expectedNumberOfIterations - numberOfIterations} iterations");
+            }
+
+            return project;
+        }
+
+        private static Task<Project> FixAllAnalyzerDiagnosticsInDocumentAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableArray<CodeFixProvider> codeFixProviders, int? codeFixIndex, Project project, int numberOfIterations, CancellationToken cancellationToken)
+        {
+            return FixAllAnalyerDiagnosticsInScopeAsync(FixAllScope.Document, analyzers, codeFixProviders, codeFixIndex, project, numberOfIterations, cancellationToken);
+        }
+
+        private static Task<Project> FixAllAnalyzerDiagnosticsInProjectAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableArray<CodeFixProvider> codeFixProviders, int? codeFixIndex, Project project, int numberOfIterations, CancellationToken cancellationToken)
+        {
+            return FixAllAnalyerDiagnosticsInScopeAsync(FixAllScope.Project, analyzers, codeFixProviders, codeFixIndex, project, numberOfIterations, cancellationToken);
+        }
+
+        private static Task<Project> FixAllAnalyzerDiagnosticsInSolutionAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableArray<CodeFixProvider> codeFixProviders, int? codeFixIndex, Project project, int numberOfIterations, CancellationToken cancellationToken)
+        {
+            return FixAllAnalyerDiagnosticsInScopeAsync(FixAllScope.Solution, analyzers, codeFixProviders, codeFixIndex, project, numberOfIterations, cancellationToken);
+        }
+
+        private static async Task<Project> FixAllAnalyerDiagnosticsInScopeAsync(FixAllScope scope, ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableArray<CodeFixProvider> codeFixProviders, int? codeFixIndex, Project project, int numberOfIterations, CancellationToken cancellationToken)
+        {
+            CodeFixProvider codeFixProvider = codeFixProviders.Single();
+
+            int expectedNumberOfIterations = numberOfIterations;
+            if (numberOfIterations < 0)
+            {
+                numberOfIterations = -numberOfIterations;
+            }
+
+            ImmutableArray<Diagnostic> previousDiagnostics = ImmutableArray.Create<Diagnostic>();
+
+            FixAllProvider fixAllProvider = codeFixProvider.GetFixAllProvider();
+
+            if (fixAllProvider == null)
+            {
+                return null;
+            }
+
+            bool done;
+            do
+            {
+                ImmutableArray<Diagnostic> analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzers, project.Documents.ToArray(), cancellationToken).ConfigureAwait(false);
+                if (analyzerDiagnostics.Length == 0)
+                {
+                    break;
+                }
+
+                if (!AreDiagnosticsDifferent(analyzerDiagnostics, previousDiagnostics))
+                {
+                    break;
+                }
+
+                if (--numberOfIterations < -1)
+                {
+                    Assert.True(false, "The upper limit for the number of fix all iterations was exceeded");
+                }
+
+                Diagnostic firstDiagnostic = null;
+                string equivalenceKey = null;
+                foreach (Diagnostic diagnostic in analyzerDiagnostics)
+                {
+                    if (!codeFixProvider.FixableDiagnosticIds.Contains(diagnostic.Id))
+                    {
+                        // do not pass unsupported diagnostics to a code fix provider
+                        continue;
+                    }
+
+                    List<CodeAction> actions = new List<CodeAction>();
+                    CodeFixContext context = new CodeFixContext(project.GetDocument(diagnostic.Location.SourceTree), diagnostic, (a, d) => actions.Add(a), cancellationToken);
+                    await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+                    if (actions.Count > (codeFixIndex ?? 0))
+                    {
+                        firstDiagnostic = diagnostic;
+                        equivalenceKey = actions[codeFixIndex ?? 0].EquivalenceKey;
+                        break;
+                    }
+                }
+
+                if (firstDiagnostic == null)
+                {
+                    numberOfIterations++;
+                    break;
+                }
+
+                previousDiagnostics = analyzerDiagnostics;
+
+                done = true;
+
+                FixAllContext.DiagnosticProvider fixAllDiagnosticProvider = TestDiagnosticProvider.Create(analyzerDiagnostics);
+
+                IEnumerable<string> analyzerDiagnosticIds = analyzers.SelectMany(x => x.SupportedDiagnostics).Select(x => x.Id);
+                IEnumerable<string> compilerDiagnosticIds = codeFixProvider.FixableDiagnosticIds.Where(x => x.StartsWith("CS", StringComparison.Ordinal));
+                IEnumerable<string> disabledDiagnosticIds = project.CompilationOptions.SpecificDiagnosticOptions.Where(x => x.Value == ReportDiagnostic.Suppress).Select(x => x.Key);
+                IEnumerable<string> relevantIds = analyzerDiagnosticIds.Concat(compilerDiagnosticIds).Except(disabledDiagnosticIds).Distinct();
+                FixAllContext fixAllContext = new FixAllContext(project.GetDocument(firstDiagnostic.Location.SourceTree), codeFixProvider, scope, equivalenceKey, relevantIds, fixAllDiagnosticProvider, cancellationToken);
+
+                CodeAction action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false);
+                if (action == null)
+                {
+                    return project;
+                }
+
+                Project fixedProject = await ApplyFixAsync(project, action, cancellationToken).ConfigureAwait(false);
+                if (fixedProject != project)
+                {
+                    done = false;
+
+                    project = await RecreateProjectDocumentsAsync(fixedProject, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            while (!done);
+
+            if (expectedNumberOfIterations >= 0)
+            {
+                Assert.Equal($"{expectedNumberOfIterations} iterations", $"{expectedNumberOfIterations - numberOfIterations} iterations");
+            }
+
+            return project;
+        }
+
+        /// <summary>
+        /// Get the existing compiler diagnostics on the input document.
+        /// </summary>
+        /// <param name="project">The <see cref="Project"/> to run the compiler diagnostic analyzers on.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
+        /// <returns>The compiler diagnostics that were found in the code.</returns>
+        private static async Task<ImmutableArray<Diagnostic>> GetCompilerDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            ImmutableArray<Diagnostic> allDiagnostics = ImmutableArray.Create<Diagnostic>();
+
+            foreach (Document document in project.Documents)
+            {
+                SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                allDiagnostics = allDiagnostics.AddRange(semanticModel.GetDiagnostics(cancellationToken: cancellationToken));
+            }
+
+            return allDiagnostics;
+        }
+
+        /// <summary>
+        /// Given a document, turn it into a string based on the syntax root.
+        /// </summary>
+        /// <param name="document">The <see cref="Document"/> to be converted to a string.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
+        /// <returns>A string containing the syntax of the <see cref="Document"/> after formatting.</returns>
+        private static async Task<string> GetStringFromDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            Document simplifiedDoc = await Simplifier.ReduceAsync(document, Simplifier.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
+            Document formatted = await Formatter.FormatAsync(simplifiedDoc, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
+            SourceText sourceText = await formatted.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            return sourceText.ToString();
+        }
+
+        /// <summary>
+        /// Implements a workaround for issue #936, force re-parsing to get the same sort of syntax tree as the original document.
+        /// </summary>
+        /// <param name="project">The project to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="Project"/>.</returns>
+        private static async Task<Project> RecreateProjectDocumentsAsync(Project project, CancellationToken cancellationToken)
+        {
+            foreach (DocumentId documentId in project.DocumentIds)
+            {
+                Document document = project.GetDocument(documentId);
+                document = await RecreateDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+                project = document.Project;
+            }
+
+            return project;
+        }
+
+        private static async Task<Document> RecreateDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            SourceText newText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            newText = newText.WithChanges(new TextChange(new TextSpan(0, 0), " "));
+            newText = newText.WithChanges(new TextChange(new TextSpan(0, 1), string.Empty));
+            return document.WithText(newText);
+        }
+
+        /// <summary>
+        /// Formats the whitespace in all documents of the specified <see cref="Project"/>.
+        /// </summary>
+        /// <param name="project">The project to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="Project"/>.</returns>
+        private static async Task<Project> ReformatProjectDocumentsAsync(Project project, CancellationToken cancellationToken)
+        {
+            foreach (DocumentId documentId in project.DocumentIds)
+            {
+                Document document = project.GetDocument(documentId);
+                document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
+                project = document.Project;
+            }
+
+            return project;
+        }
+
+        /// <summary>
+        /// Compare two collections of <see cref="Diagnostic"/>s, and return a list of any new diagnostics that appear
+        /// only in the second collection.
+        /// <note type="note">
+        /// <para>Considers <see cref="Diagnostic"/> to be the same if they have the same <see cref="Diagnostic.Id"/>s.
+        /// In the case of multiple diagnostics with the same <see cref="Diagnostic.Id"/> in a row, this method may not
+        /// necessarily return the new one.</para>
+        /// </note>
+        /// </summary>
+        /// <param name="diagnostics">The <see cref="Diagnostic"/>s that existed in the code before the code fix was
+        /// applied.</param>
+        /// <param name="newDiagnostics">The <see cref="Diagnostic"/>s that exist in the code after the code fix was
+        /// applied.</param>
+        /// <returns>A list of <see cref="Diagnostic"/>s that only surfaced in the code after the code fix was
+        /// applied.</returns>
+        private static IEnumerable<Diagnostic> GetNewDiagnostics(IEnumerable<Diagnostic> diagnostics, IEnumerable<Diagnostic> newDiagnostics)
+        {
+            Diagnostic[] oldArray = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+            Diagnostic[] newArray = newDiagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+
+            int oldIndex = 0;
+            int newIndex = 0;
+
+            while (newIndex < newArray.Length)
+            {
+                if (oldIndex < oldArray.Length && oldArray[oldIndex].Id == newArray[newIndex].Id)
+                {
+                    ++oldIndex;
+                    ++newIndex;
+                }
+                else
+                {
+                    yield return newArray[newIndex++];
+                }
+            }
+        }
+
+        /// <summary>
+        /// Apply the inputted <see cref="CodeAction"/> to the inputted document.
+        /// Meant to be used to apply code fixes.
+        /// </summary>
+        /// <param name="project">The <see cref="Project"/> to apply the fix on.</param>
+        /// <param name="codeAction">A <see cref="CodeAction"/> that will be applied to the
+        /// <paramref name="project"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
+        /// <returns>A <see cref="Project"/> with the changes from the <see cref="CodeAction"/>.</returns>
+        private static async Task<Project> ApplyFixAsync(Project project, CodeAction codeAction, CancellationToken cancellationToken)
+        {
+            ImmutableArray<CodeActionOperation> operations = await codeAction.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
+            Solution solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+            return solution.GetProject(project.Id);
+        }
+
+        private static bool AreDiagnosticsDifferent(ImmutableArray<Diagnostic> analyzerDiagnostics, ImmutableArray<Diagnostic> previousDiagnostics)
+        {
+            if (analyzerDiagnostics.Length != previousDiagnostics.Length)
+            {
+                return true;
+            }
+
+            for (int i = 0; i < analyzerDiagnostics.Length; i++)
+            {
+                if ((analyzerDiagnostics[i].Id != previousDiagnostics[i].Id)
+                    || (analyzerDiagnostics[i].Location.SourceSpan != previousDiagnostics[i].Location.SourceSpan))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework/GenericAnalyzerTest.cs
+++ b/samples/Shared/UnitTestFramework/GenericAnalyzerTest.cs
@@ -77,6 +77,10 @@ namespace Roslyn.UnitTestFramework
             get;
         }
 
+        /// <summary>
+        /// Sets the input source file for analyzer or code fix testing.
+        /// </summary>
+        /// <seealso cref="TestSources"/>
         public string TestCode
         {
             set
@@ -89,22 +93,61 @@ namespace Roslyn.UnitTestFramework
             }
         }
 
+        /// <summary>
+        /// Gets the set of input source files for analyzer or code fix testing. Files may be added to this list using
+        /// one of the <see cref="SourceFileList.Add"/> methods.
+        /// </summary>
         public SourceFileList TestSources { get; }
 
+        /// <summary>
+        /// Gets the collection of inputs to provide to the XML documentation resolver.
+        /// </summary>
+        /// <remarks>
+        /// <para>Files in this collection may be referenced via <c>&lt;include&gt;</c> elements in documentation
+        /// comments.</para>
+        /// </remarks>
         public Dictionary<string, string> XmlReferences { get; } = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Gets the list of diagnostics expected in the input source(s).
+        /// </summary>
         public List<DiagnosticResult> ExpectedDiagnostics { get; } = new List<DiagnosticResult>();
 
+        /// <summary>
+        /// Gets the list of diagnostics expected after a code fix is applied.
+        /// </summary>
         public List<DiagnosticResult> RemainingDiagnostics { get; } = new List<DiagnosticResult>();
 
+        /// <summary>
+        /// Gets the list of diagnostics expected after a Fix All operation.
+        /// </summary>
+        /// <remarks>
+        /// <para>By default, Fix All operations are expected to produce the same result as incremental fix operations.
+        /// This collection is only used when <see cref="BatchFixedSources"/> differs from
+        /// <see cref="FixedSources"/>.</para>
+        /// </remarks>
         public List<DiagnosticResult> BatchRemainingDiagnostics { get; } = new List<DiagnosticResult>();
 
+        /// <summary>
+        /// Gets or sets a value indicating whether exclusions for generated code should be tested automatically. The
+        /// default value is <see langword="true"/>.
+        /// </summary>
         public bool VerifyExclusions { get; set; } = true;
 
+        /// <summary>
+        /// Gets a collection of diagnostics to explicitly disable in the <see cref="CompilationOptions"/> for projects.
+        /// </summary>
         public List<string> DisabledDiagnostics { get; } = new List<string>();
 
+        /// <summary>
+        /// Gets or sets the index of the code fix to apply.
+        /// </summary>
         public int? CodeFixIndex { get; set; }
 
+        /// <summary>
+        /// Sets the expected output source file for code fix testing.
+        /// </summary>
+        /// <seealso cref="FixedSources"/>
         public string FixedCode
         {
             set
@@ -117,8 +160,16 @@ namespace Roslyn.UnitTestFramework
             }
         }
 
+        /// <summary>
+        /// Gets the set of expected output files for code fix testing. Files may be added to this list using one of the
+        /// <see cref="SourceFileList.Add"/> methods.
+        /// </summary>
         public SourceFileList FixedSources { get; }
 
+        /// <summary>
+        /// Sets the expected output source file after a Fix All operation is applied.
+        /// </summary>
+        /// <seealso cref="BatchFixedSources"/>
         public string BatchFixedCode
         {
             set
@@ -131,16 +182,90 @@ namespace Roslyn.UnitTestFramework
             }
         }
 
+        /// <summary>
+        /// Gets the set of expected output files after a Fix All operation is applied. Files may be added to this list
+        /// using one of the <see cref="SourceFileList.Add"/> methods.
+        /// </summary>
+        /// <remarks>
+        /// <para>By default, Fix All operations are expected to produce the same result as incremental fix operations.
+        /// If this collection is not specified for the test, <see cref="FixedSources"/> provides the expected test
+        /// results for both incremental and Fix All scenarios.</para>
+        /// </remarks>
         public SourceFileList BatchFixedSources { get; }
 
+        /// <summary>
+        /// Gets or sets the number of code fix iterations expected during code fix testing.
+        /// </summary>
+        /// <remarks>
+        /// <para>Code fixes are applied until one of the following conditions are met:</para>
+        ///
+        /// <list type="bullet">
+        /// <item><description>No diagnostics are reported in the input.</description></item>
+        /// <item><description>No code fixes are provided for the diagnostics reported in the input.</description></item>
+        /// <item><description>The code fix applied for the diagnostics does not produce a change in the source file(s).</description></item>
+        /// <item><description>The maximum number of allowed iterations is exceeded.</description></item>
+        /// </list>
+        ///
+        /// <para>If the number of iterations is positive, it represents an exact number of iterations: code fix tests
+        /// will fail if the code fix required more or fewer iterations to complete. If the number of iterations is
+        /// negative, the negation of the number of iterations is treated as an upper bound on the number of allowed
+        /// iterations: code fix tests will fail only if the code fix required more iterations to complete. If the
+        /// number of iterations is zero, the code fix test will validate that no code fixes are offered for the set of
+        /// diagnostics reported in the original input.</para>
+        ///
+        /// <para>When the number of iterations is not specified, the value is automatically selected according to the
+        /// current test configuration:</para>
+        ///
+        /// <list type="bullet">
+        /// <item><description>If the expected code fix output equals the input sources, the default value is treated as <c>0</c>.</description></item>
+        /// <item><description>Otherwise, the default value is treated as the negative of the number of fixable diagnostics appearing in the input source file(s).</description></item>
+        /// </list>
+        ///
+        /// <note>
+        /// <para>The default value for this property can be interpreted as "Iterative code fix operations are expected
+        /// to complete in at most one operation for each fixable diagnostic in the input source has been applied.
+        /// Completing in fewer iterations is acceptable."</para>
+        /// </note>
+        /// </remarks>
         public int? NumberOfIncrementalIterations { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of code fix iterations expected during code fix testing for Fix All scenarios.
+        /// </summary>
+        /// <remarks>
+        /// <para>See the <see cref="NumberOfIncrementalIterations"/> property for an overview of the behavior of this
+        /// property. If the number of Fix All iterations is not specified, the value is automatically selected
+        /// according to the current test configuration:</para>
+        ///
+        /// <list type="bullet">
+        /// <item><description>If the expected Fix All output equals the input sources, the default value is treated as <c>0</c>.</description></item>
+        /// <item><description>Otherwise, the default value is treated as <c>1</c>.</description></item>
+        /// </list>
+        ///
+        /// <note>
+        /// <para>The default value for this property can be interpreted as "Fix All operations are expected to complete
+        /// in the minimum number of iterations possible unless otherwise specified."</para>
+        /// </note>
+        /// </remarks>
+        /// <seealso cref="NumberOfIncrementalIterations"/>
         public int? NumberOfFixAllIterations { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether new compiler diagnostics are allowed to appear in code fix outputs.
+        /// The default value is <see langword="false"/>.
+        /// </summary>
         public bool AllowNewCompilerDiagnostics { get; set; } = false;
 
+        /// <summary>
+        /// Gets a collection of transformation functions to apply to <see cref="Workspace.Options"/> during diagnostic
+        /// or code fix test setup.
+        /// </summary>
         public List<Func<OptionSet, OptionSet>> OptionsTransforms { get; } = new List<Func<OptionSet, OptionSet>>();
 
+        /// <summary>
+        /// Gets a collection of transformation functions to apply to a <see cref="Solution"/> during diagnostic or code
+        /// fix test setup.
+        /// </summary>
         public List<Func<Solution, ProjectId, Solution>> SolutionTransforms { get; } = new List<Func<Solution, ProjectId, Solution>>();
 
         public async Task RunAsync(CancellationToken cancellationToken)
@@ -174,7 +299,7 @@ namespace Roslyn.UnitTestFramework
         /// <summary>
         /// Returns the code fixes being tested - to be implemented in non-abstract class.
         /// </summary>
-        /// <returns>The <see cref="CodeFixProvider"/> to be used for C# code.</returns>
+        /// <returns>The <see cref="CodeFixProvider"/> to be used.</returns>
         protected abstract IEnumerable<CodeFixProvider> GetCodeFixProviders();
 
         private bool HasFixableDiagnostics()
@@ -213,11 +338,13 @@ namespace Roslyn.UnitTestFramework
         {
             if (result.Id.StartsWith("CS", StringComparison.Ordinal))
             {
+                // This is a compiler diagnostic
                 return false;
             }
 
             if (result.Id.StartsWith("AD", StringComparison.Ordinal))
             {
+                // This diagnostic is reported by the analyzer infrastructure
                 return false;
             }
 

--- a/samples/Shared/UnitTestFramework/GenericAnalyzerTest.cs
+++ b/samples/Shared/UnitTestFramework/GenericAnalyzerTest.cs
@@ -268,7 +268,7 @@ namespace Roslyn.UnitTestFramework
         /// </summary>
         public List<Func<Solution, ProjectId, Solution>> SolutionTransforms { get; } = new List<Func<Solution, ProjectId, Solution>>();
 
-        public async Task RunAsync(CancellationToken cancellationToken)
+        public async Task RunAsync(CancellationToken cancellationToken = default)
         {
             Assert.NotEmpty(TestSources);
 
@@ -336,7 +336,8 @@ namespace Roslyn.UnitTestFramework
 
         private static bool IsSubjectToExclusion(DiagnosticResult result)
         {
-            if (result.Id.StartsWith("CS", StringComparison.Ordinal))
+            if (result.Id.StartsWith("CS", StringComparison.Ordinal)
+                || result.Id.StartsWith("VB", StringComparison.Ordinal))
             {
                 // This is a compiler diagnostic
                 return false;
@@ -348,7 +349,7 @@ namespace Roslyn.UnitTestFramework
                 return false;
             }
 
-            if (result.Spans.Length == 0)
+            if (result.Spans.IsEmpty)
             {
                 return false;
             }

--- a/samples/Shared/UnitTestFramework/MetadataReferences.cs
+++ b/samples/Shared/UnitTestFramework/MetadataReferences.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+#if !NETSTANDARD1_5
+using System;
+#endif
+
+namespace Roslyn.UnitTestFramework
+{
+    /// <summary>
+    /// Metadata references used to create test projects.
+    /// </summary>
+    public static class MetadataReferences
+    {
+        public static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.Location).WithAliases(ImmutableArray.Create("global", "corlib"));
+        public static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(System.Diagnostics.Debug).GetTypeInfo().Assembly.Location).WithAliases(ImmutableArray.Create("global", "system"));
+        public static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).GetTypeInfo().Assembly.Location);
+        public static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).GetTypeInfo().Assembly.Location);
+        public static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).GetTypeInfo().Assembly.Location);
+
+        public static readonly MetadataReference SystemRuntimeReference;
+        public static readonly MetadataReference SystemValueTupleReference;
+
+        static MetadataReferences()
+        {
+            if (typeof(string).GetTypeInfo().Assembly.GetType("System.ValueTuple", false) != null)
+            {
+                // mscorlib contains ValueTuple, so no need to add a separate reference
+                SystemRuntimeReference = null;
+                SystemValueTupleReference = null;
+            }
+            else
+            {
+#if !NETSTANDARD1_5
+                Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(x => x.GetName().Name == "System.Runtime");
+                if (systemRuntime != null)
+                {
+                    SystemRuntimeReference = MetadataReference.CreateFromFile(systemRuntime.Location);
+                }
+
+                Assembly systemValueTuple = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(x => x.GetName().Name == "System.ValueTuple");
+                if (systemValueTuple != null)
+                {
+                    SystemValueTupleReference = MetadataReference.CreateFromFile(systemValueTuple.Location);
+                }
+#endif
+            }
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework/Roslyn.UnitTestFramework.csproj
+++ b/samples/Shared/UnitTestFramework/Roslyn.UnitTestFramework.csproj
@@ -5,6 +5,19 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!--
+      Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+      not report warnings for missing comments.
+
+      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      CS1712: Type parameter 'parameter' has no matching typeparam tag in the XML comment for 'Type_or_member' (but other type parameters do)
+    -->
+    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
@@ -12,6 +25,7 @@
     <!-- This package is used for testing analyzers that support Visual Studio 2015. Do not increase this version number. -->
     <PackageReference Include="Microsoft.CodeAnalysis" Version="1.2.1" />
 
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="15.6.36" />
     <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>

--- a/samples/Shared/UnitTestFramework/Roslyn.UnitTestFramework.csproj
+++ b/samples/Shared/UnitTestFramework/Roslyn.UnitTestFramework.csproj
@@ -1,14 +1,27 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <OutputPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\bin\CSharp\Roslyn.UnitTestFramework'))</OutputPath>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.0" />
-    <PackageReference Include="Moq " Version="4.7.142" />
+    <!-- This package is used for testing analyzers that support Visual Studio 2015. Do not increase this version number. -->
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="1.2.1" />
+
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="15.6.36" />
     <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard1.5'">
+      <PropertyGroup>
+        <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
+      </PropertyGroup>
+    </When>
+  </Choose>
 
 </Project>

--- a/samples/Shared/UnitTestFramework/SourceFileList.cs
+++ b/samples/Shared/UnitTestFramework/SourceFileList.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Roslyn.UnitTestFramework
+{
+    public class SourceFileList : List<(string filename, string content)>
+    {
+        private readonly string _defaultPrefix;
+        private readonly string _defaultExtension;
+
+        public SourceFileList(string defaultPrefix, string defaultExtension)
+        {
+            _defaultPrefix = defaultPrefix;
+            _defaultExtension = defaultExtension;
+        }
+
+        public void Add(string content)
+        {
+            Add(($"{_defaultPrefix}{Count}.{_defaultExtension}", content));
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework/TestDiagnosticProvider.cs
+++ b/samples/Shared/UnitTestFramework/TestDiagnosticProvider.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Roslyn.UnitTestFramework
+{
+    internal sealed class TestDiagnosticProvider : FixAllContext.DiagnosticProvider
+    {
+        private readonly ImmutableArray<Diagnostic> _diagnostics;
+
+        private TestDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)
+        {
+            _diagnostics = diagnostics;
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<Diagnostic>>(_diagnostics);
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_diagnostics.Where(i => i.Location.GetLineSpan().Path == document.Name));
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_diagnostics.Where(i => !i.Location.IsInSource));
+        }
+
+        internal static TestDiagnosticProvider Create(ImmutableArray<Diagnostic> diagnostics)
+        {
+            return new TestDiagnosticProvider(diagnostics);
+        }
+    }
+}

--- a/samples/Shared/UnitTestFramework/TestXmlReferenceResolver.cs
+++ b/samples/Shared/UnitTestFramework/TestXmlReferenceResolver.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Roslyn.UnitTestFramework
+{
+    internal class TestXmlReferenceResolver : XmlReferenceResolver
+    {
+        public Dictionary<string, string> XmlReferences { get; } =
+            new Dictionary<string, string>();
+
+        public override bool Equals(object other)
+        {
+            return ReferenceEquals(this, other);
+        }
+
+        public override int GetHashCode()
+        {
+            return RuntimeHelpers.GetHashCode(this);
+        }
+
+        public override Stream OpenRead(string resolvedPath)
+        {
+            if (!XmlReferences.TryGetValue(resolvedPath, out string content))
+            {
+                return null;
+            }
+
+            return new MemoryStream(Encoding.UTF8.GetBytes(content));
+        }
+
+        public override string ResolveReference(string path, string baseFilePath)
+        {
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
* General cleanup
    * [x] Better documentation (DotNetAnalyzers/StyleCopAnalyzers#279 and more)
    * [x] Asynchronous methods (DotNetAnalyzers/StyleCopAnalyzers#279, DotNetAnalyzers/StyleCopAnalyzers#550)
    * [x] De-duplication of diagnostics (driver used to call some methods too many times) (DotNetAnalyzers/StyleCopAnalyzers@cc9a15a)
    * [x] Disallow undeclared compiler errors (DotNetAnalyzers/StyleCopAnalyzers@746e551)
    * [x] Compile as DLL, allow unsafe (DotNetAnalyzers/StyleCopAnalyzers@4ee468e)
    * [x] Make sure analyzers are enabled (DotNetAnalyzers/StyleCopAnalyzers#841, DotNetAnalyzers/StyleCopAnalyzers#951)
    * [x] Treat AD0001 as a test failure (DotNetAnalyzers/StyleCopAnalyzers#889)
    * [x] Cleanup to adhere to new API (DotNetAnalyzers/StyleCopAnalyzers#926)
    * [x] Enable documentation comments (DotNetAnalyzers/StyleCopAnalyzers#1055)
    * [x] Accuracy of TestDiagnosticProvider? (DotNetAnalyzers/StyleCopAnalyzers#1279)
    * [x] Deterministic diagnostic order (DotNetAnalyzers/StyleCopAnalyzers#1741)
    * [x] EmptyDiagnosticResults (DotNetAnalyzers/StyleCopAnalyzers#412)
    * [x] Better handling of code fix validation (DotNetAnalyzers/StyleCopAnalyzers#447)
    * [x] Switch to xUnit (DotNetAnalyzers/StyleCopAnalyzers#517)
    * [x] Overload VerifyCSharpDiagnosticAsync for single diagnostic case (DotNetAnalyzers/StyleCopAnalyzers#526)
    * [x] Improved code fix testing (DotNetAnalyzers/StyleCopAnalyzers#935, DotNetAnalyzers/StyleCopAnalyzers#1203)
    * [x] ~~GetOfferedCSharpFixesAsync (DotNetAnalyzers/StyleCopAnalyzers#1250)~~ (likely not required now that iteration limit properties support the value `0`)
    * [x] Require fixer for code fix testing (DotNetAnalyzers/StyleCopAnalyzers#1299)
    * [x] Verify renamed files (DotNetAnalyzers/StyleCopAnalyzers#2237)
    * [x] ~~Framework testing (DotNetAnalyzers/StyleCopAnalyzers#2425)~~ (initial project added with a few tests, but the majority of this item moved to a follow-up item)
* Extension points
    * [x] ~~Extract CreateSolution~~ (omitted in favor of `SolutionTransforms`)
    * [x] ~~Expose CreateProject (DotNetAnalyzers/StyleCopAnalyzers#1151)~~ (omitted in favor of `SolutionTransforms`)
    * [x] ~~Expose formatting options (DotNetAnalyzers/StyleCopAnalyzers#1135)~~ (left for library authors)
    * [x] Referenced assemblies (??, DotNetAnalyzers/StyleCopAnalyzers#1751, DotNetAnalyzers/StyleCopAnalyzers#2389, DotNetAnalyzers/StyleCopAnalyzers#2478) (**partial:** currently only via `SolutionTransforms`)
    * [x] Simplified DiagnosticResult API (DotNetAnalyzers/StyleCopAnalyzers#526, DotNetAnalyzers/StyleCopAnalyzers#569, DotNetAnalyzers/StyleCopAnalyzers#743, DotNetAnalyzers/StyleCopAnalyzers#2136, DotNetAnalyzers/StyleCopAnalyzers#2425)
    * [x] Support multiple analyzers (DotNetAnalyzers/StyleCopAnalyzers#802)
    * [x] Additional documents (small addition in DotNetAnalyzers/StyleCopAnalyzers#1270) (**partial:** currently only via `SolutionTransforms`)
    * [x] Disabled diagnostics (DotNetAnalyzers/StyleCopAnalyzers#1360)
    * [x] Filename passed to CreateDocument (DotNetAnalyzers/StyleCopAnalyzers#1837, DotNetAnalyzers/StyleCopAnalyzers#1841)
    * [x] XmlReferenceResolver? (DotNetAnalyzers/StyleCopAnalyzers#1898)
    * [x] ApplyCompilationOptions (improves/unifies several above items) (DotNetAnalyzers/StyleCopAnalyzers#1983) (via `SolutionTransforms`)
    * [x] Multi-file code fixes (DotNetAnalyzers/StyleCopAnalyzers#2140)
* Automatically test incremental fixes and Fix All operations (DotNetAnalyzers/StyleCopAnalyzers#1035, DotNetAnalyzers/StyleCopAnalyzers#1126, DotNetAnalyzers/StyleCopAnalyzers#1297, DotNetAnalyzers/StyleCopAnalyzers#1625, DotNetAnalyzers/StyleCopAnalyzers#1797, DotNetAnalyzers/StyleCopAnalyzers#2140)
    * [x] Number of iterations is constrained (DotNetAnalyzers/StyleCopAnalyzers#1989, DotNetAnalyzers/StyleCopAnalyzers#2140)
    * [x] ~~Restrict use of batch fixer (DotNetAnalyzers/StyleCopAnalyzers#1195)~~ (left for library authors)
    * [x] ~~Look at DotNetAnalyzers/StyleCopAnalyzers#1983?~~ (no action necessary)
* Hard-coded features that could be extensible
    * [x] Aliases for references (DotNetAnalyzers/StyleCopAnalyzers@766c2ff) (**partial:** supported through `SolutionTransforms`)
    * [x] Exclusions for generated code (DotNetAnalyzers/StyleCopAnalyzers#1044, DotNetAnalyzers/StyleCopAnalyzers#1304, DotNetAnalyzers/StyleCopAnalyzers#2018, DotNetAnalyzers/StyleCopAnalyzers#2032, plus other changes to the analyzer file over time)
    * [x] ~~Test help links (DotNetAnalyzers/StyleCopAnalyzers#1183)~~ (left for library authors)
    * [x] ~~Settings file (DotNetAnalyzers/StyleCopAnalyzers#1360)~~ (left for library authors)
    * [x] ~~Formatting options (DotNetAnalyzers/StyleCopAnalyzers#2039)~~ (left for library authors)
    * [x] ~~TestEmptySourceAsync (DotNetAnalyzers/StyleCopAnalyzers#1047)~~ (left for library authors)

Closes #123 

Items to file specific follow-up issues:

* Add tests for new types
* Find a way to use vs-mef for .NET Standard builds (required for concurrent testing)
* ~~Allow `MarkupTestFile` to populate diagnostic results~~ (implemented in 56d48d941804cda46d4af0b7de329b03ab4149eb)
* Consider using `IEnumerable<DiagnosticResult>` instead of `DiagnosticResult[]` https://github.com/dotnet/roslyn-sdk/pull/131#discussion_r210010924