### PR TITLE
Allow calling VerifyAnalyzerAsync and VerifyCodeFixAsync without explicit diagnostics

### DIFF
--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerVerifier`3.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerVerifier`3.cs
@@ -32,6 +32,9 @@ namespace Microsoft.CodeAnalysis.Testing
 
         public static DiagnosticResult CompilerError(string errorIdentifier) => new DiagnosticResult(errorIdentifier, DiagnosticSeverity.Error);
 
+        public static Task VerifyAnalyzerAsync(string source, CancellationToken cancellationToken = default)
+            => VerifyAnalyzerAsync(source, EmptyDiagnosticResults, cancellationToken);
+
         public static Task VerifyAnalyzerAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken = default)
             => VerifyAnalyzerAsync(source, new[] { expected }, cancellationToken);
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Codefix.Testing/CodeFixVerifier`4.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Codefix.Testing/CodeFixVerifier`4.cs
@@ -25,11 +25,17 @@ namespace Microsoft.CodeAnalysis.Testing
         public static DiagnosticResult CompilerError(string errorIdentifier)
             => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.CompilerError(errorIdentifier);
 
+        public static Task VerifyAnalyzerAsync(string source, CancellationToken cancellationToken = default)
+            => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.VerifyAnalyzerAsync(source, cancellationToken);
+
         public static Task VerifyAnalyzerAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken = default)
             => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.VerifyAnalyzerAsync(source, expected, cancellationToken);
 
         public static Task VerifyAnalyzerAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken = default)
             => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.VerifyAnalyzerAsync(source, expected, cancellationToken);
+
+        public static Task VerifyCodeFixAsync(string source, string fixedSource, CancellationToken cancellationToken = default)
+            => VerifyCodeFixAsync(source, EmptyDiagnosticResults, fixedSource, cancellationToken);
 
         public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken = default)
             => VerifyCodeFixAsync(source, new[] { expected }, fixedSource, cancellationToken);


### PR DESCRIPTION
This pull request adds new overloads for `VerifyAnalyzerAsync` and `VerifyCodeFixAsync` that omit the expected diagnostics. These overloads are not necessarily required, so I'd like to have a broader conversation before merging. There are two scenarios which seem most likely to benefit from this change:

1. Analyzer tests which assert that code does not contain any reported diagnostics
2. Code fix tests which use markup instead of explicit diagnostics to mark the diagnostics appearing in the input source