### PR TITLE
Avoid directly exposing NuGet APIs

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="NuGet.Common" Version="$(NuGetApiVersion)" PrivateAssets="compile" />
     <PackageReference Include="NuGet.Protocol" Version="$(NuGetApiVersion)" PrivateAssets="compile" />
     <PackageReference Include="NuGet.Resolver" Version="$(NuGetApiVersion)" PrivateAssets="compile" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetApiVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetApiVersion)" PrivateAssets="compile" />
 
     <!-- Use PrivateAssets=compile to avoid exposing our DiffPlex dependency downstream as public API. -->
     <PackageReference Include="DiffPlex" Version="1.4.4" PrivateAssets="compile" />

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PackageIdentity.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PackageIdentity.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using NuGet.Versioning;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    public sealed class PackageIdentity
+    {
+        public PackageIdentity(string id, string version)
+        {
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+        }
+
+        public string Id { get; }
+
+        public string Version { get; }
+
+        internal NuGet.Packaging.Core.PackageIdentity ToNuGetIdentity()
+        {
+            return new NuGet.Packaging.Core.PackageIdentity(Id, NuGetVersion.Parse(Version));
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -90,6 +90,10 @@ Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection.Add(System.Reflection
 Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection.Add(string path) -> void
 Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection.MetadataReferenceCollection() -> void
 Microsoft.CodeAnalysis.Testing.MetadataReferences
+Microsoft.CodeAnalysis.Testing.PackageIdentity
+Microsoft.CodeAnalysis.Testing.PackageIdentity.Id.get -> string
+Microsoft.CodeAnalysis.Testing.PackageIdentity.PackageIdentity(string id, string version) -> void
+Microsoft.CodeAnalysis.Testing.PackageIdentity.Version.get -> string
 Microsoft.CodeAnalysis.Testing.ProjectState
 Microsoft.CodeAnalysis.Testing.ProjectState.AdditionalReferences.get -> Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection
 Microsoft.CodeAnalysis.Testing.ProjectState.AssemblyName.get -> string
@@ -99,7 +103,7 @@ Microsoft.CodeAnalysis.Testing.ProjectState.Sources.get -> Microsoft.CodeAnalysi
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.AddAssemblies(System.Collections.Immutable.ImmutableArray<string> assemblies) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.AddLanguageSpecificAssemblies(string language, System.Collections.Immutable.ImmutableArray<string> assemblies) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
-Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.AddPackages(System.Collections.Immutable.ImmutableArray<NuGet.Packaging.Core.PackageIdentity> packages) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.AddPackages(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Testing.PackageIdentity> packages) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Assemblies.get -> System.Collections.Immutable.ImmutableArray<string>
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.AssemblyIdentityComparer.get -> Microsoft.CodeAnalysis.AssemblyIdentityComparer
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.LanguageSpecificAssemblies.get -> System.Collections.Immutable.ImmutableDictionary<string, System.Collections.Immutable.ImmutableArray<string>>
@@ -118,10 +122,10 @@ Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net471
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net472
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net48
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetStandard
-Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Packages.get -> System.Collections.Immutable.ImmutableArray<NuGet.Packaging.Core.PackageIdentity>
+Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Packages.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Testing.PackageIdentity>
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.ReferenceAssemblies(string targetFramework) -> void
-Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.ReferenceAssemblies(string targetFramework, NuGet.Packaging.Core.PackageIdentity referenceAssemblyPackage, string referenceAssemblyPath) -> void
-Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.ReferenceAssemblyPackage.get -> NuGet.Packaging.Core.PackageIdentity
+Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.ReferenceAssemblies(string targetFramework, Microsoft.CodeAnalysis.Testing.PackageIdentity referenceAssemblyPackage, string referenceAssemblyPath) -> void
+Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.ReferenceAssemblyPackage.get -> Microsoft.CodeAnalysis.Testing.PackageIdentity
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.ReferenceAssemblyPath.get -> string
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.ResolveAsync(string language, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.MetadataReference>>
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.TargetFramework.get -> string
@@ -129,7 +133,7 @@ Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.WithAssemblies(System.Collect
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.WithAssemblyIdentityComparer(Microsoft.CodeAnalysis.AssemblyIdentityComparer assemblyIdentityComparer) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.WithLanguageSpecificAssemblies(System.Collections.Immutable.ImmutableDictionary<string, System.Collections.Immutable.ImmutableArray<string>> languageSpecificAssemblies) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.WithLanguageSpecificAssemblies(string language, System.Collections.Immutable.ImmutableArray<string> assemblies) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
-Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.WithPackages(System.Collections.Immutable.ImmutableArray<NuGet.Packaging.Core.PackageIdentity> packages) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.WithPackages(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Testing.PackageIdentity> packages) -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 Microsoft.CodeAnalysis.Testing.SolutionState
 Microsoft.CodeAnalysis.Testing.SolutionState.AdditionalFiles.get -> Microsoft.CodeAnalysis.Testing.SourceFileCollection
 Microsoft.CodeAnalysis.Testing.SolutionState.AdditionalFilesFactories.get -> System.Collections.Generic.List<System.Func<System.Collections.Generic.IEnumerable<(string filename, Microsoft.CodeAnalysis.Text.SourceText content)>>>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
-using NuGet.Packaging.Core;
-using NuGet.Versioning;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Testing
@@ -232,7 +230,7 @@ class TestClass {
                     Sources = { testCode },
                 },
                 ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net46.Default
-                    .AddPackages(ImmutableArray.Create(new PackageIdentity("System.ValueTuple", NuGetVersion.Parse("4.5.0")))),
+                    .AddPackages(ImmutableArray.Create(new PackageIdentity("System.ValueTuple", "4.5.0"))),
             }.RunAsync();
         }
 
@@ -269,7 +267,7 @@ class TestClass {
                     Sources = { testCode },
                 },
                 ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net452.Default
-                    .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis", NuGetVersion.Parse("1.0.1")))),
+                    .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis", "1.0.1"))),
             }.RunAsync();
         }
 
@@ -290,7 +288,7 @@ class TestClass {
                     Sources = { testCode },
                 },
                 ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net46.Default
-                    .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis", NuGetVersion.Parse("2.8.2")))),
+                    .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis", "2.8.2"))),
             }.RunAsync();
         }
 
@@ -311,7 +309,7 @@ class TestClass {
                     Sources = { testCode },
                 },
                 ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default
-                    .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis", NuGetVersion.Parse("3.3.1")))),
+                    .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis", "3.3.1"))),
             }.RunAsync();
         }
 


### PR DESCRIPTION
NuGet APIs tend to change in ways that do not support the high-level compatibility approach of Microsoft.CodeAnalysis.Testing. This change wraps the PackageIdentity class to avoid directly exposing the type to consuming code.