### PR TITLE
Update Versions.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <!-- This repo version -->
     <VersionPrefix>3.2.0</VersionPrefix>
-    <NugetPackagePrefix>1.0.0</NugetPackagePrefix>
+    <NugetPackagePrefix>1.0.1</NugetPackagePrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
     <!-- Opt-in repo features -->
     <UsingToolVSSDK>true</UsingToolVSSDK>


### PR DESCRIPTION
Assuming this will fix the issue where our newer packages are not actually considered to be a higher version by NuGet. Follow up on https://github.com/dotnet/roslyn-sdk/pull/395#issuecomment-540862477

/cc @sharwell, @JoeRobich.