### PR TITLE
Support netcoreapp5.0

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -213,6 +213,7 @@ static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp11.g
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp20.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp21.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp30.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp31.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net20.Default.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net20.WindowsForms.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net40.Default.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -255,6 +255,7 @@ static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetStandard.NetStandar
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetStandard.NetStandard15.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetStandard.NetStandard16.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetStandard.NetStandard20.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetStandard.NetStandard21.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.TestFileMarkupParser.CreateTestFile(string code, System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<Microsoft.CodeAnalysis.Text.TextSpan>> spans, int? cursor) -> string
 static Microsoft.CodeAnalysis.Testing.TestFileMarkupParser.CreateTestFile(string code, System.Collections.Generic.IList<Microsoft.CodeAnalysis.Text.TextSpan> spans, int? cursor) -> string
 static Microsoft.CodeAnalysis.Testing.TestFileMarkupParser.CreateTestFile(string code, int cursor) -> string

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -212,6 +212,7 @@ static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp10.g
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp11.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp20.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp21.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp30.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net20.Default.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net20.WindowsForms.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net40.Default.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -214,6 +214,7 @@ static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp20.g
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp21.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp30.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp31.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp50.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net20.Default.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net20.WindowsForms.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net40.Default.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
@@ -802,6 +802,14 @@ namespace Microsoft.CodeAnalysis.Testing
                         "Microsoft.NETCore.App.Ref",
                         "3.1.0"),
                     Path.Combine("ref", "netcoreapp3.1"));
+
+            public static ReferenceAssemblies NetCoreApp50 { get; }
+                = new ReferenceAssemblies(
+                    "netcoreapp5.0",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref",
+                        "5.0.0-preview.1.20120.5"),
+                    Path.Combine("ref", "netcoreapp5.0"));
         }
 
         public static class NetStandard

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
@@ -786,6 +786,14 @@ namespace Microsoft.CodeAnalysis.Testing
             public static ReferenceAssemblies NetCoreApp21 { get; }
                 = new ReferenceAssemblies("netcoreapp2.1")
                 .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.NETCore.App", "2.1.13")));
+
+            public static ReferenceAssemblies NetCoreApp30 { get; }
+                = new ReferenceAssemblies(
+                    "netcoreapp3.0",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref",
+                        "3.0.0"),
+                    Path.Combine("ref", "netcoreapp3.0"));
         }
 
         public static class NetStandard

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
@@ -794,6 +794,14 @@ namespace Microsoft.CodeAnalysis.Testing
                         "Microsoft.NETCore.App.Ref",
                         "3.0.0"),
                     Path.Combine("ref", "netcoreapp3.0"));
