### PR TITLE
Improved debug experience

### DIFF
--- a/Roslyn-SDK.sln
+++ b/Roslyn-SDK.sln
@@ -91,6 +91,8 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.Visu
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.NUnit", "src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.NUnit\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.NUnit.vbproj", "{A09B3448-F5D5-4254-ACDD-B4BB4F2A1BBF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests\Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests.csproj", "{55A17330-EBD7-4E88-B816-535B46C8D426}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -201,6 +203,10 @@ Global
 		{A09B3448-F5D5-4254-ACDD-B4BB4F2A1BBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A09B3448-F5D5-4254-ACDD-B4BB4F2A1BBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A09B3448-F5D5-4254-ACDD-B4BB4F2A1BBF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55A17330-EBD7-4E88-B816-535B46C8D426}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55A17330-EBD7-4E88-B816-535B46C8D426}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55A17330-EBD7-4E88-B816-535B46C8D426}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55A17330-EBD7-4E88-B816-535B46C8D426}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -248,6 +254,7 @@ Global
 		{7DDF1D87-2D75-4493-A6F1-9E0E66F7C350} = {19217AA9-4EF3-4F37-8664-EBC16FF99D42}
 		{06875E62-AA7D-485D-A654-F7AC561F794A} = {BF4B9B19-3335-4D90-92C2-362650920629}
 		{A09B3448-F5D5-4254-ACDD-B4BB4F2A1BBF} = {BF4B9B19-3335-4D90-92C2-362650920629}
+		{55A17330-EBD7-4E88-B816-535B46C8D426} = {C8CABE1E-E5D8-41BF-934F-90F829482376}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7075E20E-F8B5-460C-8CF0-132F617F386C}

--- a/Roslyn-SDK.sln
+++ b/Roslyn-SDK.sln
@@ -93,6 +93,26 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.Visu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests\Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests.csproj", "{55A17330-EBD7-4E88-B816-535B46C8D426}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests\Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests.csproj", "{FB9F5ABC-8A5B-46D4-B462-01960B10EA2D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests\Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests.csproj", "{345D501B-AB9E-48E3-9656-3E068D651229}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests\Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests.csproj", "{7C6EE1C5-827B-44EF-9A09-010D3FB92625}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests\Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests.csproj", "{E2DD67F1-F831-400F-8ED7-5648056777AD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests\Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests.csproj", "{8492BC3A-2A4D-4E1E-A483-202B640DFB89}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests\Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests.csproj", "{F87810D9-8B74-4CE5-9A7C-02611C3FDDB5}"
+EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests\Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests.vbproj", "{281B016C-ED55-4BC9-A5AC-D2F43653E2C9}"
+EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests.vbproj", "{CF624D1C-7E90-405A-9063-A91B57A09710}"
+EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests\Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests.vbproj", "{2DBCC26E-7BF9-4EDD-B0B4-AA44B7C26039}"
+EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests.vbproj", "{2FDE73BE-FDC9-4CE4-91C8-603CF4DF3ABF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -207,6 +227,46 @@ Global
 		{55A17330-EBD7-4E88-B816-535B46C8D426}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{55A17330-EBD7-4E88-B816-535B46C8D426}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{55A17330-EBD7-4E88-B816-535B46C8D426}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB9F5ABC-8A5B-46D4-B462-01960B10EA2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB9F5ABC-8A5B-46D4-B462-01960B10EA2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB9F5ABC-8A5B-46D4-B462-01960B10EA2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB9F5ABC-8A5B-46D4-B462-01960B10EA2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{345D501B-AB9E-48E3-9656-3E068D651229}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{345D501B-AB9E-48E3-9656-3E068D651229}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{345D501B-AB9E-48E3-9656-3E068D651229}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{345D501B-AB9E-48E3-9656-3E068D651229}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C6EE1C5-827B-44EF-9A09-010D3FB92625}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C6EE1C5-827B-44EF-9A09-010D3FB92625}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C6EE1C5-827B-44EF-9A09-010D3FB92625}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C6EE1C5-827B-44EF-9A09-010D3FB92625}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2DD67F1-F831-400F-8ED7-5648056777AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2DD67F1-F831-400F-8ED7-5648056777AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2DD67F1-F831-400F-8ED7-5648056777AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2DD67F1-F831-400F-8ED7-5648056777AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8492BC3A-2A4D-4E1E-A483-202B640DFB89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8492BC3A-2A4D-4E1E-A483-202B640DFB89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8492BC3A-2A4D-4E1E-A483-202B640DFB89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8492BC3A-2A4D-4E1E-A483-202B640DFB89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F87810D9-8B74-4CE5-9A7C-02611C3FDDB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F87810D9-8B74-4CE5-9A7C-02611C3FDDB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F87810D9-8B74-4CE5-9A7C-02611C3FDDB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F87810D9-8B74-4CE5-9A7C-02611C3FDDB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{281B016C-ED55-4BC9-A5AC-D2F43653E2C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{281B016C-ED55-4BC9-A5AC-D2F43653E2C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{281B016C-ED55-4BC9-A5AC-D2F43653E2C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{281B016C-ED55-4BC9-A5AC-D2F43653E2C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF624D1C-7E90-405A-9063-A91B57A09710}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF624D1C-7E90-405A-9063-A91B57A09710}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF624D1C-7E90-405A-9063-A91B57A09710}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF624D1C-7E90-405A-9063-A91B57A09710}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2DBCC26E-7BF9-4EDD-B0B4-AA44B7C26039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2DBCC26E-7BF9-4EDD-B0B4-AA44B7C26039}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2DBCC26E-7BF9-4EDD-B0B4-AA44B7C26039}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2DBCC26E-7BF9-4EDD-B0B4-AA44B7C26039}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FDE73BE-FDC9-4CE4-91C8-603CF4DF3ABF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FDE73BE-FDC9-4CE4-91C8-603CF4DF3ABF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FDE73BE-FDC9-4CE4-91C8-603CF4DF3ABF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FDE73BE-FDC9-4CE4-91C8-603CF4DF3ABF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -255,6 +315,16 @@ Global
 		{06875E62-AA7D-485D-A654-F7AC561F794A} = {BF4B9B19-3335-4D90-92C2-362650920629}
 		{A09B3448-F5D5-4254-ACDD-B4BB4F2A1BBF} = {BF4B9B19-3335-4D90-92C2-362650920629}
 		{55A17330-EBD7-4E88-B816-535B46C8D426} = {C8CABE1E-E5D8-41BF-934F-90F829482376}
