### PR TITLE
Visual Studio Project Template: "Analyzer with Code Fix": Verifier does not properly account for multiple source files

### DIFF
--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/DiagnosticVerifier.Helper.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/DiagnosticVerifier.Helper.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
@@ -92,7 +92,10 @@ namespace TestHelper
         /// <returns>An IEnumerable containing the Diagnostics in order of Location</returns>
         private static Diagnostic[] SortDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
-            return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+            return diagnostics
+                .OrderBy(d => d.Location.SourceTree.FilePath)
+                .ThenBy(d => d.Location.SourceSpan.Start)
+                .ToArray();
         }
 
         #endregion


### PR DESCRIPTION
Fixed that DiagnosticVerifier.Helper sorts result Diagnostic objects only by SourceSpan, meaning that when multiple source files are involved, VerifyDiagnostic and VerifyCodeFix can report false negatives, since they both rely on Diagnostic and DiagnosticResult objects being sorted the same, in order to successfully check for differences.