### PR TITLE
Implement diagnostic options

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 else
                 {
                     VerifyDiagnosticLocation(analyzers, actual, expected, actual.Location, expected.Spans[0], verifier);
-                    if (!expected.Spans[0].Options.HasFlag(DiagnosticLocationOptions.IgnoreAdditionalLocations))
+                    if (!expected.Options.HasFlag(DiagnosticOptions.IgnoreAdditionalLocations))
                     {
                         var additionalLocations = actual.AdditionalLocations.ToArray();
 
@@ -539,7 +539,7 @@ namespace Microsoft.CodeAnalysis.Testing
                         return false;
                     }
 
-                    if (diagnosticResult.Spans[0].Options.HasFlag(DiagnosticLocationOptions.IgnoreAdditionalLocations))
+                    if (diagnosticResult.Options.HasFlag(DiagnosticOptions.IgnoreAdditionalLocations))
                     {
                         return true;
                     }
@@ -776,7 +776,7 @@ namespace Microsoft.CodeAnalysis.Testing
                     foreach (var span in diagnostics[i].Spans)
                     {
                         AppendLocation(span);
-                        if (span.Options.HasFlag(DiagnosticLocationOptions.IgnoreAdditionalLocations))
+                        if (diagnostics[i].Options.HasFlag(DiagnosticOptions.IgnoreAdditionalLocations))
                         {
                             break;
                         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -322,8 +322,11 @@ namespace Microsoft.CodeAnalysis.Testing
                 message = FormatVerifierMessage(analyzers, actual, expected, $"Expected diagnostic id to be \"{expected.Id}\" was \"{actual.Id}\"");
                 verifier.Equal(expected.Id, actual.Id, message);
 
-                message = FormatVerifierMessage(analyzers, actual, expected, $"Expected diagnostic severity to be \"{expected.Severity}\" was \"{actual.Severity}\"");
-                verifier.Equal(expected.Severity, actual.Severity, message);
+                if (!expected.Options.HasFlag(DiagnosticOptions.IgnoreSeverity))
+                {
+                    message = FormatVerifierMessage(analyzers, actual, expected, $"Expected diagnostic severity to be \"{expected.Severity}\" was \"{actual.Severity}\"");
+                    verifier.Equal(expected.Severity, actual.Severity, message);
+                }
 
                 if (expected.Message != null)
                 {
@@ -509,7 +512,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 var isIdMatch = diagnosticId == diagnosticResult.Id;
                 if (isLocationMatch
                     && isIdMatch
-                    && diagnostic.Severity == diagnosticResult.Severity
+                    && IsSeverityMatch(diagnostic, diagnosticResult)
                     && IsMessageMatch(diagnostic, actualArguments, diagnosticResult, expectedArguments))
                 {
                     return MatchQuality.Full;
@@ -582,6 +585,16 @@ namespace Microsoft.CodeAnalysis.Testing
                 }
 
                 return true;
+            }
+
+            static bool IsSeverityMatch(Diagnostic actual, DiagnosticResult expected)
+            {
+                if (expected.Options.HasFlag(DiagnosticOptions.IgnoreSeverity))
+                {
+                    return true;
+                }
+
+                return actual.Severity == expected.Severity;
             }
 
             static bool IsMessageMatch(Diagnostic actual, ImmutableArray<string> actualArguments, DiagnosticResult expected, ImmutableArray<string> expectedArguments)

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticLocationOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticLocationOptions.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.Testing
 {
     /// <summary>
     /// Defines options for interpreting <see cref="DiagnosticLocation"/>.
     /// </summary>
+    [Flags]
     public enum DiagnosticLocationOptions
     {
         /// <summary>
@@ -17,11 +20,5 @@ namespace Microsoft.CodeAnalysis.Testing
         /// should be ignored when comparing results.
         /// </summary>
         IgnoreLength = 1,
-
-        /// <summary>
-        /// The primary diagnostic location is defined, but additional locations have not been provided. Disables
-        /// validation of additional locations reported for the corresponding diagnostics.
-        /// </summary>
-        IgnoreAdditionalLocations = 2,
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticOptions.cs
@@ -20,5 +20,10 @@ namespace Microsoft.CodeAnalysis.Testing
         /// validation of additional locations reported for the corresponding diagnostics.
         /// </summary>
         IgnoreAdditionalLocations = 1,
+
+        /// <summary>
+        /// Ignore the diagnostic severity when verifying this diagnostic result.
+        /// </summary>
+        IgnoreSeverity = 2,
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticOptions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    /// <summary>
+    /// Defines options for interpreting <see cref="DiagnosticResult"/>.
+    /// </summary>
+    [Flags]
+    public enum DiagnosticOptions
+    {
+        /// <summary>
+        /// The result should be interpreted using the default settings.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The primary diagnostic location is defined, but additional locations have not been provided. Disables
+        /// validation of additional locations reported for the corresponding diagnostics.
+        /// </summary>
+        IgnoreAdditionalLocations = 1,
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis.Text;
 
@@ -41,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Testing
             bool suppressMessage,
             string? message,
             DiagnosticSeverity severity,
+            DiagnosticOptions options,
             string id,
             LocalizableString? messageFormat,
             object?[]? messageArguments)
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.Testing
             _suppressMessage = suppressMessage;
             _message = message;
             Severity = severity;
+            Options = options;
             Id = id;
             MessageFormat = messageFormat;
             MessageArguments = messageArguments;
@@ -57,6 +58,12 @@ namespace Microsoft.CodeAnalysis.Testing
         public ImmutableArray<DiagnosticLocation> Spans => _spans.IsDefault ? ImmutableArray<DiagnosticLocation>.Empty : _spans;
 
         public DiagnosticSeverity Severity { get; }
+
+        /// <summary>
+        /// Gets the options to consider during validation of the expected diagnostic. The default value is
+        /// <see cref="DiagnosticOptions.None"/>.
+        /// </summary>
+        public DiagnosticOptions Options { get; }
 
         public string Id { get; }
 
@@ -109,6 +116,26 @@ namespace Microsoft.CodeAnalysis.Testing
                 suppressMessage: _suppressMessage,
                 message: _message,
                 severity: severity,
+                options: Options,
+                id: Id,
+                messageFormat: MessageFormat,
+                messageArguments: MessageArguments);
+        }
+
+        /// <summary>
+        /// Transforms the current <see cref="DiagnosticResult"/> to have the specified <see cref="Options"/>.
+        /// </summary>
+        /// <param name="options">The options to consider during validation of the expected diagnostic.</param>
+        /// <returns>A new <see cref="DiagnosticResult"/> copied from the current instance with the specified
+        /// <paramref name="options"/> applied.</returns>
+        public DiagnosticResult WithOptions(DiagnosticOptions options)
+        {
+            return new DiagnosticResult(
+                spans: _spans,
+                suppressMessage: _suppressMessage,
+                message: _message,
+                severity: Severity,
+                options: options,
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments);
@@ -121,6 +148,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 suppressMessage: _suppressMessage,
                 message: _message,
                 severity: Severity,
+                options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: arguments);
@@ -133,6 +161,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 suppressMessage: message is null,
                 message: message,
                 severity: Severity,
+                options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments);
@@ -145,6 +174,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 suppressMessage: _suppressMessage,
                 message: _message,
                 severity: Severity,
+                options: Options,
                 id: Id,
                 messageFormat: messageFormat,
                 messageArguments: MessageArguments);
@@ -157,6 +187,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 suppressMessage: _suppressMessage,
                 message: _message,
                 severity: Severity,
+                options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments);
@@ -210,6 +241,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 suppressMessage: _suppressMessage,
                 message: _message,
                 severity: Severity,
