### PR TITLE
Multi-target unit tests

### DIFF
--- a/RoslynSDK.ruleset
+++ b/RoslynSDK.ruleset
@@ -18,5 +18,6 @@
   </Rules>
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers" RuleNamespace="Roslyn.Diagnostics.Analyzers">
     <Rule Id="RS0026" Action="None" /> <!-- AvoidMultipleOverloadsWithOptionalParameters -->
+    <Rule Id="RS1022" Action="None" /> <!-- AD0001: https://github.com/dotnet/roslyn-analyzers/issues/1803 -->
   </Rules>
 </RuleSet>

--- a/eng/RestoreToolset.ps1
+++ b/eng/RestoreToolset.ps1
@@ -1,0 +1,22 @@
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+# Installs additional shared frameworks for testing purposes
+function InstallDotNetSharedFramework([string]$dotnetRoot, [string]$version) {
+  $fxDir = Join-Path $dotnetRoot "shared\Microsoft.NETCore.App\$version"
+
+  if (!(Test-Path $fxDir)) {
+    $installScript = GetDotNetInstallScript $dotnetRoot
+    & $installScript -Version $version -InstallDir $dotnetRoot -Runtime dotnet
+
+    if($lastExitCode -ne 0) {
+      throw "Failed to install shared Framework $version to '$dotnetRoot' (exit code '$lastExitCode')."
+    }
+  }
+}
+
+# The following frameworks and tools are used only for testing.
+# Do not attempt to install them in source build.
+if ($env:DotNetBuildFromSource -ne "true") {
+  InstallDotNetSharedFramework $env:DOTNET_INSTALL_DIR "1.1.2"
+}

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest.cs
@@ -689,7 +689,8 @@ namespace Microsoft.CodeAnalysis.Testing
             var exportProvider = ExportProviderFactory.Value.CreateExportProvider();
 
 #if NETSTANDARD1_5 || NETSTANDARD2_0
-            return new AdhocWorkspace();
+            var host = MefHostServices.Create(exportProvider.AsCompositionContext());
+            return new AdhocWorkspace(host);
 #else
             var host = MefV1HostServices.Create(exportProvider.AsExportProvider());
             return new AdhocWorkspace(host);

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Extensions/ExportProviderExtensions.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Extensions/ExportProviderExtensions.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Composition.Hosting.Core;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    internal static class ExportProviderExtensions
+    {
+        public static CompositionContext AsCompositionContext(this ExportProvider exportProvider)
+        {
+            return new CompositionContextShim(exportProvider);
+        }
+
+        private class CompositionContextShim : CompositionContext
+        {
+            private readonly ExportProvider _exportProvider;
+
+            public CompositionContextShim(ExportProvider exportProvider)
+            {
+                _exportProvider = exportProvider;
+            }
+
+            public override bool TryGetExport(CompositionContract contract, out object export)
+            {
+                var importMany = contract.MetadataConstraints.Contains(new KeyValuePair<string, object>("IsImportMany", true));
+                var (contractType, metadataType) = GetContractType(contract.ContractType, importMany);
+
+                if (metadataType != null)
+                {
+                    var methodInfo = (from method in _exportProvider.GetType().GetTypeInfo().GetMethods()
+                                      where method.Name == nameof(ExportProvider.GetExports)
+                                      where method.IsGenericMethod && method.GetGenericArguments().Length == 2
+                                      where method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(string)
+                                      select method).Single();
+                    var parameterizedMethod = methodInfo.MakeGenericMethod(contractType, metadataType);
+                    export = parameterizedMethod.Invoke(_exportProvider, new[] { contract.ContractName });
+                }
+                else
+                {
+                    var methodInfo = (from method in _exportProvider.GetType().GetTypeInfo().GetMethods()
+                                      where method.Name == nameof(ExportProvider.GetExports)
+                                      where method.IsGenericMethod && method.GetGenericArguments().Length == 1
+                                      where method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(string)
+                                      select method).Single();
+                    var parameterizedMethod = methodInfo.MakeGenericMethod(contractType);
+                    export = parameterizedMethod.Invoke(_exportProvider, new[] { contract.ContractName });
+                }
+
+                return true;
+            }
+
+            private (Type exportType, Type metadataType) GetContractType(Type contractType, bool importMany)
+            {
+                if (importMany && contractType.IsConstructedGenericType)
+                {
+                    if (contractType.GetGenericTypeDefinition() == typeof(IList<>)
+                        || contractType.GetGenericTypeDefinition() == typeof(ICollection<>)
+                        || contractType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    {
+                        contractType = contractType.GenericTypeArguments[0];
+                    }
+                }
+
+                if (contractType.IsConstructedGenericType)
+                {
+                    if (contractType.GetGenericTypeDefinition() == typeof(Lazy<>))
+                    {
+                        return (contractType.GenericTypeArguments[0], null);
+                    }
+                    else if (contractType.GetGenericTypeDefinition() == typeof(Lazy<,>))
+                    {
+                        return (contractType.GenericTypeArguments[0], contractType.GenericTypeArguments[1]);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException();
+                    }
+                }
+
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MetadataReferences.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MetadataReferences.cs
@@ -16,23 +16,13 @@ namespace Microsoft.CodeAnalysis.Testing
     /// </summary>
     public static class MetadataReferences
     {
-#if NET452
         public static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.Location).WithAliases(ImmutableArray.Create("global", "corlib"));
         public static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(System.Diagnostics.Debug).GetTypeInfo().Assembly.Location).WithAliases(ImmutableArray.Create("global", "system"));
         public static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).GetTypeInfo().Assembly.Location);
         public static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).GetTypeInfo().Assembly.Location);
         public static readonly MetadataReference SystemCollectionsImmutableReference = MetadataReference.CreateFromFile(typeof(ImmutableArray).GetTypeInfo().Assembly.Location);
         public static readonly MetadataReference MicrosoftVisualBasicReference = MetadataReference.CreateFromFile(typeof(Microsoft.VisualBasic.Strings).GetTypeInfo().Assembly.Location);
