### PR TITLE
Default files to a full path

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <summary>
         /// Gets the prefix to apply to source files added without an explicit name.
         /// </summary>
-        protected virtual string DefaultFilePathPrefix { get; } = "Test";
+        protected virtual string DefaultFilePathPrefix { get; } = "/0/Test";
 
         /// <summary>
         /// Gets the name of the default project created for testing.

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AdditionalFilesTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AdditionalFilesTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.cs(1,23): warning Brace: message" + Environment.NewLine +
+                "// /0/Test0.cs(1,23): warning Brace: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 23, 1, 24)," + Environment.NewLine +
                 Environment.NewLine;
             Assert.Equal(expected, exception.Message);

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerTestTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerTestTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Testing
         {
             var test = new CSharpTest { TestCode = "Test code" };
             Assert.Single(test.TestState.Sources);
-            Assert.Equal("Test0.cs", test.TestState.Sources[0].filename);
+            Assert.Equal("/0/Test0.cs", test.TestState.Sources[0].filename);
             Assert.Equal("Test code", test.TestState.Sources[0].content.ToString());
             Assert.Null(test.TestState.Sources[0].content.Encoding);
             Assert.Equal(SourceHashAlgorithm.Sha1, test.TestState.Sources[0].content.ChecksumAlgorithm);
@@ -40,12 +40,12 @@ namespace Microsoft.CodeAnalysis.Testing
             test.TestCode = "Test code";
             Assert.Equal(2, test.TestState.Sources.Count);
 
-            Assert.Equal("Test0.cs", test.TestState.Sources[0].filename);
+            Assert.Equal("/0/Test0.cs", test.TestState.Sources[0].filename);
             Assert.Equal("Test code", test.TestState.Sources[0].content.ToString());
             Assert.Null(test.TestState.Sources[0].content.Encoding);
             Assert.Equal(SourceHashAlgorithm.Sha1, test.TestState.Sources[0].content.ChecksumAlgorithm);
 
-            Assert.Equal("Test1.cs", test.TestState.Sources[1].filename);
+            Assert.Equal("/0/Test1.cs", test.TestState.Sources[1].filename);
             Assert.Equal("Test code", test.TestState.Sources[1].content.ToString());
             Assert.Null(test.TestState.Sources[1].content.Encoding);
             Assert.Equal(SourceHashAlgorithm.Sha1, test.TestState.Sources[1].content.ChecksumAlgorithm);

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AutoExclusionTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AutoExclusionTests.cs
@@ -52,7 +52,7 @@ End Class
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.cs(4,23): warning ThisToBase: message" + Environment.NewLine +
+                "// /0/Test0.cs(4,23): warning ThisToBase: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(4, 23, 4, 27)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -74,7 +74,7 @@ End Class
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.cs(1,1): warning FirstLine: message" + Environment.NewLine +
+                "// /0/Test0.cs(1,1): warning FirstLine: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 1, 1, 1)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -137,7 +137,7 @@ End Class
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.vb(5,5): warning ThisToBase: message" + Environment.NewLine +
+                "// /0/Test0.vb(5,5): warning ThisToBase: message" + Environment.NewLine +
                 "VerifyVB.Diagnostic().WithSpan(5, 5, 5, 12)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -159,7 +159,7 @@ End Class
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.vb(1,1): warning FirstLine: message" + Environment.NewLine +
+                "// /0/Test0.vb(1,1): warning FirstLine: message" + Environment.NewLine +
                 "VerifyVB.Diagnostic().WithSpan(1, 1, 1, 1)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
@@ -29,7 +29,7 @@ class TestClass {
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.cs(3,34): error CS1002: ; expected" + Environment.NewLine +
+                "// /0/Test0.cs(3,34): error CS1002: ; expected" + Environment.NewLine +
                 "DiagnosticResult.CompilerError(\"CS1002\").WithSpan(3, 34, 3, 35)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -100,11 +100,11 @@ class TestClass {
                 "Expected diagnostic to end at column \"21\" was actually at column \"19\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Expected diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(2,8,2,21): error CS0246" + Environment.NewLine +
+                "    // /0/Test0.cs(2,8,2,21): error CS0246" + Environment.NewLine +
                 "DiagnosticResult.CompilerError(\"CS0246\").WithSpan(2, 8, 2, 21).WithArguments(\"IDisposable\")," + Environment.NewLine +
                 Environment.NewLine +
                 "Actual diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(2,8): error CS0246: The type or namespace name 'IDisposable' could not be found (are you missing a using directive or an assembly reference?)" + Environment.NewLine +
+                "    // /0/Test0.cs(2,8): error CS0246: The type or namespace name 'IDisposable' could not be found (are you missing a using directive or an assembly reference?)" + Environment.NewLine +
                 "DiagnosticResult.CompilerError(\"CS0246\").WithSpan(2, 8, 2, 19).WithArguments(\"IDisposable\")," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -190,11 +190,11 @@ class TestClass {
                 "Expected diagnostic message arguments to match" + Environment.NewLine +
                 Environment.NewLine +
                 "Expected diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(3,7,3,12): warning CS0414" + Environment.NewLine +
+                "    // /0/Test0.cs(3,7,3,12): warning CS0414" + Environment.NewLine +
                 "DiagnosticResult.CompilerWarning(\"CS0414\").WithSpan(3, 7, 3, 12).WithArguments(\"TestClass2.value\")," + Environment.NewLine +
                 Environment.NewLine +
                 "Actual diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(3,7): warning CS0414: The field 'TestClass.value' is assigned but its value is never used" + Environment.NewLine +
+                "    // /0/Test0.cs(3,7): warning CS0414: The field 'TestClass.value' is assigned but its value is never used" + Environment.NewLine +
                 "DiagnosticResult.CompilerWarning(\"CS0414\").WithSpan(3, 7, 3, 12).WithArguments(\"TestClass.value\")," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -218,7 +218,7 @@ class TestClass {
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.cs(3,7): warning CS0414: The field 'TestClass.value' is assigned but its value is never used" + Environment.NewLine +
+                "// /0/Test0.cs(3,7): warning CS0414: The field 'TestClass.value' is assigned but its value is never used" + Environment.NewLine +
                 "DiagnosticResult.CompilerWarning(\"CS0414\").WithSpan(3, 7, 3, 12).WithArguments(\"TestClass.value\")," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -272,7 +272,7 @@ class TestClass {
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.cs(2,1): hidden CS8019: Unnecessary using directive." + Environment.NewLine +
+                "// /0/Test0.cs(2,1): hidden CS8019: Unnecessary using directive." + Environment.NewLine +
                 "new DiagnosticResult(\"CS8019\", DiagnosticSeverity.Hidden).WithSpan(2, 1, 2, 14)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -297,7 +297,7 @@ End Class
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.vb(3) : error BC30205: End of statement expected." + Environment.NewLine +
+                "// /0/Test0.vb(3) : error BC30205: End of statement expected." + Environment.NewLine +
                 "DiagnosticResult.CompilerError(\"BC30205\").WithSpan(3, 13, 3, 14)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/DiagnosticLocationTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/DiagnosticLocationTests.cs
@@ -66,11 +66,11 @@ namespace Microsoft.CodeAnalysis.Testing
                 "Expected diagnostic to end at column \"17\" was actually at column \"18\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Expected diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,17,1,17): warning Brace" + Environment.NewLine +
+                "    // /0/Test0.cs(1,17,1,17): warning Brace" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 17)," + Environment.NewLine +
                 Environment.NewLine +
                 "Actual diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
+                "    // /0/Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -91,11 +91,11 @@ namespace Microsoft.CodeAnalysis.Testing
                 "Expected diagnostic to start at column \"18\" was actually at column \"17\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Expected diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,18): warning Brace" + Environment.NewLine +
+                "    // /0/Test0.cs(1,18): warning Brace" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithLocation(1, 18)," + Environment.NewLine +
                 Environment.NewLine +
                 "Actual diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
+                "    // /0/Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 "new DiagnosticResult(HighlightBraceSpanAnalyzer.Brace)," + Environment.NewLine +
                 Environment.NewLine +
                 "Actual diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
+                "    // /0/Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 "new DiagnosticResult(HighlightBraceSpanAnalyzer.Brace)," + Environment.NewLine +
                 Environment.NewLine +
                 "Actual diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
+                "    // /0/Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -186,11 +186,11 @@ namespace Microsoft.CodeAnalysis.Testing
                 "Expected diagnostic to end at column \"18\" was actually at column \"17\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Expected diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,17,1,18): warning Brace" + Environment.NewLine +
+                "    // /0/Test0.cs(1,17,1,18): warning Brace" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 18)," + Environment.NewLine +
                 Environment.NewLine +
                 "Actual diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
+                "    // /0/Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 17)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
@@ -211,11 +211,11 @@ namespace Microsoft.CodeAnalysis.Testing
                 "Expected diagnostic to start at column \"18\" was actually at column \"17\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Expected diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,18): warning Brace" + Environment.NewLine +
+                "    // /0/Test0.cs(1,18): warning Brace" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithLocation(1, 18)," + Environment.NewLine +
                 Environment.NewLine +
                 "Actual diagnostic:" + Environment.NewLine +
-                "    // Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
+                "    // /0/Test0.cs(1,17): warning Brace: message" + Environment.NewLine +
                 "VerifyCS.Diagnostic().WithSpan(1, 17, 1, 17)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/AdditionalFilesFixTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.UnitTests/AdditionalFilesFixTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 "Mismatch between number of diagnostics returned, expected \"0\" actual \"1\"" + Environment.NewLine +
                 Environment.NewLine +
                 "Diagnostics:" + Environment.NewLine +
-                "// Test0.cs(1,24): error CS1513: } expected" + Environment.NewLine +
+                "// /0/Test0.cs(1,24): error CS1513: } expected" + Environment.NewLine +
                 "DiagnosticResult.CompilerError(\"CS1513\").WithSpan(1, 24, 1, 24)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);


### PR DESCRIPTION
This change allows **.editorconfig** support to work automatically when an **.editorconfig** file is added to the solution with the path **/.editorconfig**.