+                options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments);
@@ -237,6 +269,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 suppressMessage: _suppressMessage,
                 message: _message,
                 severity: Severity,
+                options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments);
@@ -249,6 +282,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 suppressMessage: _suppressMessage,
                 message: _message,
                 severity: Severity,
+                options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments);

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -40,6 +40,7 @@ Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions.IgnoreLength = 1 -> Mic
 Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions.None = 0 -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticOptions.IgnoreAdditionalLocations = 1 -> Microsoft.CodeAnalysis.Testing.DiagnosticOptions
+Microsoft.CodeAnalysis.Testing.DiagnosticOptions.IgnoreSeverity = 2 -> Microsoft.CodeAnalysis.Testing.DiagnosticOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticOptions.None = 0 -> Microsoft.CodeAnalysis.Testing.DiagnosticOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.DiagnosticResult(Microsoft.CodeAnalysis.DiagnosticDescriptor descriptor) -> void

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -36,9 +36,11 @@ Microsoft.CodeAnalysis.Testing.DiagnosticLocation.DiagnosticLocation(Microsoft.C
 Microsoft.CodeAnalysis.Testing.DiagnosticLocation.Options.get -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticLocation.Span.get -> Microsoft.CodeAnalysis.FileLinePositionSpan
 Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
-Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions.IgnoreAdditionalLocations = 2 -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions.IgnoreLength = 1 -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions.None = 0 -> Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions
+Microsoft.CodeAnalysis.Testing.DiagnosticOptions
+Microsoft.CodeAnalysis.Testing.DiagnosticOptions.IgnoreAdditionalLocations = 1 -> Microsoft.CodeAnalysis.Testing.DiagnosticOptions
+Microsoft.CodeAnalysis.Testing.DiagnosticOptions.None = 0 -> Microsoft.CodeAnalysis.Testing.DiagnosticOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.DiagnosticResult(Microsoft.CodeAnalysis.DiagnosticDescriptor descriptor) -> void
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.DiagnosticResult(string id, Microsoft.CodeAnalysis.DiagnosticSeverity severity) -> void
@@ -47,6 +49,7 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.Id.get -> string
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Message.get -> string
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.MessageArguments.get -> object[]
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.MessageFormat.get -> Microsoft.CodeAnalysis.LocalizableString
+Microsoft.CodeAnalysis.Testing.DiagnosticResult.Options.get -> Microsoft.CodeAnalysis.Testing.DiagnosticOptions
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Severity.get -> Microsoft.CodeAnalysis.DiagnosticSeverity
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Spans.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Testing.DiagnosticLocation>
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithArguments(params object[] arguments) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
@@ -60,6 +63,7 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(string path, int li
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithMessage(string message) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithMessageFormat(Microsoft.CodeAnalysis.LocalizableString messageFormat) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithNoLocation() -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
+Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithOptions(Microsoft.CodeAnalysis.Testing.DiagnosticOptions options) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity severity) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(Microsoft.CodeAnalysis.FileLinePositionSpan span) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(Microsoft.CodeAnalysis.FileLinePositionSpan span, Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions options) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
@@ -439,7 +439,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 }
             }
 
