### PR TITLE
Suggest calling VerifyCS.Diagnostic instead of GetCSharpResultAt

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.Testing
             string? message,
             DiagnosticSeverity severity,
             string id,
-            LocalizableString messageFormat,
-            object[] messageArguments)
+            LocalizableString? messageFormat,
+            object?[]? messageArguments)
         {
             _spans = spans;
             _suppressMessage = suppressMessage;
@@ -90,9 +90,9 @@ namespace Microsoft.CodeAnalysis.Testing
             }
         }
 
-        public LocalizableString MessageFormat { get; }
+        public LocalizableString? MessageFormat { get; }
 
-        public object[] MessageArguments { get; }
+        public object?[]? MessageArguments { get; }
 
         public bool HasLocation => !Spans.IsEmpty;
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Extensions/IEnumerableExtensions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Extensions/IEnumerableExtensions.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CodeAnalysis.Testing
 {
     internal static class IEnumerableExtensions
     {
+        private static readonly Func<object?, bool> s_notNullTest = x => x is object;
+
         public static DiagnosticResult[] ToOrderedArray(this IEnumerable<DiagnosticResult> diagnosticResults)
         {
             return diagnosticResults
@@ -18,6 +20,12 @@ namespace Microsoft.CodeAnalysis.Testing
                 .ThenBy(diagnosticResult => diagnosticResult.Spans.FirstOrDefault().Span.Span.End.Character)
                 .ThenBy(diagnosticResult => diagnosticResult.Id, StringComparer.Ordinal)
                 .ToArray();
+        }
+
+        internal static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
+            where T : class
+        {
+            return source.Where<T?>(s_notNullTest)!;
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.Testing
 
             if (MarkupHandling == MarkupMode.None)
             {
-                return (explicitDiagnostics.Select(diagnostic => diagnostic.WithDefaultPath(defaultPath)).ToOrderedArray(), sources.ToArray());
+                return (explicitDiagnostics.Select(diagnostic => diagnostic.WithDefaultPath(defaultPath)).ToArray(), sources.ToArray());
             }
 
             var sourceFiles = new List<(string filename, SourceText content)>();
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 }
             }
 
-            return (diagnostics.ToOrderedArray(), sourceFiles.ToArray());
+            return (diagnostics.ToArray(), sourceFiles.ToArray());
         }
 
         private DiagnosticResult? CreateDiagnosticForPosition(

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AdditionalFilesTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AdditionalFilesTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.cs(1,23): warning Brace: message" + Environment.NewLine +
-                "GetCSharpResultAt(1, 23, HighlightBracesAnalyzer.Brace)" + Environment.NewLine +
+                "VerifyCS.Diagnostic().WithSpan(1, 23, 1, 24)" + Environment.NewLine +
                 Environment.NewLine;
             Assert.Equal(expected, exception.Message);
         }
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// File1.txt(1,14): warning Brace: message" + Environment.NewLine +
-                "new DiagnosticResult(HighlightBracesAnalyzer.Brace).WithSpan(\"File1.txt\", 1, 14, 1, 15)" + Environment.NewLine +
+                "new DiagnosticResult().WithSpan(\"File1.txt\", 1, 14, 1, 15)" + Environment.NewLine +
                 Environment.NewLine;
             Assert.Equal(expected, exception.Message);
         }

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AutoExclusionTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AutoExclusionTests.cs
@@ -53,9 +53,9 @@ End Class
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.cs(4,23): warning ThisToBase: message" + Environment.NewLine +
-                "GetCSharpResultAt(4, 23, ReplaceThisWithBaseAnalyzer.ThisToBase)" + Environment.NewLine +
+                "VerifyCS.Diagnostic().WithSpan(4, 23, 4, 27)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -75,9 +75,9 @@ End Class
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.cs(1,1): warning FirstLine: message" + Environment.NewLine +
-                "GetCSharpResultAt(1, 1, FirstLineDiagnosticAnalyzer.FirstLine)" + Environment.NewLine +
+                "VerifyCS.Diagnostic().WithSpan(1, 1, 1, 1)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -138,9 +138,9 @@ End Class
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.vb(5,5): warning ThisToBase: message" + Environment.NewLine +
-                "GetBasicResultAt(5, 5, ReplaceThisWithBaseAnalyzer.ThisToBase)" + Environment.NewLine +
+                "VerifyVB.Diagnostic().WithSpan(5, 5, 5, 12)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -160,9 +160,9 @@ End Class
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.vb(1,1): warning FirstLine: message" + Environment.NewLine +
-                "GetBasicResultAt(1, 1, FirstLineDiagnosticAnalyzer.FirstLine)" + Environment.NewLine +
+                "VerifyVB.Diagnostic().WithSpan(1, 1, 1, 1)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Theory]

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
@@ -30,8 +30,9 @@ class TestClass {
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.cs(3,34): error CS1002: ; expected" + Environment.NewLine +
+                "DiagnosticResult.CompilerError(\"CS1002\").WithSpan(3, 34, 3, 35)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -103,8 +104,9 @@ class TestClass {
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.cs(3,7): warning CS0414: The field 'TestClass.value' is assigned but its value is never used" + Environment.NewLine +
+                "DiagnosticResult.CompilerError(\"CS0414\").WithSpan(3, 7, 3, 12)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -156,8 +158,9 @@ class TestClass {
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.cs(2,1): hidden CS8019: Unnecessary using directive." + Environment.NewLine +
+                "new DiagnosticResult(\"CS8019\", DiagnosticSeverity.Hidden).WithSpan(2, 1, 2, 14)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -180,8 +183,9 @@ End Class
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.vb(3) : error BC30205: End of statement expected." + Environment.NewLine +
+                "DiagnosticResult.CompilerError(\"BC30205\").WithSpan(3, 13, 3, 14)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
@@ -80,9 +80,38 @@ class TestClass {
             await new CSharpTest
             {
                 TestCode = testCode,
-                ExpectedDiagnostics = { DiagnosticResult.CompilerWarning("CS0414").WithSpan(3, 7, 3, 12).WithMessage("The field 'TestClass.value' is assigned but its value is never used") },
+                ExpectedDiagnostics = { DiagnosticResult.CompilerWarning("CS0414").WithSpan(3, 7, 3, 12).WithArguments("TestClass.value") },
                 CompilerDiagnostics = CompilerDiagnostics.Warnings,
             }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestCSharpCompilerWarningDeclaredWithWrongArgument()
+        {
+            var testCode = @"
+class TestClass {
+  int value = 3;
+}
+";
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await new CSharpTest
+                {
+                    TestCode = testCode,
+                    ExpectedDiagnostics = { DiagnosticResult.CompilerWarning("CS0414").WithSpan(3, 7, 3, 12).WithArguments("TestClass2.value") },
+                    CompilerDiagnostics = CompilerDiagnostics.Warnings,
+                }.RunAsync();
+            });
+
+            var expected =
+                "Expected diagnostic message arguments to match" + Environment.NewLine +
+                Environment.NewLine +
+                "Diagnostic:" + Environment.NewLine +
+                "    // Test0.cs(3,7): warning CS0414: The field 'TestClass.value' is assigned but its value is never used" + Environment.NewLine +
+                "DiagnosticResult.CompilerWarning(\"CS0414\").WithSpan(3, 7, 3, 12).WithArguments(\"TestClass.value\")" + Environment.NewLine +
+                Environment.NewLine;
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -104,7 +133,7 @@ class TestClass {
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.cs(3,7): warning CS0414: The field 'TestClass.value' is assigned but its value is never used" + Environment.NewLine +
-                "DiagnosticResult.CompilerError(\"CS0414\").WithSpan(3, 7, 3, 12)" + Environment.NewLine +
+                "DiagnosticResult.CompilerWarning(\"CS0414\").WithSpan(3, 7, 3, 12).WithArguments(\"TestClass.value\")" + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/DiagnosticLocationTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/DiagnosticLocationTests.cs
@@ -67,9 +67,9 @@ namespace Microsoft.CodeAnalysis.Testing
                 Environment.NewLine +
                 "Diagnostic:" + Environment.NewLine +
                 "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
-                "GetCSharpResultAt(1, 17, HighlightBraceSpanAnalyzer.Brace)" + Environment.NewLine +
+                "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -88,9 +88,9 @@ namespace Microsoft.CodeAnalysis.Testing
                 Environment.NewLine +
                 "Diagnostic:" + Environment.NewLine +
                 "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
-                "GetCSharpResultAt(1, 17, HighlightBraceSpanAnalyzer.Brace)" + Environment.NewLine +
+                "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -110,8 +110,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 "A project diagnostic with No location" + Environment.NewLine +
                 "Actual:" + Environment.NewLine +
                 "// Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
-                "GetCSharpResultAt(1, 17, HighlightBraceSpanAnalyzer.Brace)" + Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+                "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)" + Environment.NewLine;
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -131,8 +131,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 "A project diagnostic with No location" + Environment.NewLine +
                 "Actual:" + Environment.NewLine +
                 "// Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
-                "GetCSharpResultAt(1, 17, HighlightBraceSpanAnalyzer.Brace)" + Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+                "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)" + Environment.NewLine;
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -169,9 +169,9 @@ namespace Microsoft.CodeAnalysis.Testing
                 Environment.NewLine +
                 "Diagnostic:" + Environment.NewLine +
                 "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
-                "GetCSharpResultAt(1, 17, HighlightBracePositionAnalyzer.Brace)" + Environment.NewLine +
+                "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 17)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]
@@ -190,9 +190,9 @@ namespace Microsoft.CodeAnalysis.Testing
                 Environment.NewLine +
                 "Diagnostic:" + Environment.NewLine +
                 "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
-                "GetCSharpResultAt(1, 17, HighlightBracePositionAnalyzer.Brace)" + Environment.NewLine +
+                "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 17)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         private abstract class HighlightBraceAnalyzer : DiagnosticAnalyzer

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/AdditionalFilesFixTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/AdditionalFilesFixTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 }.RunAsync();
             });
 
