### PR TITLE
Automatically include all compiler diagnostics with IDs that match a provided code fix

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -781,7 +781,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, GetAnalyzerOptions(project), cancellationToken);
                 var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync().ConfigureAwait(false);
-                diagnostics.AddRange(allDiagnostics.Where(IsIncludedDiagnostic));
+
+                diagnostics.AddRange(allDiagnostics.Where(diagnostic => IsCompilerDiagnosticIncluded(diagnostic, CompilerDiagnostics)));
             }
 
             var results = SortDistinctDiagnostics(diagnostics);
@@ -792,11 +793,9 @@ namespace Microsoft.CodeAnalysis.Testing
         /// Extension point to allow inheriting classes to include diagnostics which would otherwise be filtered. The default implementation returns false
         /// </summary>
         /// <param name="diagnostic">the diagnostic which is subject to filter processes.</param>
+        /// <param name="compilerDiagnostics">level of diagnostic used to filter compiler diagnostics</param>
         /// <returns>return true to exclude a diagnostic, false to leave it up to internal logic.</returns>
-        protected virtual bool IsDiagnosticHandled(Diagnostic diagnostic) => false;
-
-        protected virtual bool IsCompilerDiagnosticIncluded(Diagnostic diagnostic,
-            CompilerDiagnostics compilerDiagnostics)
+        protected virtual bool IsCompilerDiagnosticIncluded(Diagnostic diagnostic, CompilerDiagnostics compilerDiagnostics)
         {
             return IsCompilerDiagnostic(diagnostic)
                 || IsCompilerDiagnosticIncluded();

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -791,6 +791,7 @@ namespace Microsoft.CodeAnalysis.Testing
             bool IsIncludedDiagnostic(Diagnostic diagnostic)
             {
                 return !IsCompilerDiagnostic(diagnostic)
+                    || IsDiagnosticHandled(diagnostic)
                     || IsCompilerDiagnosticIncluded(diagnostic);
             }
 
@@ -821,6 +822,13 @@ namespace Microsoft.CodeAnalysis.Testing
                 }
             }
         }
+
+        /// <summary>
+        /// Extension point to allow inheriting classes to include diagnostics which would otherwise be filtered. The default implementation returns false
+        /// </summary>
+        /// <param name="diagnostic">the diagnostic which is subject to filter processes.</param>
+        /// <returns>return true to exclude a diagnostic, false to leave it up to internal logic.</returns>
+        protected internal virtual bool IsDiagnosticHandled(Diagnostic diagnostic) => false;
 
         /// <summary>
         /// Gets the effective analyzer options for a project. The default implementation returns

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -782,7 +782,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, GetAnalyzerOptions(project), cancellationToken);
                 var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync().ConfigureAwait(false);
 
-                diagnostics.AddRange(allDiagnostics.Where(diagnostic => IsCompilerDiagnosticIncluded(diagnostic, CompilerDiagnostics)));
+                diagnostics.AddRange(allDiagnostics.Where(diagnostic => IsCompilerDiagnosticIncluded(diagnostic, compilerDiagnostics)));
             }
 
             var results = SortDistinctDiagnostics(diagnostics);
@@ -797,15 +797,15 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <returns>return true to exclude a diagnostic, false to leave it up to internal logic.</returns>
         protected virtual bool IsCompilerDiagnosticIncluded(Diagnostic diagnostic, CompilerDiagnostics compilerDiagnostics)
         {
-            return IsCompilerDiagnostic(diagnostic)
-                || IsCompilerDiagnosticIncluded();
+            return !IsCompilerDiagnostic(diagnostic)
+                || IsCompilerDiagnosticIncluded(diagnostic, compilerDiagnostics);
 
             static bool IsCompilerDiagnostic(Diagnostic diagnostic)
             {
                 return diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Compiler);
             }
 