-            return diagnosticResult.WithMessage(null).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
+            return diagnosticResult.WithMessage(null).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations | DiagnosticOptions.IgnoreSeverity);
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SolutionState.cs
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis.Testing
             }
 
             var linePosition = content.Lines.GetLinePosition(position);
-            return diagnosticResult.Value.WithLocation(filename, linePosition, DiagnosticLocationOptions.IgnoreAdditionalLocations);
+            return diagnosticResult.Value.WithLocation(filename, linePosition);
         }
 
         private DiagnosticResult? CreateDiagnosticForSpan(
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.Testing
             }
 
             var linePositionSpan = content.Lines.GetLinePositionSpan(span);
-            return diagnosticResult.Value.WithSpan(new FileLinePositionSpan(filename, linePositionSpan), DiagnosticLocationOptions.IgnoreAdditionalLocations);
+            return diagnosticResult.Value.WithSpan(new FileLinePositionSpan(filename, linePositionSpan));
         }
 
         private DiagnosticResult? CreateDiagnostic(
@@ -439,7 +439,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 }
             }
 
-            return diagnosticResult.WithMessage(null);
+            return diagnosticResult.WithMessage(null).WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
         }
     }
 }

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/IncludeDiagnosticsMentionedByCodeFixTests.cs
@@ -61,7 +61,8 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         /// <summary>
-        /// Verifies that a test case with automatically include compiler diagnostics which are part of the the provided codefix
+        /// Verifies that a test case will automatically include compiler diagnostics which are part of the the provided
+        /// codefix.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
@@ -94,6 +95,42 @@ namespace ConsoleApp1
 
             var diagnostic = DiagnosticResult.CompilerWarning("CS0169").WithSpan(8, 21, 8, 30).WithArguments("ConsoleApp1.TestClass.someField");
             await Verify<SomeCodeFix>.VerifyCodeFixAsync(before, diagnostic, after);
+        }
+
+        /// <summary>
+        /// Verifies that a test case will automatically include compiler diagnostics which are part of the the provided
+        /// codefix, and the markup will ignore the severity of the diagnostic.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(419, "https://github.com/dotnet/roslyn-sdk/issues/419")]
+        public async Task VerifySimpleMarkupSyntaxWorks()
+        {
+            var before = @"
+using System;
+
+namespace ConsoleApp1
+{
+    public class TestClass
+    {
+        private int {|CS0169:someField|};
+
+        public void SomeMethod(){}
+    }
+}";
+
+            var after = @"
+using System;
+
+namespace ConsoleApp1
+{
+    public class TestClass
+    {
+        public void SomeMethod(){}
+    }
+}";
+
+            await Verify<SomeCodeFix>.VerifyCodeFixAsync(before, after);
         }
     }
 }


### PR DESCRIPTION
* Move `IgnoreAdditionalLocations` to `DiagnosticOptions`
* Implement `DiagnosticOptions.IgnoreSeverity`

Aside from the obvious benefit of allowing #419 to work with markup syntax, this change improves the experience of converting tests in dotnet/roslyn, where diagnostics are frequently reported with non-default severities.