### PR TITLE
Fix the assembly name of SolutionExplorer.csproj

### DIFF
--- a/samples/CSharp/SolutionExplorer/SolutionExplorer.csproj
+++ b/samples/CSharp/SolutionExplorer/SolutionExplorer.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="MSBuild.Sdk.Extras/1.6.41">
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.41">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <RootNamespace>MSBuildWorkspaceTester</RootNamespace>
-    <AssemblyName>WorkspaceTester</AssemblyName>
+    <AssemblyName>SolutionExplorer</AssemblyName>
     <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
     <OutputType>WinExe</OutputType>
     <AssemblyTitle>MSBuildWorkspaceTester</AssemblyTitle>


### PR DESCRIPTION
Repo toolset looks for `$(AssemblyName).csproj` to determine the language name of WPF temporary projects. The mismatch meant this project file was not found.