-            bool IsCompilerDiagnosticIncluded()
+            static bool IsCompilerDiagnosticIncluded(Diagnostic diagnostic, CompilerDiagnostics compilerDiagnostics)
             {
                 switch (compilerDiagnostics)
                 {

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -828,7 +828,7 @@ namespace Microsoft.CodeAnalysis.Testing
         /// </summary>
         /// <param name="diagnostic">the diagnostic which is subject to filter processes.</param>
         /// <returns>return true to exclude a diagnostic, false to leave it up to internal logic.</returns>
-        protected internal virtual bool IsDiagnosticHandled(Diagnostic diagnostic) => false;
+        protected virtual bool IsDiagnosticHandled(Diagnostic diagnostic) => false;
 
         /// <summary>
         /// Gets the effective analyzer options for a project. The default implementation returns

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -786,41 +786,6 @@ namespace Microsoft.CodeAnalysis.Testing
 
             var results = SortDistinctDiagnostics(diagnostics);
             return results.ToImmutableArray();
-
-            // Local function
-            bool IsIncludedDiagnostic(Diagnostic diagnostic)
-            {
-                return !IsCompilerDiagnostic(diagnostic)
-                    || IsDiagnosticHandled(diagnostic)
-                    || IsCompilerDiagnosticIncluded(diagnostic);
-            }
-
-            static bool IsCompilerDiagnostic(Diagnostic diagnostic)
-            {
-                return diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Compiler);
-            }
-
-            bool IsCompilerDiagnosticIncluded(Diagnostic diagnostic)
-            {
-                switch (compilerDiagnostics)
-                {
-                case CompilerDiagnostics.None:
-                default:
-                    return false;
-
-                case CompilerDiagnostics.Errors:
-                    return diagnostic.Severity >= DiagnosticSeverity.Error;
-
-                case CompilerDiagnostics.Warnings:
-                    return diagnostic.Severity >= DiagnosticSeverity.Warning;
-
-                case CompilerDiagnostics.Suggestions:
-                    return diagnostic.Severity >= DiagnosticSeverity.Info;
-
-                case CompilerDiagnostics.All:
-                    return true;
-                }
-            }
         }
 
         /// <summary>
@@ -829,6 +794,40 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <param name="diagnostic">the diagnostic which is subject to filter processes.</param>
         /// <returns>return true to exclude a diagnostic, false to leave it up to internal logic.</returns>
         protected virtual bool IsDiagnosticHandled(Diagnostic diagnostic) => false;