-#endif
 
-#if NETSTANDARD1_5 || NETSTANDARD2_0
-        public static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.FullName).WithAliases(ImmutableArray.Create("global", "corlib"));
-        public static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(System.Diagnostics.Debug).GetTypeInfo().Assembly.FullName).WithAliases(ImmutableArray.Create("global", "system"));
-        public static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).GetTypeInfo().Assembly.FullName);
-        public static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).GetTypeInfo().Assembly.FullName);
-        public static readonly MetadataReference SystemCollectionsImmutableReference = MetadataReference.CreateFromFile(typeof(ImmutableArray).GetTypeInfo().Assembly.FullName);
-        public static readonly MetadataReference MicrosoftVisualBasicReference = MetadataReference.CreateFromFile(typeof(Microsoft.VisualBasic.Strings).GetTypeInfo().Assembly.FullName);
-#endif
         public static readonly MetadataReference SystemRuntimeReference;
         public static readonly MetadataReference SystemValueTupleReference;
 

--- a/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -10,6 +10,10 @@
   <Import Project="Sdk.props" Sdk="RoslynTools.RepoToolset" />
 
   <PropertyGroup>
+    <TestTargetFrameworks>net46;netcoreapp1.1</TestTargetFrameworks>
+    <!-- Uncomment the following line to test on .NET Core 1.1 -->
+    <!--<TestTargetFrameworks>netcoreapp1.1;$(TestTargetFrameworks)</TestTargetFrameworks>-->
+
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -10,9 +10,11 @@
   <Import Project="Sdk.props" Sdk="RoslynTools.RepoToolset" />
 
   <PropertyGroup>
-    <TestTargetFrameworks>net46;netcoreapp1.1</TestTargetFrameworks>
+    <TestTargetFrameworks>net46;netcoreapp1.1;netcoreapp2.0</TestTargetFrameworks>
     <!-- Uncomment the following line to test on .NET Core 1.1 -->
     <!--<TestTargetFrameworks>netcoreapp1.1;$(TestTargetFrameworks)</TestTargetFrameworks>-->
+    <!-- Uncomment the following line to test on .NET Core 2.0 -->
+    <!--<TestTargetFrameworks>netcoreapp2.0;$(TestTargetFrameworks)</TestTargetFrameworks>-->
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Utilities/Microsoft.CodeAnalysis.Testing.Utilities.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Utilities/Microsoft.CodeAnalysis.Testing.Utilities.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests.vbproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.UnitTests.vbproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests.vbproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.UnitTests.vbproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests.vbproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.UnitTests.vbproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests.vbproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.UnitTests.vbproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
* Run unit tests on .NET Core 1.1 and .NET Core 2.0
* Fix assembly location failures in `MetadataReferences`
* Fix batch fixer failure when the .NET Standard test assemblies are used