### PR TITLE
Avoid trying to load Microsoft.VisualBasic when not necessary

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MetadataReferences.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/MetadataReferences.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 
 #if NETSTANDARD1_5
@@ -22,11 +23,12 @@ namespace Microsoft.CodeAnalysis.Testing
         public static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).GetTypeInfo().Assembly.Location);
         public static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).GetTypeInfo().Assembly.Location);
         public static readonly MetadataReference SystemCollectionsImmutableReference = MetadataReference.CreateFromFile(typeof(ImmutableArray).GetTypeInfo().Assembly.Location);
-        public static readonly MetadataReference MicrosoftVisualBasicReference = MetadataReference.CreateFromFile(typeof(Microsoft.VisualBasic.Strings).GetTypeInfo().Assembly.Location);
 
         internal static readonly MetadataReference? MscorlibFacadeReference;
         internal static readonly MetadataReference? SystemRuntimeReference;
         internal static readonly MetadataReference? SystemValueTupleReference;
+
+        private static MetadataReference? _microsoftVisualBasicReference;
 
         static MetadataReferences()
         {
@@ -67,6 +69,27 @@ namespace Microsoft.CodeAnalysis.Testing
 #else
 #error Unsupported target framework.
 #endif
+        }
+
+        public static MetadataReference MicrosoftVisualBasicReference
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get
+            {
+                if (_microsoftVisualBasicReference is null)
+                {
+                    try
+                    {
+                        _microsoftVisualBasicReference = MetadataReference.CreateFromFile(typeof(Microsoft.VisualBasic.Strings).GetTypeInfo().Assembly.Location);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new PlatformNotSupportedException("Microsoft.VisualBasic is not supported on this platform", e);
+                    }
+                }
+
+                return _microsoftVisualBasicReference;
+            }
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -140,6 +140,7 @@ static Microsoft.CodeAnalysis.Testing.AnalyzerVerifier<TAnalyzer, TTest, TVerifi
 static Microsoft.CodeAnalysis.Testing.DiagnosticResult.CompilerError(string identifier) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 static Microsoft.CodeAnalysis.Testing.DiagnosticResult.CompilerWarning(string identifier) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 static Microsoft.CodeAnalysis.Testing.IVerifierExtensions.EqualOrDiff(this Microsoft.CodeAnalysis.Testing.IVerifier verifier, string expected, string actual, string message = null) -> void
+static Microsoft.CodeAnalysis.Testing.MetadataReferences.MicrosoftVisualBasicReference.get -> Microsoft.CodeAnalysis.MetadataReference
 static Microsoft.CodeAnalysis.Testing.TestFileMarkupParser.CreateTestFile(string code, System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<Microsoft.CodeAnalysis.Text.TextSpan>> spans, int? cursor) -> string
 static Microsoft.CodeAnalysis.Testing.TestFileMarkupParser.CreateTestFile(string code, System.Collections.Generic.IList<Microsoft.CodeAnalysis.Text.TextSpan> spans, int? cursor) -> string
 static Microsoft.CodeAnalysis.Testing.TestFileMarkupParser.CreateTestFile(string code, int cursor) -> string
@@ -158,7 +159,6 @@ static Microsoft.CodeAnalysis.Testing.TestFileMarkupParser.GetSpans(string input
 static readonly Microsoft.CodeAnalysis.Testing.DiagnosticResult.EmptyDiagnosticResults -> Microsoft.CodeAnalysis.Testing.DiagnosticResult[]
 static readonly Microsoft.CodeAnalysis.Testing.MetadataReferences.CodeAnalysisReference -> Microsoft.CodeAnalysis.MetadataReference
 static readonly Microsoft.CodeAnalysis.Testing.MetadataReferences.CorlibReference -> Microsoft.CodeAnalysis.MetadataReference
-static readonly Microsoft.CodeAnalysis.Testing.MetadataReferences.MicrosoftVisualBasicReference -> Microsoft.CodeAnalysis.MetadataReference
 static readonly Microsoft.CodeAnalysis.Testing.MetadataReferences.SystemCollectionsImmutableReference -> Microsoft.CodeAnalysis.MetadataReference
 static readonly Microsoft.CodeAnalysis.Testing.MetadataReferences.SystemCoreReference -> Microsoft.CodeAnalysis.MetadataReference
 static readonly Microsoft.CodeAnalysis.Testing.MetadataReferences.SystemReference -> Microsoft.CodeAnalysis.MetadataReference


### PR DESCRIPTION
This change allows analyzer tests for C# to run on Mono.

See #237
See mono/mono#10679