### PR TITLE
Add NumberOfFixAllInDocumentIterations property

### DIFF
--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest.cs
@@ -706,7 +706,11 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <see cref="Diagnostic.Location"/> and <see cref="Diagnostic.Id"/>.</returns>
         private static Diagnostic[] SortDistinctDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
-            return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ThenBy(d => d.Location.SourceSpan.End).ThenBy(d => d.Id).ToArray();
+            return diagnostics
+                .OrderBy(d => d.Location.GetLineSpan().Path, StringComparer.Ordinal)
+                .ThenBy(d => d.Location.SourceSpan.Start)
+                .ThenBy(d => d.Location.SourceSpan.End)
+                .ThenBy(d => d.Id).ToArray();
         }
 
         /// <summary>

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
@@ -160,6 +160,20 @@ namespace Microsoft.CodeAnalysis.Testing
         public int? NumberOfFixAllIterations { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of code fix iterations expected during code fix testing for Fix All in Document
+        /// scenarios.
+        /// </summary>
+        /// <remarks>
+        /// <para>See the <see cref="NumberOfIncrementalIterations"/> property for an overview of the behavior of this
+        /// property. If the number of Fix All in Document iterations is not specified, the value from
+        /// <see cref="NumberOfFixAllIterations"/> is used.</para>
+        /// </remarks>
+        /// <seealso cref="NumberOfIncrementalIterations"/>
+        /// <seealso cref="NumberOfFixAllIterations"/>
+        /// <seealso href="https://github.com/dotnet/roslyn-sdk/issues/147">#147: Figure out Fix All iteration counts by context</seealso>
+        public int? NumberOfFixAllInDocumentIterations { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether new compiler diagnostics are allowed to appear in code fix outputs.
         /// The default value is <see langword="false"/>.
         /// </summary>
@@ -274,6 +288,7 @@ namespace Microsoft.CodeAnalysis.Testing
 
             int numberOfIncrementalIterations;
             int numberOfFixAllIterations;
+            int numberOfFixAllInDocumentIterations;
             if (NumberOfIncrementalIterations != null)
             {
                 numberOfIncrementalIterations = NumberOfIncrementalIterations.Value;
@@ -310,6 +325,15 @@ namespace Microsoft.CodeAnalysis.Testing
                 }
             }
 
+            if (NumberOfFixAllInDocumentIterations != null)
+            {
+                numberOfFixAllInDocumentIterations = NumberOfFixAllInDocumentIterations.Value;
+            }
+            else
+            {
+                numberOfFixAllInDocumentIterations = numberOfFixAllIterations;
+            }
+
             var t1 = VerifyFixAsync(Language, GetDiagnosticAnalyzers().ToImmutableArray(), GetCodeFixProviders().ToImmutableArray(), oldSources, additionalFiles, newSources, fixedAdditionalFiles, numberOfIncrementalIterations, FixEachAnalyzerDiagnosticAsync, cancellationToken).ConfigureAwait(false);
 
             var fixAllProvider = GetCodeFixProviders().Select(codeFixProvider => codeFixProvider.GetFixAllProvider()).Where(codeFixProvider => codeFixProvider != null).ToImmutableArray();
@@ -325,7 +349,7 @@ namespace Microsoft.CodeAnalysis.Testing
                     await t1;
                 }
 
