### PR TITLE
Markup options

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,6 +51,7 @@
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
     <!-- Testing -->
     <MicrosoftCodeAnalysisPrimaryTestVersion>2.6.1</MicrosoftCodeAnalysisPrimaryTestVersion>
+    <XunitCombinatorialVersion>1.2.7</XunitCombinatorialVersion>
     <!-- Analyzers -->
     <RoslynDiagnosticsAnalyzersVersion>2.6.2-beta2</RoslynDiagnosticsAnalyzersVersion>
     <StyleCopAnalyzersVersion>1.1.0-beta008</StyleCopAnalyzersVersion>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -282,16 +282,19 @@ namespace Microsoft.CodeAnalysis.Testing
                 else
                 {
                     VerifyDiagnosticLocation(analyzers, actual, actual.Location, expected.Spans[0], verifier);
-                    var additionalLocations = actual.AdditionalLocations.ToArray();
-
-                    verifier.Equal(
-                        expected.Spans.Length - 1,
-                        additionalLocations.Length,
-                        $"Expected {expected.Spans.Length - 1} additional locations but got {additionalLocations.Length} for Diagnostic:\r\n    {FormatDiagnostics(analyzers, actual)}\r\n");
-
-                    for (var j = 0; j < additionalLocations.Length; ++j)
+                    if (!expected.Spans[0].Options.HasFlag(DiagnosticLocationOptions.IgnoreAdditionalLocations))
                     {
-                        VerifyDiagnosticLocation(analyzers, actual, additionalLocations[j], expected.Spans[j + 1], verifier);
+                        var additionalLocations = actual.AdditionalLocations.ToArray();
+
+                        verifier.Equal(
+                            expected.Spans.Length - 1,
+                            additionalLocations.Length,
+                            $"Expected {expected.Spans.Length - 1} additional locations but got {additionalLocations.Length} for Diagnostic:\r\n    {FormatDiagnostics(analyzers, actual)}\r\n");
+
+                        for (var j = 0; j < additionalLocations.Length; ++j)
+                        {
+                            VerifyDiagnosticLocation(analyzers, actual, additionalLocations[j], expected.Spans[j + 1], verifier);
+                        }
                     }
                 }
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <summary>
         /// Gets the default diagnostic to use during markup processing. By default, the <em>single</em> diagnostic of
         /// the first analyzer is used, and no default diagonostic is available if multiple diagnostics are provided by
-        /// the analyzer. If <see cref="MarkupOptions.PreferFirstDescriptor"/> is used, the first available diagnostic
+        /// the analyzer. If <see cref="MarkupOptions.UseFirstDescriptor"/> is used, the first available diagnostic
         /// is used.
         /// </summary>
         /// <param name="analyzers">The analyzers to consider.</param>
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 return null;
             }
 
