### PR TITLE
Revert "Include a fallback ordering by diagnostic message"

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -698,9 +698,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 .OrderBy(d => d.Location.GetLineSpan().Path, StringComparer.Ordinal)
                 .ThenBy(d => d.Location.SourceSpan.Start)
                 .ThenBy(d => d.Location.SourceSpan.End)
-                .ThenBy(d => d.Id)
-                .ThenBy(d => d.GetMessage(), StringComparer.Ordinal)
-                .ToArray();
+                .ThenBy(d => d.Id).ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
Reverts dotnet/roslyn-sdk#300

This didn't address the non-determinism in the intended tests, and produced a large amount of churn when attempting to upgrade StyleCop Analyzers' tests. I need to rethink the approach.