-                var t2 = VerifyFixAsync(Language, GetDiagnosticAnalyzers().ToImmutableArray(), GetCodeFixProviders().ToImmutableArray(), oldSources, additionalFiles, batchNewSources ?? newSources, fixedAdditionalFiles, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
+                var t2 = VerifyFixAsync(Language, GetDiagnosticAnalyzers().ToImmutableArray(), GetCodeFixProviders().ToImmutableArray(), oldSources, additionalFiles, batchNewSources ?? newSources, fixedAdditionalFiles, numberOfFixAllInDocumentIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
                 if (Debugger.IsAttached)
                 {
                     await t2;

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/PublicAPI.Unshipped.txt
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/PublicAPI.Unshipped.txt
@@ -13,6 +13,8 @@ Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.CodeFixValidationMode.get 
 Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.CodeFixValidationMode.set -> void
 Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.FixedCode.set -> void
 Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.FixedSources.get -> Microsoft.CodeAnalysis.Testing.SourceFileList
+Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.NumberOfFixAllInDocumentIterations.get -> int?
+Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.NumberOfFixAllInDocumentIterations.set -> void
 Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.NumberOfFixAllIterations.get -> int?
 Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.NumberOfFixAllIterations.set -> void
 Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.NumberOfIncrementalIterations.get -> int?

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/CodeFixIterationTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/CodeFixIterationTests.cs
@@ -243,6 +243,114 @@ class TestClass {
             Assert.Equal(message, exception.Message);
         }
 
+        [Fact]
+        [WorkItem(147, "https://github.com/dotnet/roslyn-sdk/issues/147")]
+        public async Task TestOneIterationRequiredForEachOfTwoDocuments()
+        {
+            var testCode1 = @"
+class TestClass1 {
+  int field = [|4|];
+}
+";
+            var testCode2 = @"
+class TestClass2 {
+  int field = [|4|];
+}
+";
+            var fixedCode1 = @"
+class TestClass1 {
+  int field =  5;
+}
+";
+            var fixedCode2 = @"
+class TestClass2 {
+  int field =  5;
+}
+";
+
+            await new CSharpTest
+            {
+                TestSources = { testCode1, testCode2 },
+                FixedSources = { fixedCode1, fixedCode2 },
+                NumberOfFixAllInDocumentIterations = 2,
+            }.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(147, "https://github.com/dotnet/roslyn-sdk/issues/147")]
+        public async Task TestOneIterationRequiredForEachOfTwoDocumentsButNotDeclared()
+        {
+            var testCode1 = @"
+class TestClass1 {
+  int field = [|4|];
+}
+";
+            var testCode2 = @"
+class TestClass2 {
+  int field = [|4|];
+}
+";
+            var fixedCode1 = @"
+class TestClass1 {
+  int field =  5;
+}
+";
+            var fixedCode2 = @"
+class TestClass2 {
+  int field =  5;
+}
+";
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await new CSharpTest
+                {
+                    TestSources = { testCode1, testCode2 },
+                    FixedSources = { fixedCode1, fixedCode2 },
+                }.RunAsync();
+            });
+
+            Assert.Equal("Expected '1' iterations but found '2' iterations.", exception.Message);
+        }
+
+        [Fact]
+        [WorkItem(147, "https://github.com/dotnet/roslyn-sdk/issues/147")]
+        public async Task TestOneIterationRequiredForEachOfTwoDocumentsButDeclaredForAll()
+        {
+            var testCode1 = @"
+class TestClass1 {
+  int field = [|4|];
+}
+";
+            var testCode2 = @"
+class TestClass2 {
+  int field = [|4|];
+}
+";
+            var fixedCode1 = @"
+class TestClass1 {
+  int field =  5;
+}
+";
+            var fixedCode2 = @"
+class TestClass2 {
+  int field =  5;
+}
+";
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await new CSharpTest
+                {
+                    TestSources = { testCode1, testCode2 },
+                    FixedSources = { fixedCode1, fixedCode2 },
+                    NumberOfFixAllIterations = 2,
+                }.RunAsync();
+            });
+
+            Assert.Equal("Expected '2' iterations but found '1' iterations.", exception.Message);
+        }
+
         /// <summary>
         /// Reports a diagnostic on any integer literal token with a value less than five.
         /// </summary>


### PR DESCRIPTION
This property allows the number of iterations for Fix All in Document to be specified separately from the number of iterations for Fix All in Project and Fix All in Solution.

This provides a workaround for #147, but we can likely make improvements to *at least* the default values for these properties.