### PR TITLE
Rename AnalyzerTest.cs to match the first type name

### DIFF
--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -15,7 +15,7 @@ using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.CodeAnalysis.Testing
 {
-    public abstract partial class AnalyzerTest<TVerifier>
+    public abstract class AnalyzerTest<TVerifier>
         where TVerifier : IVerifier, new()
     {
         private static readonly Lazy<IExportProviderFactory> ExportProviderFactory;


### PR DESCRIPTION
The use of a `partial class` left this file inconsistent with all the others.