+
+        protected virtual bool IsCompilerDiagnosticIncluded(Diagnostic diagnostic,
+            CompilerDiagnostics compilerDiagnostics)
+        {
+            return IsCompilerDiagnostic(diagnostic)
+                || IsCompilerDiagnosticIncluded();
+
+            static bool IsCompilerDiagnostic(Diagnostic diagnostic)
+            {
+                return diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Compiler);
+            }
+
+            bool IsCompilerDiagnosticIncluded()
+            {
+                switch (compilerDiagnostics)
+                {
+                    case CompilerDiagnostics.None:
+                    default:
+                        return false;
+
+                    case CompilerDiagnostics.Errors:
+                        return diagnostic.Severity >= DiagnosticSeverity.Error;
+
+                    case CompilerDiagnostics.Warnings:
+                        return diagnostic.Severity >= DiagnosticSeverity.Warning;
+
+                    case CompilerDiagnostics.Suggestions:
+                        return diagnostic.Severity >= DiagnosticSeverity.Info;
+
+                    case CompilerDiagnostics.All:
+                        return true;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the effective analyzer options for a project. The default implementation returns

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -251,6 +251,7 @@ virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.CreateWorkspace()
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultFilePath.get -> string
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultFilePathPrefix.get -> string
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultTestProjectName.get -> string
+virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.IsDiagnosticHandled(Microsoft.CodeAnalysis.Diagnostic diagnostic) -> bool
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.GetAnalyzerOptions(Microsoft.CodeAnalysis.Project project) -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.GetDefaultDiagnostic(Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer[] analyzers) -> Microsoft.CodeAnalysis.DiagnosticDescriptor
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.RunAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -251,7 +251,7 @@ virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.CreateWorkspace()
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultFilePath.get -> string
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultFilePathPrefix.get -> string
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultTestProjectName.get -> string
-virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.IsDiagnosticHandled(Microsoft.CodeAnalysis.Diagnostic diagnostic) -> bool
+virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.IsCompilerDiagnosticIncluded(Microsoft.CodeAnalysis.Diagnostic diagnostic, Microsoft.CodeAnalysis.Testing.CompilerDiagnostics compilerDiagnostics) -> bool
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.GetAnalyzerOptions(Microsoft.CodeAnalysis.Project project) -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.GetDefaultDiagnostic(Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer[] analyzers) -> Microsoft.CodeAnalysis.DiagnosticDescriptor
 virtual Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.RunAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
@@ -169,6 +169,14 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <returns>The <see cref="CodeFixProvider"/> to be used.</returns>
         protected abstract IEnumerable<CodeFixProvider> GetCodeFixProviders();
 
+        /// <inheritdoc />
+        protected override bool IsDiagnosticHandled(Diagnostic diagnostic)
+        {
+            var codeFixProviders = GetCodeFixProviders();
+            return codeFixProviders
+                .Any(provider => provider.FixableDiagnosticIds.Any(fixerDiagnosticId => string.Equals(fixerDiagnosticId, diagnostic.Id, StringComparison.OrdinalIgnoreCase)));
+        }
+
         public override async Task RunAsync(CancellationToken cancellationToken = default)
         {
             Verify.NotEmpty($"{nameof(TestState)}.{nameof(SolutionState.Sources)}", TestState.Sources);

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
@@ -170,11 +170,21 @@ namespace Microsoft.CodeAnalysis.Testing
         protected abstract IEnumerable<CodeFixProvider> GetCodeFixProviders();
 
         /// <inheritdoc />
-        protected override bool IsDiagnosticHandled(Diagnostic diagnostic)
+        protected override bool IsCompilerDiagnosticIncluded(Diagnostic diagnostic, CompilerDiagnostics compilerDiagnostics)
         {
-            var codeFixProviders = GetCodeFixProviders();
-            return codeFixProviders
-                .Any(provider => provider.FixableDiagnosticIds.Any(fixerDiagnosticId => string.Equals(fixerDiagnosticId, diagnostic.Id, StringComparison.OrdinalIgnoreCase)));
+            if (base.IsCompilerDiagnosticIncluded(diagnostic, compilerDiagnostics))
+            {
+                return true;
+            }
+
+            return CodeFixProvidersHandleDiagnostic(diagnostic);
+
+            bool CodeFixProvidersHandleDiagnostic(Diagnostic localDiagnostic)
+            {
+                var codeFixProviders = GetCodeFixProviders();
+                return codeFixProviders
+                    .Any(provider => provider.FixableDiagnosticIds.Any(fixerDiagnosticId => string.Equals(fixerDiagnosticId, localDiagnostic.Id, StringComparison.OrdinalIgnoreCase)));
+            }
         }
 
         public override async Task RunAsync(CancellationToken cancellationToken = default)

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/PublicAPI.Unshipped.txt
@@ -27,6 +27,7 @@ Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider
 Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider.EmptyCodeFixProvider() -> void
 abstract Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.GetCodeFixProviders() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider>
 abstract Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.SyntaxKindType.get -> System.Type
+override Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.IsDiagnosticHandled(Microsoft.CodeAnalysis.Diagnostic diagnostic) -> bool
 override Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.RunAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 override Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string>
 override Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/PublicAPI.Unshipped.txt
@@ -27,7 +27,7 @@ Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider
 Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider.EmptyCodeFixProvider() -> void
 abstract Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.GetCodeFixProviders() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider>
 abstract Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.SyntaxKindType.get -> System.Type
-override Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.IsDiagnosticHandled(Microsoft.CodeAnalysis.Diagnostic diagnostic) -> bool
+override Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.IsCompilerDiagnosticIncluded(Microsoft.CodeAnalysis.Diagnostic diagnostic, Microsoft.CodeAnalysis.Testing.CompilerDiagnostics compilerDiagnostics) -> bool
 override Microsoft.CodeAnalysis.Testing.CodeFixTest<TVerifier>.RunAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 override Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string>
 override Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
@@ -24,6 +24,12 @@ namespace Microsoft.CodeAnalysis.Testing
         [PartNotDiscoverable]
         internal class SomeCodeFix : CodeFixProvider
         {
+            /// <inheritdoc />
+            public override FixAllProvider GetFixAllProvider()
+            {
+                return WellKnownFixAllProviders.BatchFixer;
+            }
+
             public override Task RegisterCodeFixesAsync(CodeFixContext context)
             {
                 foreach (var diagnostic in context.Diagnostics)

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
@@ -83,6 +83,7 @@ namespace ConsoleApp1
             public void SomeMethod(){}
     }
 }";
+
             await Verify<SomeCodeFix>.VerifyCodeFixAsync(before, DiagnosticResult.CompilerWarning("CS0169"), after);
         }
     }

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.CodeAnalysis.Testing
+{
+    public class IncludeDiagnosticsMentiondByCodeFixTests
+    {
+        
+    }
+}

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
@@ -1,7 +1,89 @@
-﻿namespace Microsoft.CodeAnalysis.Testing
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Testing
 {
-    public class IncludeDiagnosticsMentiondByCodeFixTests
+    public class IncludeDiagnosticsMentionedByCodeFixTests
     {
-        
+        private class Verify<TCodeFix> : CodeFixVerifier<EmptyDiagnosticAnalyzer, TCodeFix, CSharpCodeFixTest<EmptyDiagnosticAnalyzer, TCodeFix>, DefaultVerifier>
+            where TCodeFix : CodeFixProvider, new()
+        {
+        }
+
+        [ExportCodeFixProvider(LanguageNames.CSharp)]
+        [PartNotDiscoverable]
+        internal class SomeCodeFix : CodeFixProvider
+        {
+            public override Task RegisterCodeFixesAsync(CodeFixContext context)
+            {
+                foreach (var diagnostic in context.Diagnostics)
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            nameof(SomeCodeFix),
+                            cancellationToken => CreateChangedDocument(context.Document, diagnostic.Location.SourceSpan,
+                                cancellationToken),
+                            nameof(SomeCodeFix)),
+                        diagnostic);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            private async Task<Document> CreateChangedDocument(
+                Document document,
+                TextSpan sourceSpan,
+                CancellationToken cancellationToken)
+            {
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken);
+                var root = await tree.GetRootAsync(cancellationToken);
+                var node = root.FindNode(sourceSpan);
+                return document.WithSyntaxRoot(root.RemoveNode(node, SyntaxRemoveOptions.AddElasticMarker));
+            }
+
+            public override ImmutableArray<string> FixableDiagnosticIds => new[] { "CS0169" }.ToImmutableArray();
+        }
+
+        /// <summary>
+        /// Verifies that a test case with automatically include compiler diagnostics which are part of the the provided codefix
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(419, "https://github.com/dotnet/roslyn-sdk/issues/419")]
+        public async Task VerifySimpleSyntaxWorks()
+        {
+            var before = @"
+using System;
+
+namespace ConsoleApp1
+{
+    public class TestClass
+    {
+            private int someField;
+
+            public void SomeMethod(){}
+    }
+}";
+
+            var after = @"
+using System;
+
+namespace ConsoleApp1
+{
+    public class TestClass
+    {
+            public void SomeMethod(){}
+    }
+}";
+            await Verify<SomeCodeFix>.VerifyCodeFixAsync(before, DiagnosticResult.CompilerWarning("CS0169"), after);
+        }
     }
 }


### PR DESCRIPTION
this PR fixes #419