+		{FB9F5ABC-8A5B-46D4-B462-01960B10EA2D} = {C8CABE1E-E5D8-41BF-934F-90F829482376}
+		{345D501B-AB9E-48E3-9656-3E068D651229} = {F71DFC4B-905A-4D0C-913F-6DB9743695F0}
+		{7C6EE1C5-827B-44EF-9A09-010D3FB92625} = {F71DFC4B-905A-4D0C-913F-6DB9743695F0}
+		{E2DD67F1-F831-400F-8ED7-5648056777AD} = {0B73A100-46C1-4DCD-9B23-018D67896ED6}
+		{8492BC3A-2A4D-4E1E-A483-202B640DFB89} = {0B73A100-46C1-4DCD-9B23-018D67896ED6}
+		{F87810D9-8B74-4CE5-9A7C-02611C3FDDB5} = {A7AF7E27-F8E0-4713-9538-DDC08C47200B}
+		{281B016C-ED55-4BC9-A5AC-D2F43653E2C9} = {0E639BE0-953E-4B08-A1EF-DC4CE6AD8E9C}
+		{CF624D1C-7E90-405A-9063-A91B57A09710} = {0E639BE0-953E-4B08-A1EF-DC4CE6AD8E9C}
+		{2DBCC26E-7BF9-4EDD-B0B4-AA44B7C26039} = {8A157868-2CBB-4EC4-9CCF-6C5CEF30CBA9}
+		{2FDE73BE-FDC9-4CE4-91C8-603CF4DF3ABF} = {8A157868-2CBB-4EC4-9CCF-6C5CEF30CBA9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7075E20E-F8B5-460C-8CF0-132F617F386C}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,7 +58,9 @@
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <SystemCompositionVersion>1.1.0</SystemCompositionVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
-    
+
+    <!-- Analyzers -->
+    <StyleCopAnalyzersVersion>1.1.0-beta008</StyleCopAnalyzersVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\..\stylecop.json" Link="stylecop.json" />
     <None Include="$(CodeAnalysisRuleSet)" Condition="'$(CodeAnalysisRuleSet)' != ''" Link="%(Filename)%(Extension)" />
   </ItemGroup>

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -9,6 +9,14 @@
 
   <Import Project="Sdk.props" Sdk="RoslynTools.RepoToolset" />
 