+
+            public static ReferenceAssemblies NetCoreApp31 { get; }
+                = new ReferenceAssemblies(
+                    "netcoreapp3.1",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref",
+                        "3.1.0"),
+                    Path.Combine("ref", "netcoreapp3.1"));
         }
 
         public static class NetStandard

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
@@ -374,6 +374,7 @@ class TestClass {
         [Theory]
         [InlineData("netstandard1.1", Skip = "https://github.com/dotnet/roslyn-sdk/issues/471")]
         [InlineData("netstandard2.0", Skip = "https://github.com/dotnet/roslyn-sdk/issues/471")]
+        [InlineData("netstandard2.1", Skip = "https://github.com/dotnet/roslyn-sdk/issues/471")]
         [InlineData("net452")]
         [InlineData("net472")]
         public async Task TestRoslynCompilerUsage_1(string targetFramework)
@@ -399,6 +400,7 @@ class TestClass {
         [Theory]
         [InlineData("netstandard1.3")]
         [InlineData("netstandard2.0")]
+        [InlineData("netstandard2.1")]
         [InlineData("net46")]
         [InlineData("net472")]
         public async Task TestRoslynCompilerUsage_2(string targetFramework)
@@ -423,6 +425,7 @@ class TestClass {
 
         [Theory]
         [InlineData("netstandard2.0")]
+        [InlineData("netstandard2.1")]
         [InlineData("net472")]
         public async Task TestRoslynCompilerUsage_3(string targetFramework)
         {

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
@@ -404,6 +404,7 @@ class TestClass {
         [InlineData("net46")]
         [InlineData("net472")]
         [InlineData("netcoreapp3.0")]
+        [InlineData("netcoreapp3.1")]
         public async Task TestRoslynCompilerUsage_2(string targetFramework)
         {
             var testCode = @"
@@ -428,6 +429,7 @@ class TestClass {
         [InlineData("netstandard2.0")]
         [InlineData("netstandard2.1")]
         [InlineData("net472")]
+        [InlineData("netcoreapp3.1")]
         public async Task TestRoslynCompilerUsage_3(string targetFramework)
         {
             var testCode = @"

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
@@ -403,6 +403,7 @@ class TestClass {
         [InlineData("netstandard2.1")]
         [InlineData("net46")]
         [InlineData("net472")]
+        [InlineData("netcoreapp3.0")]
         public async Task TestRoslynCompilerUsage_2(string targetFramework)
         {
             var testCode = @"

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/CompilerErrorTests.cs
@@ -405,6 +405,7 @@ class TestClass {
         [InlineData("net472")]
         [InlineData("netcoreapp3.0")]
         [InlineData("netcoreapp3.1")]
+        [InlineData("netcoreapp5.0")]
         public async Task TestRoslynCompilerUsage_2(string targetFramework)
         {
             var testCode = @"
@@ -430,6 +431,7 @@ class TestClass {
         [InlineData("netstandard2.1")]
         [InlineData("net472")]
         [InlineData("netcoreapp3.1")]
+        [InlineData("netcoreapp5.0")]
         public async Task TestRoslynCompilerUsage_3(string targetFramework)
         {
             var testCode = @"

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
@@ -398,6 +398,14 @@ namespace Microsoft.CodeAnalysis.Testing
             Assert.NotEmpty(resolved);
         }
 
+        [Fact]
+        public async Task ResolveReferenceAssemblies_NetCoreApp30()
+        {
+            var referenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp30;
+            var resolved = await referenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
+            Assert.NotEmpty(resolved);
+        }
+
         [Theory]
         [InlineData("net40")]
         [InlineData("net45")]
@@ -414,6 +422,7 @@ namespace Microsoft.CodeAnalysis.Testing
         [InlineData("netcoreapp1.1")]
         [InlineData("netcoreapp2.0")]
         [InlineData("netcoreapp2.1")]
+        [InlineData("netcoreapp3.0")]
         [InlineData("netstandard1.0")]
         [InlineData("netstandard1.1")]
         [InlineData("netstandard1.2")]
@@ -460,6 +469,7 @@ class TestClass {
                 "netcoreapp1.1" => ReferenceAssemblies.NetCore.NetCoreApp11,
                 "netcoreapp2.0" => ReferenceAssemblies.NetCore.NetCoreApp20,
                 "netcoreapp2.1" => ReferenceAssemblies.NetCore.NetCoreApp21,
+                "netcoreapp3.0" => ReferenceAssemblies.NetCore.NetCoreApp30,
                 "netstandard1.0" => ReferenceAssemblies.NetStandard.NetStandard10,
                 "netstandard1.1" => ReferenceAssemblies.NetStandard.NetStandard11,
                 "netstandard1.2" => ReferenceAssemblies.NetStandard.NetStandard12,

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
@@ -414,6 +414,14 @@ namespace Microsoft.CodeAnalysis.Testing
             Assert.NotEmpty(resolved);
         }
 
+        [Fact]
+        public async Task ResolveReferenceAssemblies_NetCoreApp50()
+        {
+            var referenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50;
+            var resolved = await referenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
+            Assert.NotEmpty(resolved);
+        }
+
         [Theory]
         [InlineData("net40")]
         [InlineData("net45")]
@@ -432,6 +440,7 @@ namespace Microsoft.CodeAnalysis.Testing
         [InlineData("netcoreapp2.1")]
         [InlineData("netcoreapp3.0")]
         [InlineData("netcoreapp3.1")]
+        [InlineData("netcoreapp5.0")]
         [InlineData("netstandard1.0")]
         [InlineData("netstandard1.1")]
         [InlineData("netstandard1.2")]
@@ -480,6 +489,7 @@ class TestClass {
                 "netcoreapp2.1" => ReferenceAssemblies.NetCore.NetCoreApp21,
                 "netcoreapp3.0" => ReferenceAssemblies.NetCore.NetCoreApp30,
                 "netcoreapp3.1" => ReferenceAssemblies.NetCore.NetCoreApp31,
+                "netcoreapp5.0" => ReferenceAssemblies.NetCore.NetCoreApp50,
                 "netstandard1.0" => ReferenceAssemblies.NetStandard.NetStandard10,
                 "netstandard1.1" => ReferenceAssemblies.NetStandard.NetStandard11,
                 "netstandard1.2" => ReferenceAssemblies.NetStandard.NetStandard12,

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
@@ -359,6 +359,14 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         [Fact]
+        public async Task ResolveReferenceAssemblies_NetStandard21()
+        {
+            var referenceAssemblies = ReferenceAssemblies.NetStandard.NetStandard21;
+            var resolved = await referenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
+            Assert.NotEmpty(resolved);
+        }
+
+        [Fact]
         public async Task ResolveReferenceAssemblies_NetCoreApp10()
         {
             var referenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp10;
@@ -414,6 +422,7 @@ namespace Microsoft.CodeAnalysis.Testing
         [InlineData("netstandard1.5")]
         [InlineData("netstandard1.6")]
         [InlineData("netstandard2.0")]
+        [InlineData("netstandard2.1")]
         public async Task ResolveHashSetExceptInNet20(string targetFramework)
         {
             var testCode = @"
@@ -459,6 +468,7 @@ class TestClass {
                 "netstandard1.5" => ReferenceAssemblies.NetStandard.NetStandard15,
                 "netstandard1.6" => ReferenceAssemblies.NetStandard.NetStandard16,
                 "netstandard2.0" => ReferenceAssemblies.NetStandard.NetStandard20,
+                "netstandard2.1" => ReferenceAssemblies.NetStandard.NetStandard21,
                 null => throw new ArgumentNullException(nameof(targetFramework)),
                 _ => throw new NotSupportedException($"Target framework '{targetFramework}' is not currently supported."),
             };

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
@@ -406,6 +406,14 @@ namespace Microsoft.CodeAnalysis.Testing
             Assert.NotEmpty(resolved);
         }
 
+        [Fact]
+        public async Task ResolveReferenceAssemblies_NetCoreApp31()
+        {
+            var referenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp31;
+            var resolved = await referenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
+            Assert.NotEmpty(resolved);
+        }
+
         [Theory]
         [InlineData("net40")]
         [InlineData("net45")]
@@ -423,6 +431,7 @@ namespace Microsoft.CodeAnalysis.Testing
         [InlineData("netcoreapp2.0")]
         [InlineData("netcoreapp2.1")]
         [InlineData("netcoreapp3.0")]
+        [InlineData("netcoreapp3.1")]
         [InlineData("netstandard1.0")]
         [InlineData("netstandard1.1")]
         [InlineData("netstandard1.2")]
@@ -470,6 +479,7 @@ class TestClass {
                 "netcoreapp2.0" => ReferenceAssemblies.NetCore.NetCoreApp20,
                 "netcoreapp2.1" => ReferenceAssemblies.NetCore.NetCoreApp21,
                 "netcoreapp3.0" => ReferenceAssemblies.NetCore.NetCoreApp30,
+                "netcoreapp3.1" => ReferenceAssemblies.NetCore.NetCoreApp31,
                 "netstandard1.0" => ReferenceAssemblies.NetStandard.NetStandard10,
                 "netstandard1.1" => ReferenceAssemblies.NetStandard.NetStandard11,
                 "netstandard1.2" => ReferenceAssemblies.NetStandard.NetStandard12,


### PR DESCRIPTION
Support **netcoreapp5.0** (using the latest available package [5.0.0-preview.1.20120.5](https://www.nuget.org/packages/Microsoft.NETCore.App.Ref/5.0.0-preview.1.20120.5)).

Builds on #488 