### PR TITLE
Include a fallback ordering by diagnostic message

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -698,7 +698,9 @@ namespace Microsoft.CodeAnalysis.Testing
                 .OrderBy(d => d.Location.GetLineSpan().Path, StringComparer.Ordinal)
                 .ThenBy(d => d.Location.SourceSpan.Start)
                 .ThenBy(d => d.Location.SourceSpan.End)
-                .ThenBy(d => d.Id).ToArray();
+                .ThenBy(d => d.Id)
+                .ThenBy(d => d.GetMessage(), StringComparer.Ordinal)
+                .ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
This change improves deterministic test behavior for diagnostics reported with the same ID and location.

See dotnet/roslyn-analyzers#2292