+  <!-- We always want a good debugging experience in tests -->
+  <PropertyGroup>
+    <Optimize>false</Optimize>
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <EmbedAllSources>true</EmbedAllSources>
+  </PropertyGroup>
+
   <!-- StyleCop Analyzers configuration -->
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Testing
@@ -171,6 +174,50 @@ namespace Microsoft.CodeAnalysis.Testing
             var result = this;
             result._spans = Spans.Add(span);
             return result;
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            if (HasLocation)
+            {
+                var location = Spans[0];
+                builder.Append(location.Path == string.Empty ? "?" : location.Path);
+                builder.Append("(");
+                builder.Append(location.StartLinePosition.Line);
+                builder.Append(",");
+                builder.Append(location.StartLinePosition.Character);
+                if (location.EndLinePosition != location.StartLinePosition)
+                {
+                    builder.Append(",");
+                    builder.Append(location.EndLinePosition.Line);
+                    builder.Append(",");
+                    builder.Append(location.EndLinePosition.Character);
+                }
+
+                builder.Append("): ");
+            }
+
+            builder.Append(Severity.ToString().ToLowerInvariant());
+            builder.Append(" ");
+            builder.Append(Id);
+
+            try
+            {
+                var message = Message;
+                if (message != null)
+                {
+                    builder.Append(": ").Append(message);
+                }
+            }
+            catch (FormatException)
+            {
+                // A message format is provided without arguments, so we print the unformatted string
+                Debug.Assert(MessageFormat != null, $"Assertion failed: {nameof(MessageFormat)} != null");
+                builder.Append(": ").Append(MessageFormat);
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\stylecop.json" Link="stylecop.json" />
     <None Include="$(CodeAnalysisRuleSet)" Condition="'$(CodeAnalysisRuleSet)' != ''" Link="%(Filename)%(Extension)" />
   </ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -1,0 +1,24 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>  
+  <PropertyGroup>
+    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
+    
+    <!-- Opt-out repo features -->
+    <UsingToolXliff>false</UsingToolXliff>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="RoslynTools.RepoToolset" />
+
+  <!-- StyleCop Analyzers configuration -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\RoslynSDK.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\stylecop.json" Link="stylecop.json" />
+    <None Include="$(CodeAnalysisRuleSet)" Condition="'$(CodeAnalysisRuleSet)' != ''" Link="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.targets
+++ b/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.targets
@@ -1,0 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  <Import Project="Sdk.targets" Sdk="RoslynTools.RepoToolset" />
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/DiagnosticResultTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/DiagnosticResultTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    public class DiagnosticResultTests
+    {
+        private static DiagnosticResult CompilerError
+            => DiagnosticResult.CompilerError("CS1002").WithLocation(1, 1).WithMessage("; expected");
+
+        [Fact]
+        public void TestToString()
+        {
+            Assert.Equal(
+                "?(1,1): error CS1002: ; expected",
+                CompilerError.ToString());
+        }
+
+        [Fact]
+        public void TestToStringWithSpan()
+        {
+            Assert.Equal(
+                "?(1,3,2,4): error CS1002",
+                DiagnosticResult.CompilerError("CS1002").WithSpan(1, 3, 2, 4).ToString());
+        }
+
+        [Fact]
+        public void TestToStringSeverity()
+        {
+            Assert.Equal(
+                "?(1,1): error CS1002: ; expected",
+                CompilerError.WithSeverity(DiagnosticSeverity.Error).ToString());
+            Assert.Equal(
+                "?(1,1): warning CS1002: ; expected",
+                CompilerError.WithSeverity(DiagnosticSeverity.Warning).ToString());
+            Assert.Equal(
+                "?(1,1): info CS1002: ; expected",
+                CompilerError.WithSeverity(DiagnosticSeverity.Info).ToString());
+            Assert.Equal(
+                "?(1,1): hidden CS1002: ; expected",
+                CompilerError.WithSeverity(DiagnosticSeverity.Hidden).ToString());
+        }
+
+        [Fact]
+        public void TestToStringWithoutLocation()
+        {
+            Assert.Equal(
+                "error CS1002: ; expected",
+                DiagnosticResult.CompilerError("CS1002").WithMessage("; expected").ToString());
+        }
+
+        [Fact]
+        public void TestToStringWithoutMessage()
+        {
+            Assert.Equal(
+                "?(1,1): error CS1002",
+                DiagnosticResult.CompilerError("CS1002").WithLocation(1, 1).ToString());
+        }
+
+        [Fact]
+        public void TestToStringWithoutLocationOrMessage()
+        {
+            Assert.Equal(
+                "error CS1002",
+                DiagnosticResult.CompilerError("CS1002").ToString());
+        }
+
+        [Fact]
+        public void TestToStringWithMessageFormat()
+        {
+            Assert.Equal(
+                "error CS1002: {0} expected",
+                DiagnosticResult.CompilerError("CS1002").WithMessageFormat("{0} expected").ToString());
+            Assert.Equal(
+                "error CS1002: ; expected",
+                DiagnosticResult.CompilerError("CS1002").WithMessageFormat("{0} expected").WithArguments(";").ToString());
+        }
+    }
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.Analyzer.Testing\Microsoft.CodeAnalysis.Analyzer.Testing.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CSharp.Analyzer.Testing\Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit\Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CSharp.CodeFix.Testing\Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit\Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.CodeFix.Testing\Microsoft.CodeAnalysis.CodeFix.Testing.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests.csproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.Testing.Verifiers.XUnit\Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests.vbproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests.vbproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing\Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.vbproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests.vbproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests.vbproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit\Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.vbproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests.vbproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests.vbproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.vbproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests.vbproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests.vbproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Tools\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit\Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.vbproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests/xunit.runner.json
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}


### PR DESCRIPTION
* Add **UnitTests** projects for Microsoft.CodeAnalysis.Testing, except for assemblies specific to NUnit and MSTest
* Improved end-user debugging experience for analyzer testing
    * Disable optimization for shipping assemblies
    * Embed symbols in shipping assemblies
    * Embed sources in shipping assemblies
* Define `DiagnosticResult.ToString()` for improved debugging