-            Assert.Equal($"Context: Iterative code fix application{Environment.NewLine}content of 'File1.txt' did not match. Diff shown with expected as baseline:{Environment.NewLine}-Wrong file text{Environment.NewLine}+File text{Environment.NewLine}", exception.Message);
+            new DefaultVerifier().EqualOrDiff($"Context: Iterative code fix application{Environment.NewLine}content of 'File1.txt' did not match. Diff shown with expected as baseline:{Environment.NewLine}-Wrong file text{Environment.NewLine}+File text{Environment.NewLine}", exception.Message);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 }.RunAsync();
             });
 
-            Assert.Equal($"Context: Iterative code fix application{Environment.NewLine}content of 'File1.txt' did not match. Diff shown with expected as baseline:{Environment.NewLine}-  File text{Environment.NewLine}+File text{Environment.NewLine}", exception.Message);
+            new DefaultVerifier().EqualOrDiff($"Context: Iterative code fix application{Environment.NewLine}content of 'File1.txt' did not match. Diff shown with expected as baseline:{Environment.NewLine}-  File text{Environment.NewLine}+File text{Environment.NewLine}", exception.Message);
         }
 
         [Fact]
@@ -161,8 +161,9 @@ namespace Microsoft.CodeAnalysis.Testing
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
                 "// Test0.cs(1,24): error CS1513: } expected" + Environment.NewLine +
+                "DiagnosticResult.CompilerError(\"CS1513\").WithSpan(1, 24, 1, 24)" + Environment.NewLine +
                 Environment.NewLine;
-            Assert.Equal(expected, exception.Message);
+            new DefaultVerifier().EqualOrDiff(expected, exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
* Improved code suggestions for failed diagnostic validation
* Allow verification of message arguments without messages (reduces sensitivity to localization, especially for compiler diagnostics)

The first commit is shared with #415.

Fixes #341