### PR TITLE
Standard diagnostics

### DIFF
--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerVerifier`3.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerVerifier`3.cs
@@ -28,8 +28,6 @@ namespace Microsoft.CodeAnalysis.Testing
 
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor) => new DiagnosticResult(descriptor);
 
-        public static DiagnosticResult CompilerError(string errorIdentifier) => new DiagnosticResult(errorIdentifier, DiagnosticSeverity.Error);
-
         public static Task VerifyAnalyzerAsync(string source, CancellationToken cancellationToken = default)
             => VerifyAnalyzerAsync(source, DiagnosticResult.EmptyDiagnosticResults, cancellationToken);
 

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerVerifier`3.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerVerifier`3.cs
@@ -12,8 +12,6 @@ namespace Microsoft.CodeAnalysis.Testing
            where TTest : AnalyzerTest<TVerifier>, new()
            where TVerifier : IVerifier, new()
     {
-        public static DiagnosticResult[] EmptyDiagnosticResults { get; } = { };
-
         public static DiagnosticResult Diagnostic(string diagnosticId = null)
         {
             var analyzer = new TAnalyzer();
@@ -33,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Testing
         public static DiagnosticResult CompilerError(string errorIdentifier) => new DiagnosticResult(errorIdentifier, DiagnosticSeverity.Error);
 
         public static Task VerifyAnalyzerAsync(string source, CancellationToken cancellationToken = default)
-            => VerifyAnalyzerAsync(source, EmptyDiagnosticResults, cancellationToken);
+            => VerifyAnalyzerAsync(source, DiagnosticResult.EmptyDiagnosticResults, cancellationToken);
 
         public static Task VerifyAnalyzerAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken = default)
             => VerifyAnalyzerAsync(source, new[] { expected }, cancellationToken);

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -68,6 +68,9 @@ namespace Microsoft.CodeAnalysis.Testing
 
         public bool HasLocation => (_spans != default) && (_spans.Length > 0);
 
+        public static DiagnosticResult CompilerError(string identifier)
+            => new DiagnosticResult(identifier, DiagnosticSeverity.Error);
+
         public DiagnosticResult WithSeverity(DiagnosticSeverity severity)
         {
             var result = this;

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -10,6 +10,8 @@ namespace Microsoft.CodeAnalysis.Testing
     /// </summary>
     public struct DiagnosticResult
     {
+        public static readonly DiagnosticResult[] EmptyDiagnosticResults = { };
+
         private static readonly object[] EmptyArguments = new object[0];
 
         private ImmutableArray<FileLinePositionSpan> _spans;

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -71,6 +71,9 @@ namespace Microsoft.CodeAnalysis.Testing
         public static DiagnosticResult CompilerError(string identifier)
             => new DiagnosticResult(identifier, DiagnosticSeverity.Error);
 
+        public static DiagnosticResult CompilerWarning(string identifier)
+            => new DiagnosticResult(identifier, DiagnosticSeverity.Warning);
+
         public DiagnosticResult WithSeverity(DiagnosticSeverity severity)
         {
             var result = this;

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixVerifier`4.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixVerifier`4.cs
@@ -13,9 +13,6 @@ namespace Microsoft.CodeAnalysis.Testing
            where TTest : CodeFixTest<TVerifier>, new()
            where TVerifier : IVerifier, new()
     {
-        public static DiagnosticResult[] EmptyDiagnosticResults
-            => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.EmptyDiagnosticResults;
-
         public static DiagnosticResult Diagnostic(string diagnosticId = null)
             => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.Diagnostic(diagnosticId);
 
@@ -35,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Testing
             => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.VerifyAnalyzerAsync(source, expected, cancellationToken);
 
         public static Task VerifyCodeFixAsync(string source, string fixedSource, CancellationToken cancellationToken = default)
-            => VerifyCodeFixAsync(source, EmptyDiagnosticResults, fixedSource, cancellationToken);
+            => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource, cancellationToken);
 
         public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken = default)
             => VerifyCodeFixAsync(source, new[] { expected }, fixedSource, cancellationToken);

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixVerifier`4.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixVerifier`4.cs
@@ -19,9 +19,6 @@ namespace Microsoft.CodeAnalysis.Testing
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
             => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.Diagnostic(descriptor);
 
-        public static DiagnosticResult CompilerError(string errorIdentifier)
-            => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.CompilerError(errorIdentifier);
-
         public static Task VerifyAnalyzerAsync(string source, CancellationToken cancellationToken = default)
             => AnalyzerVerifier<TAnalyzer, TTest, TVerifier>.VerifyAnalyzerAsync(source, cancellationToken);
 


### PR DESCRIPTION
* Consolidate definitions of `EmptyDiagnosticResults`
* Consolidate definitions of `CompilerError`
* Add definition of `CompilerWarning`

@jmarolf This pull request includes a subset of #157