-            if (MarkupOptions.HasFlag(MarkupOptions.PreferFirstDescriptor))
+            if (MarkupOptions.HasFlag(MarkupOptions.UseFirstDescriptor))
             {
                 foreach (var analyzer in analyzers)
                 {

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -86,6 +86,12 @@ namespace Microsoft.CodeAnalysis.Testing
         /// </summary>
         public CompilerDiagnostics CompilerDiagnostics { get; set; } = CompilerDiagnostics.Errors;
 
+        /// <summary>
+        /// Gets or sets options for the markup processor when markup is used for diagnostics. The default value is
+        /// <see cref="MarkupOptions.None"/>.
+        /// </summary>
+        public MarkupOptions MarkupOptions { get; set; }
+
         public SolutionState TestState { get; }
 
         /// <summary>
@@ -125,12 +131,49 @@ namespace Microsoft.CodeAnalysis.Testing
             Verify.NotEmpty($"{nameof(TestState)}.{nameof(SolutionState.Sources)}", TestState.Sources);
 
             var analyzers = GetDiagnosticAnalyzers().ToArray();
-            var defaultDiagnostic = analyzers.Length > 0 && analyzers[0].SupportedDiagnostics.Length == 1 ? analyzers[0].SupportedDiagnostics[0] : null;
+            var defaultDiagnostic = GetDefaultDiagnostic(analyzers);
             var supportedDiagnostics = analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics).ToImmutableArray();
             var fixableDiagnostics = ImmutableArray<string>.Empty;
-            var testState = TestState.WithInheritedValuesApplied(null, fixableDiagnostics).WithProcessedMarkup(defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
+            var testState = TestState.WithInheritedValuesApplied(null, fixableDiagnostics).WithProcessedMarkup(MarkupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
 
             await VerifyDiagnosticsAsync(testState.Sources.ToArray(), testState.AdditionalFiles.ToArray(), testState.AdditionalReferences.ToArray(), testState.ExpectedDiagnostics.ToArray(), Verify, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the default diagnostic to use during markup processing. By default, the <em>single</em> diagnostic of
+        /// the first analyzer is used, and no default diagonostic is available if multiple diagnostics are provided by
+        /// the analyzer. If <see cref="MarkupOptions.PreferFirstDescriptor"/> is used, the first available diagnostic
+        /// is used.
+        /// </summary>
+        /// <param name="analyzers">The analyzers to consider.</param>
+        /// <returns>The default diagnostic to use during markup processing.</returns>
+        protected internal virtual DiagnosticDescriptor GetDefaultDiagnostic(DiagnosticAnalyzer[] analyzers)
+        {
+            if (analyzers.Length == 0)
+            {
+                return null;
+            }
+
+            if (MarkupOptions.HasFlag(MarkupOptions.PreferFirstDescriptor))
+            {
+                foreach (var analyzer in analyzers)
+                {
+                    if (analyzer.SupportedDiagnostics.Any())
+                    {
+                        return analyzer.SupportedDiagnostics[0];
+                    }
+                }
+
+                return null;
+            }
+            else if (analyzers[0].SupportedDiagnostics.Length == 1)
+            {
+                return analyzers[0].SupportedDiagnostics[0];
+            }
+            else
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticLocationOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticLocationOptions.cs
@@ -17,5 +17,11 @@ namespace Microsoft.CodeAnalysis.Testing
         /// should be ignored when comparing results.
         /// </summary>
         IgnoreLength = 1,
+
+        /// <summary>
+        /// The primary diagnostic location is defined, but additional locations have not been provided. Disables
+        /// validation of additional locations reported for the corresponding diagnostics.
+        /// </summary>
+        IgnoreAdditionalLocations = 2,
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -167,6 +167,9 @@ namespace Microsoft.CodeAnalysis.Testing
         public DiagnosticResult WithLocation(string path, LinePosition location)
             => AppendSpan(new FileLinePositionSpan(path, location, location), DiagnosticLocationOptions.IgnoreLength);
 
+        public DiagnosticResult WithLocation(string path, LinePosition location, DiagnosticLocationOptions options)
+            => AppendSpan(new FileLinePositionSpan(path, location, location), options | DiagnosticLocationOptions.IgnoreLength);
+
         public DiagnosticResult WithSpan(int startLine, int startColumn, int endLine, int endColumn)
             => WithSpan(path: string.Empty, startLine, startColumn, endLine, endColumn);
 
@@ -175,6 +178,9 @@ namespace Microsoft.CodeAnalysis.Testing
 
         public DiagnosticResult WithSpan(FileLinePositionSpan span)
             => AppendSpan(span, DiagnosticLocationOptions.None);
+
+        public DiagnosticResult WithSpan(FileLinePositionSpan span, DiagnosticLocationOptions options)
+            => AppendSpan(span, options);
 
         public DiagnosticResult WithDefaultPath(string path)
         {

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MarkupOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MarkupOptions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    /// <summary>
+    /// Specifies additional options for the markup parser.
+    /// </summary>
+    [Flags]
+    public enum MarkupOptions
+    {
+        /// <summary>
+        /// No additional markup options are specified.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Use the first matching diagnostic descriptor when multiple diagnostics match the syntax. By default, this
+        /// option is not specified and the markup parser will fail when the syntax does not represent a <em>unique</em>
+        /// descriptor.
+        /// </summary>
+        PreferFirstDescriptor = 0x0001,
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MarkupOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MarkupOptions.cs
@@ -20,6 +20,6 @@ namespace Microsoft.CodeAnalysis.Testing
         /// option is not specified and the markup parser will fail when the syntax does not represent a <em>unique</em>
         /// descriptor.
         /// </summary>
-        PreferFirstDescriptor = 0x0001,
+        UseFirstDescriptor = 0x0001,
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -33,6 +33,7 @@ Microsoft.CodeAnalysis.Testing.DiagnosticLocation.DiagnosticLocation(Microsoft.C
 Microsoft.CodeAnalysis.Testing.DiagnosticLocation.Options.get -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticLocation.Span.get -> Microsoft.CodeAnalysis.FileLinePositionSpan
 Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
+Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions.IgnoreAdditionalLocations = 2 -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions.IgnoreLength = 1 -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions.None = 0 -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticResult
@@ -51,12 +52,14 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLineOffset(int offset) -> Mi
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(Microsoft.CodeAnalysis.Text.LinePosition location) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(int line, int column) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(string path, Microsoft.CodeAnalysis.Text.LinePosition location) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
+Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(string path, Microsoft.CodeAnalysis.Text.LinePosition location, Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions options) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(string path, int line, int column) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithMessage(string message) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithMessageFormat(Microsoft.CodeAnalysis.LocalizableString messageFormat) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithNoLocation() -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity severity) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(Microsoft.CodeAnalysis.FileLinePositionSpan span) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
+Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(Microsoft.CodeAnalysis.FileLinePositionSpan span, Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions options) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(int startLine, int startColumn, int endLine, int endColumn) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(string path, int startLine, int startColumn, int endLine, int endColumn) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -82,7 +82,7 @@ Microsoft.CodeAnalysis.Testing.MarkupMode.IgnoreFixable = 2 -> Microsoft.CodeAna
 Microsoft.CodeAnalysis.Testing.MarkupMode.None = 0 -> Microsoft.CodeAnalysis.Testing.MarkupMode
 Microsoft.CodeAnalysis.Testing.MarkupOptions
 Microsoft.CodeAnalysis.Testing.MarkupOptions.None = 0 -> Microsoft.CodeAnalysis.Testing.MarkupOptions
-Microsoft.CodeAnalysis.Testing.MarkupOptions.PreferFirstDescriptor = 1 -> Microsoft.CodeAnalysis.Testing.MarkupOptions
+Microsoft.CodeAnalysis.Testing.MarkupOptions.UseFirstDescriptor = 1 -> Microsoft.CodeAnalysis.Testing.MarkupOptions
 Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection
 Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection.Add(System.Reflection.Assembly assembly) -> void
 Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection.Add(string path) -> void

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -6,6 +6,8 @@ Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.CreateProject((string fil
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DisabledDiagnostics.get -> System.Collections.Generic.List<string>
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.ExpectedDiagnostics.get -> System.Collections.Generic.List<Microsoft.CodeAnalysis.Testing.DiagnosticResult>
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.GetSortedDiagnosticsAsync(Microsoft.CodeAnalysis.Solution solution, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers, Microsoft.CodeAnalysis.Testing.CompilerDiagnostics compilerDiagnostics, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>>
+Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.MarkupOptions.get -> Microsoft.CodeAnalysis.Testing.MarkupOptions
+Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.MarkupOptions.set -> void
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.OptionsTransforms.get -> System.Collections.Generic.List<System.Func<Microsoft.CodeAnalysis.Options.OptionSet, Microsoft.CodeAnalysis.Options.OptionSet>>
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.SolutionTransforms.get -> System.Collections.Generic.List<System.Func<Microsoft.CodeAnalysis.Solution, Microsoft.CodeAnalysis.ProjectId, Microsoft.CodeAnalysis.Solution>>
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.TestBehaviors.get -> Microsoft.CodeAnalysis.Testing.TestBehaviors
@@ -75,6 +77,9 @@ Microsoft.CodeAnalysis.Testing.MarkupMode.Allow = 3 -> Microsoft.CodeAnalysis.Te
 Microsoft.CodeAnalysis.Testing.MarkupMode.Ignore = 1 -> Microsoft.CodeAnalysis.Testing.MarkupMode
 Microsoft.CodeAnalysis.Testing.MarkupMode.IgnoreFixable = 2 -> Microsoft.CodeAnalysis.Testing.MarkupMode
 Microsoft.CodeAnalysis.Testing.MarkupMode.None = 0 -> Microsoft.CodeAnalysis.Testing.MarkupMode
+Microsoft.CodeAnalysis.Testing.MarkupOptions
+Microsoft.CodeAnalysis.Testing.MarkupOptions.None = 0 -> Microsoft.CodeAnalysis.Testing.MarkupOptions
+Microsoft.CodeAnalysis.Testing.MarkupOptions.PreferFirstDescriptor = 1 -> Microsoft.CodeAnalysis.Testing.MarkupOptions
 Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection
 Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection.Add(System.Reflection.Assembly assembly) -> void
 Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection.Add(string path) -> void
@@ -92,7 +97,7 @@ Microsoft.CodeAnalysis.Testing.SolutionState.MarkupHandling.set -> void
 Microsoft.CodeAnalysis.Testing.SolutionState.SolutionState(string defaultPrefix, string defaultExtension) -> void
 Microsoft.CodeAnalysis.Testing.SolutionState.Sources.get -> Microsoft.CodeAnalysis.Testing.SourceFileList
 Microsoft.CodeAnalysis.Testing.SolutionState.WithInheritedValuesApplied(Microsoft.CodeAnalysis.Testing.SolutionState baseState, System.Collections.Immutable.ImmutableArray<string> fixableDiagnostics) -> Microsoft.CodeAnalysis.Testing.SolutionState
-Microsoft.CodeAnalysis.Testing.SolutionState.WithProcessedMarkup(Microsoft.CodeAnalysis.DiagnosticDescriptor defaultDiagnostic, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> supportedDiagnostics, System.Collections.Immutable.ImmutableArray<string> fixableDiagnostics, string defaultPath) -> Microsoft.CodeAnalysis.Testing.SolutionState
+Microsoft.CodeAnalysis.Testing.SolutionState.WithProcessedMarkup(Microsoft.CodeAnalysis.Testing.MarkupOptions markupOptions, Microsoft.CodeAnalysis.DiagnosticDescriptor defaultDiagnostic, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> supportedDiagnostics, System.Collections.Immutable.ImmutableArray<string> fixableDiagnostics, string defaultPath) -> Microsoft.CodeAnalysis.Testing.SolutionState
 Microsoft.CodeAnalysis.Testing.SourceFileCollection
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((string filename, string content) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.SourceFileCollection() -> void
@@ -154,6 +159,7 @@ virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultFilePath.g
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultFilePathPrefix.get -> string
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultTestProjectName.get -> string
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.GetAnalyzerOptions(Microsoft.CodeAnalysis.Project project) -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
+virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.GetDefaultDiagnostic(Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer[] analyzers) -> Microsoft.CodeAnalysis.DiagnosticDescriptor
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.RunAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 virtual Microsoft.CodeAnalysis.Testing.DefaultVerifier.CreateMessage(string message) -> string
 virtual Microsoft.CodeAnalysis.Testing.DefaultVerifier.Empty<T>(string collectionName, System.Collections.Generic.IEnumerable<T> collection) -> void

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Testing
             {
                 if (defaultDiagnostic is null)
                 {
-                    throw new InvalidOperationException($"Markup syntax can only omit the diagnostic ID if the first analyzer only supports a single diagnostic. To customize the default value, override {nameof(AnalyzerTest<DefaultVerifier>)}<TVerifier>.{nameof(AnalyzerTest<DefaultVerifier>.GetDefaultDiagnostic)} or specify {nameof(MarkupOptions)}.{nameof(MarkupOptions.PreferFirstDescriptor)}.");
+                    throw new InvalidOperationException($"Markup syntax can only omit the diagnostic ID if the first analyzer only supports a single diagnostic. To customize the default value, override {nameof(AnalyzerTest<DefaultVerifier>)}<TVerifier>.{nameof(AnalyzerTest<DefaultVerifier>.GetDefaultDiagnostic)} or specify {nameof(MarkupOptions)}.{nameof(MarkupOptions.UseFirstDescriptor)}.");
                 }
 
                 if (MarkupHandling == MarkupMode.IgnoreFixable && fixableDiagnostics.Contains(defaultDiagnostic.Id))
@@ -410,10 +410,10 @@ namespace Microsoft.CodeAnalysis.Testing
                 var descriptor = descriptors.FirstOrDefault();
                 if (descriptor != null)
                 {
-                    if (!markupOptions.HasFlag(MarkupOptions.PreferFirstDescriptor)
+                    if (!markupOptions.HasFlag(MarkupOptions.UseFirstDescriptor)
                         && descriptors.Skip(1).Any())
                     {
-                        throw new InvalidOperationException($"Multiple diagnostic descriptors with ID {diagnosticId} were found. Use the explicitly diagnostic creation syntax or specify {nameof(MarkupOptions)}.{nameof(MarkupOptions.PreferFirstDescriptor)} to use the first matching diagnostic.");
+                        throw new InvalidOperationException($"Multiple diagnostic descriptors with ID {diagnosticId} were found. Use the explicitly diagnostic creation syntax or specify {nameof(MarkupOptions)}.{nameof(MarkupOptions.UseFirstDescriptor)} to use the first matching diagnostic.");
                     }
 
                     diagnosticResult = new DiagnosticResult(descriptor);

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.Testing
             }
 
             var linePosition = content.Lines.GetLinePosition(position);
-            return diagnosticResult.Value.WithLocation(filename, linePosition);
+            return diagnosticResult.Value.WithLocation(filename, linePosition, DiagnosticLocationOptions.IgnoreAdditionalLocations);
         }
 
         private DiagnosticResult? CreateDiagnosticForSpan(
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.Testing
             }
 
             var linePositionSpan = content.Lines.GetLinePositionSpan(span);
-            return diagnosticResult.Value.WithSpan(new FileLinePositionSpan(filename, linePositionSpan));
+            return diagnosticResult.Value.WithSpan(new FileLinePositionSpan(filename, linePositionSpan), DiagnosticLocationOptions.IgnoreAdditionalLocations);
         }
 
         private DiagnosticResult? CreateDiagnostic(

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
@@ -233,6 +233,7 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <see cref="MarkupHandling"/>, and returns a new <see cref="SolutionState"/> with the <see cref="Sources"/>,
         /// <see cref="AdditionalFiles"/>, and <see cref="ExpectedDiagnostics"/> updated accordingly.
         /// </summary>
+        /// <param name="markupOptions">Additional options to apply during markup processing.</param>
         /// <param name="defaultDiagnostic">The diagnostic descriptor to use for markup spans without an explicit name,
         /// or <see langword="null"/> if no such default exists.</param>
         /// <param name="supportedDiagnostics">The diagnostics supported by analyzers used by the test.</param>
@@ -244,15 +245,15 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <see cref="MarkupMode.None"/>.</returns>
         /// <exception cref="InvalidOperationException">If <see cref="InheritanceMode"/> is not
         /// <see cref="StateInheritanceMode.Explicit"/>.</exception>
-        public SolutionState WithProcessedMarkup(DiagnosticDescriptor defaultDiagnostic, ImmutableArray<DiagnosticDescriptor> supportedDiagnostics, ImmutableArray<string> fixableDiagnostics, string defaultPath)
+        public SolutionState WithProcessedMarkup(MarkupOptions markupOptions, DiagnosticDescriptor defaultDiagnostic, ImmutableArray<DiagnosticDescriptor> supportedDiagnostics, ImmutableArray<string> fixableDiagnostics, string defaultPath)
         {
             if (InheritanceMode != StateInheritanceMode.Explicit)
             {
                 throw new InvalidOperationException("Inheritance processing must complete before markup processing.");
             }
 
-            (var expected, var testSources) = ProcessMarkupSources(Sources, ExpectedDiagnostics, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, defaultPath);
-            var (additionalExpected, additionalFiles) = ProcessMarkupSources(AdditionalFiles.Concat(AdditionalFilesFactories.SelectMany(factory => factory())), expected, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, defaultPath);
+            (var expected, var testSources) = ProcessMarkupSources(Sources, ExpectedDiagnostics, markupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, defaultPath);
+            var (additionalExpected, additionalFiles) = ProcessMarkupSources(AdditionalFiles.Concat(AdditionalFilesFactories.SelectMany(factory => factory())), expected, markupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, defaultPath);
 
             var result = new SolutionState(_defaultPrefix, _defaultExtension);
             result.MarkupHandling = MarkupMode.None;
@@ -267,6 +268,7 @@ namespace Microsoft.CodeAnalysis.Testing
         private (DiagnosticResult[], (string filename, SourceText content)[]) ProcessMarkupSources(
             IEnumerable<(string filename, SourceText content)> sources,
             IEnumerable<DiagnosticResult> explicitDiagnostics,
+            MarkupOptions markupOptions,
             DiagnosticDescriptor defaultDiagnostic,
             ImmutableArray<DiagnosticDescriptor> supportedDiagnostics,
             ImmutableArray<string> fixableDiagnostics,
@@ -303,7 +305,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 var sourceText = SourceText.From(output, content.Encoding, content.ChecksumAlgorithm);
                 foreach (var position in positions)
                 {
-                    var diagnostic = CreateDiagnosticForPosition(defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, string.Empty, filename, sourceText, position);
+                    var diagnostic = CreateDiagnosticForPosition(markupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, string.Empty, filename, sourceText, position);
                     if (!diagnostic.HasValue)
                     {
                         continue;
@@ -316,7 +318,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 {
                     foreach (var span in spans)
                     {
-                        var diagnostic = CreateDiagnosticForSpan(defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, name, filename, sourceText, span);
+                        var diagnostic = CreateDiagnosticForSpan(markupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, name, filename, sourceText, span);
                         if (!diagnostic.HasValue)
                         {
                             continue;
@@ -331,6 +333,7 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         private DiagnosticResult? CreateDiagnosticForPosition(
+            MarkupOptions markupOptions,
             DiagnosticDescriptor defaultDiagnostic,
             ImmutableArray<DiagnosticDescriptor> supportedDiagnostics,
             ImmutableArray<string> fixableDiagnostics,
@@ -339,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Testing
             SourceText content,
             int position)
         {
-            var diagnosticResult = CreateDiagnostic(defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, diagnosticId);
+            var diagnosticResult = CreateDiagnostic(markupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, diagnosticId);
             if (diagnosticResult == null)
             {
                 return null;
@@ -350,6 +353,7 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         private DiagnosticResult? CreateDiagnosticForSpan(
+            MarkupOptions markupOptions,
             DiagnosticDescriptor defaultDiagnostic,
             ImmutableArray<DiagnosticDescriptor> supportedDiagnostics,
             ImmutableArray<string> fixableDiagnostics,
@@ -358,7 +362,7 @@ namespace Microsoft.CodeAnalysis.Testing
             SourceText content,
             TextSpan span)
         {
-            var diagnosticResult = CreateDiagnostic(defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, diagnosticId);
+            var diagnosticResult = CreateDiagnostic(markupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, diagnosticId);
             if (diagnosticResult == null)
             {
                 return null;
@@ -369,6 +373,7 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         private DiagnosticResult? CreateDiagnostic(
+            MarkupOptions markupOptions,
             DiagnosticDescriptor defaultDiagnostic,
             ImmutableArray<DiagnosticDescriptor> supportedDiagnostics,
             ImmutableArray<string> fixableDiagnostics,
@@ -384,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Testing
             {
                 if (defaultDiagnostic is null)
                 {
-                    throw new InvalidOperationException("Markup syntax can only omit the diagnostic ID if the first analyzer only supports a single diagnostic");
+                    throw new InvalidOperationException($"Markup syntax can only omit the diagnostic ID if the first analyzer only supports a single diagnostic. To customize the default value, override {nameof(AnalyzerTest<DefaultVerifier>)}<TVerifier>.{nameof(AnalyzerTest<DefaultVerifier>.GetDefaultDiagnostic)} or specify {nameof(MarkupOptions)}.{nameof(MarkupOptions.PreferFirstDescriptor)}.");
                 }
 
                 if (MarkupHandling == MarkupMode.IgnoreFixable && fixableDiagnostics.Contains(defaultDiagnostic.Id))
@@ -401,9 +406,16 @@ namespace Microsoft.CodeAnalysis.Testing
                     return null;
                 }
 
-                var descriptor = supportedDiagnostics.SingleOrDefault(d => d.Id == diagnosticId);
+                var descriptors = supportedDiagnostics.Where(d => d.Id == diagnosticId);
+                var descriptor = descriptors.FirstOrDefault();
                 if (descriptor != null)
                 {
+                    if (!markupOptions.HasFlag(MarkupOptions.PreferFirstDescriptor)
+                        && descriptors.Skip(1).Any())
+                    {
+                        throw new InvalidOperationException($"Multiple diagnostic descriptors with ID {diagnosticId} were found. Use the explicitly diagnostic creation syntax or specify {nameof(MarkupOptions)}.{nameof(MarkupOptions.PreferFirstDescriptor)} to use the first matching diagnostic.");
+                    }
+
                     diagnosticResult = new DiagnosticResult(descriptor);
                 }
                 else

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Testing
             Verify.NotEmpty($"{nameof(TestState)}.{nameof(SolutionState.Sources)}", TestState.Sources);
 
             var analyzers = GetDiagnosticAnalyzers().ToArray();
-            var defaultDiagnostic = analyzers.Length > 0 && analyzers[0].SupportedDiagnostics.Length == 1 ? analyzers[0].SupportedDiagnostics[0] : null;
+            var defaultDiagnostic = GetDefaultDiagnostic(analyzers);
             var supportedDiagnostics = analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics).ToImmutableArray();
             var fixableDiagnostics = GetCodeFixProviders().SelectMany(provider => provider.FixableDiagnosticIds).ToImmutableArray();
 
@@ -182,9 +182,9 @@ namespace Microsoft.CodeAnalysis.Testing
             var rawFixedState = FixedState.WithInheritedValuesApplied(rawTestState, fixableDiagnostics);
             var rawBatchFixedState = BatchFixedState.WithInheritedValuesApplied(rawFixedState, fixableDiagnostics);
 
-            var testState = rawTestState.WithProcessedMarkup(defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
-            var fixedState = rawFixedState.WithProcessedMarkup(defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
-            var batchFixedState = rawBatchFixedState.WithProcessedMarkup(defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
+            var testState = rawTestState.WithProcessedMarkup(MarkupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
+            var fixedState = rawFixedState.WithProcessedMarkup(MarkupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
+            var batchFixedState = rawBatchFixedState.WithProcessedMarkup(MarkupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
 
             await VerifyDiagnosticsAsync(testState.Sources.ToArray(), testState.AdditionalFiles.ToArray(), testState.AdditionalReferences.ToArray(), testState.ExpectedDiagnostics.ToArray(), Verify.PushContext("Diagnostics of test state"), cancellationToken).ConfigureAwait(false);
 

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MarkupTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MarkupTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -12,9 +13,10 @@ namespace Microsoft.CodeAnalysis.Testing
 {
     public class MarkupTests
     {
-        [Fact]
+        [Theory]
+        [CombinatorialData]
         [WorkItem(189, "https://github.com/dotnet/roslyn-sdk/issues/189")]
-        public async Task TestCSharpMarkupBrace()
+        public async Task TestCSharpMarkupBrace(bool reportAdditionalLocations)
         {
             var testCode = @"
 class TestClass {|Brace:{|}
@@ -22,24 +24,26 @@ class TestClass {|Brace:{|}
 }
 ";
 
-            await new CSharpTest(nestedDiagnostics: false, hiddenDescriptors: false) { TestCode = testCode }.RunAsync();
+            await new CSharpTest(nestedDiagnostics: false, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode }.RunAsync();
         }
 
-        [Fact]
+        [Theory]
+        [CombinatorialData]
         [WorkItem(181, "https://github.com/dotnet/roslyn-sdk/issues/181")]
-        public async Task TestCSharpMarkupSingleBracePosition()
+        public async Task TestCSharpMarkupSingleBracePosition(bool reportAdditionalLocations)
         {
             var testCode = @"
 class TestClass $${
 }
 ";
 
-            await new CSharpTest(nestedDiagnostics: false, hiddenDescriptors: false) { TestCode = testCode }.RunAsync();
+            await new CSharpTest(nestedDiagnostics: false, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode }.RunAsync();
         }
 
-        [Fact]
+        [Theory]
+        [CombinatorialData]
         [WorkItem(181, "https://github.com/dotnet/roslyn-sdk/issues/181")]
-        public async Task TestCSharpMarkupMultipleBracePositions()
+        public async Task TestCSharpMarkupMultipleBracePositions(bool reportAdditionalLocations)
         {
             var testCode = @"
 class TestClass $${
@@ -47,12 +51,13 @@ class TestClass $${
 }
 ";
 
-            await new CSharpTest(nestedDiagnostics: false, hiddenDescriptors: false) { TestCode = testCode }.RunAsync();
+            await new CSharpTest(nestedDiagnostics: false, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode }.RunAsync();
         }
 
-        [Fact]
+        [Theory]
+        [CombinatorialData]
         [WorkItem(189, "https://github.com/dotnet/roslyn-sdk/issues/189")]
-        public async Task TestCSharpNestedMarkupBrace()
+        public async Task TestCSharpNestedMarkupBrace(bool reportAdditionalLocations)
         {
             var testCode = @"
 class TestClass {|BraceOuter:{|Brace:{|}|}
@@ -60,11 +65,12 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 }
 ";
 
-            await new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false) { TestCode = testCode }.RunAsync();
+            await new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode }.RunAsync();
         }
 
-        [Fact]
-        public async Task TestCSharpNestedMarkupBraceUnspecifiedIdWithoutDefault()
+        [Theory]
+        [CombinatorialData]
+        public async Task TestCSharpNestedMarkupBraceUnspecifiedIdWithoutDefault(bool reportAdditionalLocations)
         {
             var testCode = @"
 class TestClass {|BraceOuter:{|Brace:{|}|}
@@ -72,15 +78,16 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 }
 ";
 
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false) { TestCode = testCode }.RunAsync());
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode }.RunAsync());
 
             var expected = "Markup syntax can only omit the diagnostic ID if the first analyzer only supports a single diagnostic. To customize the default value, override AnalyzerTest<TVerifier>.GetDefaultDiagnostic or specify MarkupOptions.PreferFirstDescriptor.";
             Assert.Equal(expected, exception.Message);
         }
 
-        [Fact]
+        [Theory]
+        [CombinatorialData]
         [WorkItem(189, "https://github.com/dotnet/roslyn-sdk/issues/189")]
-        public async Task TestCSharpNestedMarkupBraceMultipleWithoutDefault()
+        public async Task TestCSharpNestedMarkupBraceMultipleWithoutDefault(bool reportAdditionalLocations)
         {
             var testCode = @"
 class TestClass {|BraceOuter:{|Brace:{|}|}
@@ -88,15 +95,16 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 }
 ";
 
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: true) { TestCode = testCode }.RunAsync());
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: true, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode }.RunAsync());
 
             var expected = "Multiple diagnostic descriptors with ID Brace were found. Use the explicitly diagnostic creation syntax or specify MarkupOptions.PreferFirstDescriptor to use the first matching diagnostic.";
             Assert.Equal(expected, exception.Message);
         }
 
-        [Fact]
+        [Theory]
+        [CombinatorialData]
         [WorkItem(189, "https://github.com/dotnet/roslyn-sdk/issues/189")]
-        public async Task TestCSharpNestedMarkupBraceWithDefault()
+        public async Task TestCSharpNestedMarkupBraceWithDefault(bool reportAdditionalLocations)
         {
             var testCode = @"
 class TestClass {|BraceOuter:{|Brace:{|}|}
@@ -104,7 +112,7 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 }
 ";
 
-            await new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false) { TestCode = testCode, MarkupOptions = MarkupOptions.PreferFirstDescriptor }.RunAsync();
+            await new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode, MarkupOptions = MarkupOptions.PreferFirstDescriptor }.RunAsync();
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -124,11 +132,13 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 
             private readonly bool _nestedDiagnostics;
             private readonly bool _hiddenDescriptors;
+            private readonly bool _reportAdditionalLocations;
 
-            public HighlightBracesAnalyzer(bool nestedDiagnostics, bool hiddenDescriptors)
+            public HighlightBracesAnalyzer(bool nestedDiagnostics, bool hiddenDescriptors, bool reportAdditionalLocations)
             {
                 _nestedDiagnostics = nestedDiagnostics;
                 _hiddenDescriptors = hiddenDescriptors;
+                _reportAdditionalLocations = reportAdditionalLocations;
             }
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
@@ -171,12 +181,20 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
                         continue;
                     }
 
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation()));
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), additionalLocations: GetAdditionalLocations(token)));
 
                     if (_nestedDiagnostics)
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(DescriptorOuter, token.GetLocation()));
+                        context.ReportDiagnostic(Diagnostic.Create(DescriptorOuter, token.GetLocation(), additionalLocations: GetAdditionalLocations(token)));
                     }
+                }
+            }
+
+            private IEnumerable<Location> GetAdditionalLocations(SyntaxToken token)
+            {
+                if (_reportAdditionalLocations)
+                {
+                    yield return token.Parent.ChildTokens().Single(t => t.IsKind(SyntaxKind.CloseBraceToken)).GetLocation();
                 }
             }
         }
@@ -185,11 +203,13 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
         {
             private readonly bool _nestedDiagnostics;
             private readonly bool _hiddenDescriptors;
+            private readonly bool _reportAdditionalLocations;
 
-            public CSharpTest(bool nestedDiagnostics, bool hiddenDescriptors)
+            public CSharpTest(bool nestedDiagnostics, bool hiddenDescriptors, bool reportAdditionalLocations)
             {
                 _nestedDiagnostics = nestedDiagnostics;
                 _hiddenDescriptors = hiddenDescriptors;
+                _reportAdditionalLocations = reportAdditionalLocations;
             }
 
             public override string Language => LanguageNames.CSharp;
@@ -201,7 +221,7 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 
             protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()
             {
-                yield return new HighlightBracesAnalyzer(_nestedDiagnostics, _hiddenDescriptors);
+                yield return new HighlightBracesAnalyzer(_nestedDiagnostics, _hiddenDescriptors, _reportAdditionalLocations);
             }
         }
     }

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MarkupTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MarkupTests.cs
@@ -80,7 +80,7 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode }.RunAsync());
 
-            var expected = "Markup syntax can only omit the diagnostic ID if the first analyzer only supports a single diagnostic. To customize the default value, override AnalyzerTest<TVerifier>.GetDefaultDiagnostic or specify MarkupOptions.PreferFirstDescriptor.";
+            var expected = "Markup syntax can only omit the diagnostic ID if the first analyzer only supports a single diagnostic. To customize the default value, override AnalyzerTest<TVerifier>.GetDefaultDiagnostic or specify MarkupOptions.UseFirstDescriptor.";
             Assert.Equal(expected, exception.Message);
         }
 
@@ -97,7 +97,7 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: true, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode }.RunAsync());
 
-            var expected = "Multiple diagnostic descriptors with ID Brace were found. Use the explicitly diagnostic creation syntax or specify MarkupOptions.PreferFirstDescriptor to use the first matching diagnostic.";
+            var expected = "Multiple diagnostic descriptors with ID Brace were found. Use the explicitly diagnostic creation syntax or specify MarkupOptions.UseFirstDescriptor to use the first matching diagnostic.";
             Assert.Equal(expected, exception.Message);
         }
 
@@ -112,7 +112,7 @@ class TestClass {|BraceOuter:{|Brace:{|}|}
 }
 ";
 
-            await new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode, MarkupOptions = MarkupOptions.PreferFirstDescriptor }.RunAsync();
+            await new CSharpTest(nestedDiagnostics: true, hiddenDescriptors: false, reportAdditionalLocations: reportAdditionalLocations) { TestCode = testCode, MarkupOptions = MarkupOptions.UseFirstDescriptor }.RunAsync();
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Utilities/Microsoft.CodeAnalysis.Testing.Utilities.csproj
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Utilities/Microsoft.CodeAnalysis.Testing.Utilities.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisPrimaryTestVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisPrimaryTestVersion)" />
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Add MarkupOptions, and allow option ~~PreferFirstDescriptor~~ UseFirstDescriptor
* Implement DiagnosticLocationOptions.IgnoreAdditionalLocations

IgnoreAdditionalLocations was implemented based on experiences with dotnet/roslyn-analyzers#2400. The introduction of an additional location meant markup could no longer be used for code fix testing.

~~PreferFirstDescriptor~~ UseFirstDescriptor was implemented as an aid to testing code style analyzers in Roslyn, which declare support for multiple diagnostics but nearly always just use the first descriptor.