### PR TITLE
Make SolutionState.ContentEqual handles encoding changes

### DIFF
--- a/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
+++ b/src/Tools/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
@@ -214,6 +214,11 @@ namespace Microsoft.CodeAnalysis.Testing
                     return false;
                 }
 
+                if (!Equals(x[i].content.Encoding, y[i].content.Encoding))
+                {
+                    return false;
+                }
+
                 if (!x[i].content.ContentEquals(y[i].content))
                 {
                     return false;


### PR DESCRIPTION
Fixes a bug that occurs when testing a code fix that only changes the encoding of source files.

Indirectly related to https://github.com/dotnet/roslyn/issues/4767