### PR TITLE
Use Microsoft.VisualStudio.Composition when available

### DIFF
--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest.cs
@@ -6,14 +6,34 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.CodeAnalysis.Testing
 {
     public abstract partial class AnalyzerTest<TVerifier>
         where TVerifier : IVerifier, new()
     {
+        private static readonly Lazy<IExportProviderFactory> ExportProviderFactory;
+
+        static AnalyzerTest()
+        {
+            ExportProviderFactory = new Lazy<IExportProviderFactory>(
+                () =>
+                {
+                    var discovery = new AttributedPartDiscovery(Resolver.DefaultInstance, isNonPublicSupported: true);
+                    var parts = Task.Run(() => discovery.CreatePartsAsync(MefHostServices.DefaultAssemblies)).GetAwaiter().GetResult();
+                    var catalog = ComposableCatalog.Create(Resolver.DefaultInstance).AddParts(parts);
+
+                    var configuration = CompositionConfiguration.Create(catalog);
+                    var runtimeComposition = RuntimeComposition.CreateRuntimeComposition(configuration);
+                    return runtimeComposition.CreateExportProviderFactory();
+                },
+                LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
         protected TVerifier Verify { get; }
 
         protected virtual string DefaultFilePathPrefix { get; } = "Test";
@@ -773,7 +793,14 @@ namespace Microsoft.CodeAnalysis.Testing
 
         public virtual AdhocWorkspace CreateWorkspace()
         {
+            var exportProvider = ExportProviderFactory.Value.CreateExportProvider();
+
+#if NETSTANDARD1_5
             return new AdhocWorkspace();
+#else
+            var host = MefV1HostServices.Create(exportProvider.AsExportProvider());
+            return new AdhocWorkspace(host);
+#endif
         }
 
         protected abstract CompilationOptions CreateCompilationOptions();

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MetadataReferences.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MetadataReferences.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
-#if !NETSTANDARD1_1
+#if !NETSTANDARD1_5
 using System;
 #endif
 
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Testing
         public static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).GetTypeInfo().Assembly.Location);
 #endif
 
-#if NETSTANDARD1_1
+#if NETSTANDARD1_5
         public static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.FullName).WithAliases(ImmutableArray.Create("global", "corlib"));
         public static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(System.Diagnostics.Debug).GetTypeInfo().Assembly.FullName).WithAliases(ImmutableArray.Create("global", "system"));
         public static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).GetTypeInfo().Assembly.FullName);
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Testing
 
         static MetadataReferences()
         {
-#if NETSTANDARD1_1
+#if NETSTANDARD1_5
             if (typeof(string).GetTypeInfo().Assembly.ExportedTypes.Any(x => x.Name == "System.ValueTuple"))
             {
                 // mscorlib contains ValueTuple, so no need to add a separate reference

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.Analyzer.Testing</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
   

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="15.6.36" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Testing.MSTest</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>netstandard1.1</TargetFrameworks>
+   <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Testing.NUnit</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
   

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>netstandard1.5</TargetFrameworks>
+   <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit</AssemblyName>

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.xUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.xUnit.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.xUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.xUnit.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.xUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Testing.xUnit</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Analyzer.Testing</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Testing</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Codefix.Testing</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Testing</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.MSTest.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.MSTest.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Codefix.Testing.MSTest</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Testing.MSTest</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>netstandard1.1</TargetFrameworks>
+   <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Testing.NUnit</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>netstandard1.5</TargetFrameworks>
+   <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Codefix.Testing.NUnit</AssemblyName>

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.xUnit/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.xUnit.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.xUnit/Microsoft.CodeAnalysis.CSharp.Codefix.Testing.xUnit.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.CSharp.Codefix.Testing.xUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Testing.xUnit</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Codefix.Testing/Microsoft.CodeAnalysis.Codefix.Testing.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Codefix.Testing/Microsoft.CodeAnalysis.Codefix.Testing.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.Codefix.Testing</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.MSTest/Microsoft.CodeAnalysis.Testing.Verifiers.MSTest.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.MSTest/Microsoft.CodeAnalysis.Testing.Verifiers.MSTest.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.Testing.Verifiers.MSTest</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.Testing.Verifiers</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+   <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.Testing.Verifiers.NUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.Testing.Verifiers</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.xUnit/Microsoft.CodeAnalysis.Testing.Verifiers.xUnit.csproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.xUnit/Microsoft.CodeAnalysis.Testing.Verifiers.xUnit.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.Testing.Verifiers.xUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.Testing.Verifiers</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest.vbproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>15.5</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Testing.MSTest</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit.vbproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+   <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>15.5</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Testing.NUnit</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.xUnit/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.xUnit.vbproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.xUnit/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.xUnit.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>15.5</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.xUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Testing.xUnit</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.vbproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>15.5</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Testing</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.MSTest.vbproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.MSTest.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>15.5</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.MSTest</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Testing.MSTest</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.NUnit.vbproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.NUnit.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-   <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+   <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>15.5</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.NUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Testing.NUnit</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.xUnit/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.xUnit.vbproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.xUnit/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.xUnit.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>15.5</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.xUnit</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Testing.xUnit</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.vbproj
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing/Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing.vbproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>15.5</LangVersion>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Codefix.Testing</AssemblyName>
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Testing</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 


### PR DESCRIPTION
* Use vs-mef in the .NET Framework 4.5.2 target
* Will file a follow-up issue to use vs-mef in .NET Standard 1.5 build (requires adapting `ExportProvider` to `MefHostServices`)