### PR TITLE
Automatically apply MarkupHandling and InheritanceMode

### DIFF
--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Testing
 
         protected AnalyzerTest()
         {
-            TestState = new SolutionState(DefaultFilePathPrefix, DefaultFileExt, MarkupMode.Allow) { InheritanceMode = StateInheritanceMode.Explicit };
+            TestState = new SolutionState(DefaultFilePathPrefix, DefaultFileExt);
         }
 
         /// <summary>

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -83,11 +83,11 @@ Microsoft.CodeAnalysis.Testing.SolutionState.AdditionalFiles.get -> Microsoft.Co
 Microsoft.CodeAnalysis.Testing.SolutionState.AdditionalFilesFactories.get -> System.Collections.Generic.List<System.Func<System.Collections.Generic.IEnumerable<(string filename, Microsoft.CodeAnalysis.Text.SourceText content)>>>
 Microsoft.CodeAnalysis.Testing.SolutionState.AdditionalReferences.get -> Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection
 Microsoft.CodeAnalysis.Testing.SolutionState.ExpectedDiagnostics.get -> System.Collections.Generic.List<Microsoft.CodeAnalysis.Testing.DiagnosticResult>
-Microsoft.CodeAnalysis.Testing.SolutionState.InheritanceMode.get -> Microsoft.CodeAnalysis.Testing.StateInheritanceMode
+Microsoft.CodeAnalysis.Testing.SolutionState.InheritanceMode.get -> Microsoft.CodeAnalysis.Testing.StateInheritanceMode?
 Microsoft.CodeAnalysis.Testing.SolutionState.InheritanceMode.set -> void
-Microsoft.CodeAnalysis.Testing.SolutionState.MarkupHandling.get -> Microsoft.CodeAnalysis.Testing.MarkupMode
+Microsoft.CodeAnalysis.Testing.SolutionState.MarkupHandling.get -> Microsoft.CodeAnalysis.Testing.MarkupMode?
 Microsoft.CodeAnalysis.Testing.SolutionState.MarkupHandling.set -> void
-Microsoft.CodeAnalysis.Testing.SolutionState.SolutionState(string defaultPrefix, string defaultExtension, Microsoft.CodeAnalysis.Testing.MarkupMode markupMode) -> void
+Microsoft.CodeAnalysis.Testing.SolutionState.SolutionState(string defaultPrefix, string defaultExtension) -> void
 Microsoft.CodeAnalysis.Testing.SolutionState.Sources.get -> Microsoft.CodeAnalysis.Testing.SourceFileList
 Microsoft.CodeAnalysis.Testing.SolutionState.WithInheritedValuesApplied(Microsoft.CodeAnalysis.Testing.SolutionState baseState, System.Collections.Immutable.ImmutableArray<string> fixableDiagnostics) -> Microsoft.CodeAnalysis.Testing.SolutionState
 Microsoft.CodeAnalysis.Testing.SolutionState.WithProcessedMarkup(Microsoft.CodeAnalysis.DiagnosticDescriptor defaultDiagnostic, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> supportedDiagnostics, System.Collections.Immutable.ImmutableArray<string> fixableDiagnostics, string defaultPath) -> Microsoft.CodeAnalysis.Testing.SolutionState

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
@@ -152,8 +152,8 @@ namespace Microsoft.CodeAnalysis.Testing
 
         protected CodeFixTest()
         {
-            FixedState = new SolutionState(DefaultFilePathPrefix, DefaultFileExt, MarkupMode.IgnoreFixable) { InheritanceMode = StateInheritanceMode.AutoInherit };
-            BatchFixedState = new SolutionState(DefaultFilePathPrefix, DefaultFileExt, MarkupMode.IgnoreFixable) { InheritanceMode = StateInheritanceMode.AutoInherit };
+            FixedState = new SolutionState(DefaultFilePathPrefix, DefaultFileExt);
+            BatchFixedState = new SolutionState(DefaultFilePathPrefix, DefaultFileExt);
         }
 
         /// <summary>
@@ -201,8 +201,8 @@ namespace Microsoft.CodeAnalysis.Testing
 
         private static bool CodeFixExpected(SolutionState state)
         {
-            return state.InheritanceMode != StateInheritanceMode.AutoInherit
-                || state.MarkupHandling != MarkupMode.IgnoreFixable
+            return state.InheritanceMode != null
+                || state.MarkupHandling != null
                 || state.Sources.Any()
                 || state.AdditionalFiles.Any()
                 || state.AdditionalFilesFactories.Any();

--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixVerifier`4.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixVerifier`4.cs
@@ -39,14 +39,6 @@ namespace Microsoft.CodeAnalysis.Testing
                 FixedCode = fixedSource,
             };
 
-            if (fixedSource == source)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
             test.ExpectedDiagnostics.AddRange(expected);
             return test.RunAsync(CancellationToken.None);
         }

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerTestTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerTestTests.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.Testing
         public void TestDefaults()
         {
             var test = new CSharpTest();
-            Assert.Equal(StateInheritanceMode.Explicit, test.TestState.InheritanceMode);
-            Assert.Equal(MarkupMode.Allow, test.TestState.MarkupHandling);
+            Assert.Null(test.TestState.InheritanceMode);
+            Assert.Null(test.TestState.MarkupHandling);
             Assert.Empty(test.TestState.Sources);
             Assert.Empty(test.TestState.AdditionalFiles);
             Assert.Empty(test.TestState.AdditionalFilesFactories);


### PR DESCRIPTION
This change eliminates the need for consumers to copy this block when creating their own code fix test extensions:

https://github.com/dotnet/roslyn-sdk/blob/8e52673d3e6ca938bf674bba4fd110a734331331/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixVerifier%604.cs#L42-L48 

This requirement had a fairly substantial impact on https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/2870, even though we weren't testing this scenario in most cases.