### PR TITLE
Fix SolutionExplorer sample so that it can launch again

### DIFF
--- a/samples/CSharp/SolutionExplorer/SolutionExplorer.csproj
+++ b/samples/CSharp/SolutionExplorer/SolutionExplorer.csproj
@@ -11,8 +11,6 @@
     <Description></Description>
     <Copyright>Copyright ©  2017</Copyright>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>


### PR DESCRIPTION
When building, the assembly version gets set to 42.42.42.42. However, the project file contains elements to set the version to 1.0.0.0. This causes a mismatch with what the XAML compiler produces. When the project contains 1.0.0.0, the App.InitializeComponent tries to load resources using "/SolutionExplorer;V1.0.0.0;component/app.xaml" as the URI. This causes the application to fail immediately when launched because the actual version number of the assembly is 42.42.42.42. Removing the elements from the project file fixes the issue and the XAML compiler produces code that loads resources using "/SolutionExplorer;component/app.xaml".