### PR TITLE
Add exception handler in DiagnosticResult.Message

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -76,7 +76,14 @@ namespace Microsoft.CodeAnalysis.Testing
 
                 if (MessageFormat != null)
                 {
-                    return string.Format(MessageFormat.ToString(), MessageArguments ?? EmptyArguments);
+                    try
+                    {
+                        return string.Format(MessageFormat.ToString(), MessageArguments ?? EmptyArguments);
+                    }
+                    catch (FormatException)
+                    {
+                        return MessageFormat.ToString();
+                    }
                 }
 
                 return null;

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -280,19 +280,10 @@ namespace Microsoft.CodeAnalysis.Testing
             builder.Append(" ");
             builder.Append(Id);
 
-            try
+            var message = Message;
+            if (message != null)
             {
-                var message = Message;
-                if (message != null)
-                {
-                    builder.Append(": ").Append(message);
-                }
-            }
-            catch (FormatException)
-            {
-                // A message format is provided without arguments, so we print the unformatted string
-                Debug.Assert(MessageFormat != null, $"Assertion failed: {nameof(MessageFormat)} != null");
-                builder.Append(": ").Append(MessageFormat);
+                builder.Append(": ").Append(message);
             }
 
             return builder.ToString();


### PR DESCRIPTION
To be consistent with `DiagnosticResult.ToString`, `Diagnostic.GetMessage` and `LocalizableResourceString.GetText` when format arguments are not provided.