### PR TITLE
Update VSSDK dependencies to Visual Studio 16.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,6 +50,7 @@
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <SystemCompositionVersion>1.1.0</SystemCompositionVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
+    <DiffPlexVersion>1.4.4</DiffPlexVersion>
     <!-- Testing -->
     <MicrosoftCodeAnalysis2PrimaryTestVersion>2.6.1</MicrosoftCodeAnalysis2PrimaryTestVersion>
     <MicrosoftCodeAnalysis3PrimaryTestVersion>3.3.1</MicrosoftCodeAnalysis3PrimaryTestVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,24 +27,25 @@
     <VSSDKTemplateWizardInterfaceVersion>12.0.4</VSSDKTemplateWizardInterfaceVersion>
     <EnvDTEVersion>8.0.1</EnvDTEVersion>
     <EnvDTE80Version>8.0.0</EnvDTE80Version>
-    <MicrosoftVisualStudioComponentModelHostVersion>14.0.25424</MicrosoftVisualStudioComponentModelHostVersion>
-    <MicrosoftVisualStudioCoreUtilityVersion>16.2.45</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVisualStudioEditorVersion>14.3.25407</MicrosoftVisualStudioEditorVersion>
-    <MicrosoftVisualStudioLanguageStandardClassificationVersion>14.3.25407</MicrosoftVisualStudioLanguageStandardClassificationVersion>
-    <MicrosoftVisualStudioOLEInteropVersion>7.10.6070</MicrosoftVisualStudioOLEInteropVersion>
-    <MicrosoftVisualStudioShell140Version>14.3.25407</MicrosoftVisualStudioShell140Version>
-    <MicrosoftVisualStudioShellInteropVersion>7.10.6071</MicrosoftVisualStudioShellInteropVersion>
-    <MicrosoftVisualStudioShellInterop80Version>8.0.50727</MicrosoftVisualStudioShellInterop80Version>
-    <MicrosoftVisualStudioShellInterop90Version>9.0.30729</MicrosoftVisualStudioShellInterop90Version>
-    <MicrosoftVisualStudioShellInterop100Version>10.0.30319</MicrosoftVisualStudioShellInterop100Version>
-    <MicrosoftVisualStudioShellInterop110Version>11.0.61030</MicrosoftVisualStudioShellInterop110Version>
-    <MicrosoftVisualStudioTextDataVersion>16.2.45</MicrosoftVisualStudioTextDataVersion>
-    <MicrosoftVisualStudioTextLogicVersion>16.2.45</MicrosoftVisualStudioTextLogicVersion>
-    <MicrosoftVisualStudioTextManagerInteropVersion>7.10.6070</MicrosoftVisualStudioTextManagerInteropVersion>
-    <MicrosoftVisualStudioTextUIVersion>16.2.45</MicrosoftVisualStudioTextUIVersion>
-    <MicrosoftVisualStudioTextUIWpfVersion>16.2.45</MicrosoftVisualStudioTextUIWpfVersion>
-    <MicrosoftVisualStudioUtilitiesVersion>14.3.25407</MicrosoftVisualStudioUtilitiesVersion>
-    <MicrosoftVisualStudioThreadingVersion>16.3.13</MicrosoftVisualStudioThreadingVersion>
+    <MicrosoftVisualStudioComponentModelHostVersion>16.4.280</MicrosoftVisualStudioComponentModelHostVersion>
+    <MicrosoftVisualStudioCoreUtilityVersion>16.4.280</MicrosoftVisualStudioCoreUtilityVersion>
+    <MicrosoftVisualStudioEditorVersion>16.4.280</MicrosoftVisualStudioEditorVersion>
+    <MicrosoftVisualStudioLanguageStandardClassificationVersion>16.4.280</MicrosoftVisualStudioLanguageStandardClassificationVersion>
+    <MicrosoftVisualStudioOLEInteropVersion>7.10.6071</MicrosoftVisualStudioOLEInteropVersion>
+    <MicrosoftVisualStudioShell150Version>16.5.29911.84</MicrosoftVisualStudioShell150Version>
+    <MicrosoftVisualStudioShellInteropVersion>7.10.6072</MicrosoftVisualStudioShellInteropVersion>
+    <MicrosoftVisualStudioShellInterop80Version>8.0.50728</MicrosoftVisualStudioShellInterop80Version>
+    <MicrosoftVisualStudioShellInterop90Version>9.0.30730</MicrosoftVisualStudioShellInterop90Version>
+    <MicrosoftVisualStudioShellInterop100Version>10.0.30320</MicrosoftVisualStudioShellInterop100Version>
+    <MicrosoftVisualStudioShellInterop110Version>11.0.61031</MicrosoftVisualStudioShellInterop110Version>
+    <MicrosoftVisualStudioTextDataVersion>16.4.280</MicrosoftVisualStudioTextDataVersion>
+    <MicrosoftVisualStudioTextLogicVersion>16.4.280</MicrosoftVisualStudioTextLogicVersion>
+    <MicrosoftVisualStudioTextManagerInteropVersion>7.10.6071</MicrosoftVisualStudioTextManagerInteropVersion>
+    <MicrosoftVisualStudioTextUIVersion>16.4.280</MicrosoftVisualStudioTextUIVersion>
+    <MicrosoftVisualStudioTextUIWpfVersion>16.4.280</MicrosoftVisualStudioTextUIWpfVersion>
+    <MicrosoftVisualStudioUtilitiesVersion>16.5.29903.186</MicrosoftVisualStudioUtilitiesVersion>
+    <MicrosoftVisualStudioThreadingVersion>16.5.132</MicrosoftVisualStudioThreadingVersion>
+    <StreamJsonRpcVersion>2.3.99</StreamJsonRpcVersion>
     <!-- Libs -->
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <SystemCompositionVersion>1.1.0</SystemCompositionVersion>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -56,6 +56,6 @@
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetApiVersion)" PrivateAssets="compile" />
 
     <!-- Use PrivateAssets=compile to avoid exposing our DiffPlex dependency downstream as public API. -->
-    <PackageReference Include="DiffPlex" Version="1.4.4" PrivateAssets="compile" />
+    <PackageReference Include="DiffPlex" Version="$(DiffPlexVersion)" PrivateAssets="compile" />
   </ItemGroup>
 </Project>

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/Roslyn.SDK.Template.Wizard.csproj
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/Roslyn.SDK.Template.Wizard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="$(MicrosoftVisualStudioShell140Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="$(MicrosoftVisualStudioShellInteropVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="$(MicrosoftVisualStudioShellInterop80Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop90Version)" />
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="VSLangProj" Version="$(VSLangProjVersion)" />
     <PackageReference Include="VSSDK.TemplateWizardInterface" Version="$(VSSDKTemplateWizardInterfaceVersion)" />
   </ItemGroup>

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKAnalyzerTemplateWizard.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKAnalyzerTemplateWizard.cs
@@ -13,7 +13,9 @@ public class RoslynSDKAnalyzerTemplateWizard : RoslynSDKChildTemplateWizard
         // included in the VSIX. The only way to solve this is to have th wizard mark the
         // assemblies as copy local false.
         Project = project;
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
         if (project.Object is VSProject vsProject)
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
         {
             if (vsProject.References != null)
             {

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKChildTemplateWizard.InterfaceMembers.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKChildTemplateWizard.InterfaceMembers.cs
@@ -37,7 +37,9 @@ public partial class RoslynSDKChildTemplateWizard : IWizard
         WriteOutBetaNugetSource("dotnet.myget.org roslyn", "https://dotnet.myget.org/F/roslyn/api/v3/index.json");
         WriteOutBetaNugetSource("dotnet.myget.org roslyn-analyzers", "https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json");
         NugetWizard.RunStarted(automationObject, replacementsDictionary, runKind, customParams);
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
         OnRunStarted(automationObject as DTE, replacementsDictionary, runKind, customParams);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
     }
 
     private void WriteOutBetaNugetSource(string key, string value)

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKRootTemplateWizard.InterfaceMembers.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKRootTemplateWizard.InterfaceMembers.cs
@@ -19,7 +19,9 @@ public partial class RoslynSDKRootTemplateWizard : IWizard
     {
         WriteOutBetaNugetSource("dotnet.myget.org roslyn", "https://dotnet.myget.org/F/roslyn/api/v3/index.json");
         WriteOutBetaNugetSource("dotnet.myget.org roslyn-analyzers", "https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json");
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
         OnRunStarted(automationObject as DTE, replacementsDictionary, runKind, customParams);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
     }
 
     private void WriteOutBetaNugetSource(string key, string value)

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKTestTemplateWizard.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKTestTemplateWizard.cs
@@ -8,7 +8,9 @@ public class RoslynSDKTestTemplateWizard : RoslynSDKChildTemplateWizard
     public override void OnProjectFinishedGenerating(Project project)
     {
         // There is no good way for the test project to reference the main project, so we will use the wizard.
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
         if (project.Object is VSProject vsProject)
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
         {
             var referenceProject = vsProject.References.AddProject(RoslynSDKAnalyzerTemplateWizard.Project);
         }

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKVsixTemplateWizardSecondProject.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKVsixTemplateWizardSecondProject.cs
@@ -9,10 +9,12 @@ public class RoslynSDKVsixTemplateWizardSecondProject : RoslynSDKTestTemplateWiz
         base.OnProjectFinishedGenerating(project);
 
         // set the VSIX project to be the starting project
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
         var dte = project.DTE;
         if (dte.Solution.Projects.Count == 2)
         {
             dte.Solution.Properties.Item("StartupProject").Value = project.Name;
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
         }
     }
 }

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKVsixTemplateWizardThirdProject.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/RoslynSDKVsixTemplateWizardThirdProject.cs
@@ -9,10 +9,12 @@ public class RoslynSDKVsixTemplateWizardThirdProject : RoslynSDKTestTemplateWiza
         base.OnProjectFinishedGenerating(project);
 
         // set the VSIX project to be the starting project
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
         var dte = project.DTE;
         if (dte.Solution.Projects.Count == 3)
         {
             dte.Solution.Properties.Item("StartupProject").Value = project.Name;
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
         }
     }
 }

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/Roslyn.SyntaxVisualizer.Control.csproj
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/Roslyn.SyntaxVisualizer.Control.csproj
@@ -16,10 +16,11 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersionVS2019)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVisualBasicVersionVS2019)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="$(MicrosoftVisualStudioShell140Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop110Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
@@ -5,7 +5,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.14.0"
+             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="300">
     <UserControl.Resources>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/Roslyn.SyntaxVisualizer.Extension.csproj
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/Roslyn.SyntaxVisualizer.Extension.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="$(MicrosoftVisualStudioShell140Version)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="$(MicrosoftVisualStudioShellInteropVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="$(MicrosoftVisualStudioShellInterop80Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop90Version)" />
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
+    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
   </ItemGroup>
 
   <!-- Project References -->

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml
@@ -5,7 +5,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
+             xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:s="clr-namespace:Roslyn.SyntaxVisualizer.Control;assembly=Roslyn.SyntaxVisualizer.Control"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml.cs
@@ -262,8 +262,8 @@ namespace Roslyn.SyntaxVisualizer.Extension
                     if (document != null)
                     {
                         // Get the SyntaxTree and SemanticModel corresponding to the Document.
-                        activeSyntaxTree = document.GetSyntaxTreeAsync().Result;
-                        var activeSemanticModel = document.GetSemanticModelAsync().Result;
+                        activeSyntaxTree = ThreadHelper.JoinableTaskFactory.Run(() => document.GetSyntaxTreeAsync());
+                        var activeSemanticModel = ThreadHelper.JoinableTaskFactory.Run(() => document.GetSemanticModelAsync());
 
                         // Display the SyntaxTree.
                         if (contentType.IsOfType(VisualBasicContentType) || contentType.IsOfType(CSharpContentType))

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml.cs
@@ -47,7 +47,9 @@ namespace Roslyn.SyntaxVisualizer.Extension
             {
 
                 // Only enable this feature if the Visual Studio package for DGML is installed.
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                 shellService.IsPackageInstalled(GuidList.GuidProgressionPkg, out var canDisplayDirectedSyntaxGraph);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                 if (Convert.ToBoolean(canDisplayDirectedSyntaxGraph))
                 {
                     syntaxVisualizer.SyntaxNodeDirectedGraphRequested += DisplaySyntaxNodeDgml;
@@ -124,8 +126,10 @@ namespace Roslyn.SyntaxVisualizer.Extension
             {
                 if (globalServiceProvider == null)
                 {
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                     globalServiceProvider = (Microsoft.VisualStudio.OLE.Interop.IServiceProvider)Package.GetGlobalService(
                         typeof(Microsoft.VisualStudio.OLE.Interop.IServiceProvider));
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                 }
 
                 return globalServiceProvider;
@@ -153,7 +157,9 @@ namespace Roslyn.SyntaxVisualizer.Extension
             var ptr = IntPtr.Zero;
             object service = null;
 
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
             if (serviceProvider.QueryService(ref guidService, ref guidInterface, out ptr) == 0 &&
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                 ptr != IntPtr.Zero)
             {
                 try
@@ -219,7 +225,9 @@ namespace Roslyn.SyntaxVisualizer.Extension
         {
             if (RunningDocumentTable != null)
             {
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                 RunningDocumentTable.AdviseRunningDocTableEvents(this, out runningDocumentTableCookie);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
             }
         }
 
@@ -227,7 +235,9 @@ namespace Roslyn.SyntaxVisualizer.Extension
         {
             if (runningDocumentTableCookie != 0)
             {
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                 runningDocumentTable.UnadviseRunningDocTableEvents(runningDocumentTableCookie);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                 runningDocumentTableCookie = 0;
             }
         }
@@ -449,10 +459,14 @@ namespace Roslyn.SyntaxVisualizer.Extension
             // contents of the file on disk with the new directed syntax graph and load 
             // this new graph into the already open view of the file.
             if (VsShellUtilities.IsDocumentOpen(
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                 ServiceProvider.GlobalProvider, dgmlFilePath, GuidList.GuidVsDesignerViewKind,
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                 out var docUIHierarchy, out var docItemId, out var docWindowFrame) && docWindowFrame != null)
             {
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                 if (RunningDocumentTable.FindAndLockDocument((uint)_VSRDTFLAGS.RDT_NoLock, dgmlFilePath,
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                                                              out var docHierarchy, out docItemId,
                                                              out var docDataIUnknownPointer,
                                                              out cookie) == VSConstants.S_OK)
@@ -465,24 +479,32 @@ namespace Roslyn.SyntaxVisualizer.Extension
                         try
                         {
                             var persistDocDataService =
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                                 (IVsPersistDocData)Marshal.GetObjectForIUnknown(persistDocDataServicePointer);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
 
                             if (persistDocDataService != null)
                             {
                                 // The below call ensures that there are no pop-ups from Visual Studio
                                 // prompting the user to reload the file each time it is changed.
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                                 FileChangeService.IgnoreFile(0, dgmlFilePath, TRUE);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
 
                                 // Update the file on disk with the new directed syntax graph.
                                 dgml.Save(dgmlFilePath);
 
                                 // The below calls ensure that the file is refreshed inside Visual Studio
                                 // so that the latest contents are displayed to the user.
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                                 FileChangeService.SyncFile(dgmlFilePath);
                                 persistDocDataService.ReloadDocData((uint)_VSRELOADDOCDATA.RDD_IgnoreNextFileChange);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
 
                                 // Make sure the directed syntax graph window is visible but don't give it focus.
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                                 docWindowFrame.ShowNoActivate();
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                             }
                         }
                         finally
@@ -499,13 +521,17 @@ namespace Roslyn.SyntaxVisualizer.Extension
 
                 // Open the new directed syntax graph in the 'design' view.
                 VsShellUtilities.OpenDocument(
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                     ServiceProvider.GlobalProvider, dgmlFilePath, GuidList.GuidVsDesignerViewKind,
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                     out docUIHierarchy, out docItemId, out docWindowFrame);
 
                 // Register event handler to ensure that directed syntax graph file is deleted when the solution is closed.
                 // This ensures that the file won't be persisted in the .suo file and that it therefore won't get re-opened
                 // when the solution is re-opened.
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                 SolutionService.AdviseSolutionEvents(this, out cookie);
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
             }
         }
 

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerExtensionPackage.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerExtensionPackage.cs
@@ -55,8 +55,10 @@ namespace Roslyn.SyntaxVisualizer.Extension
                 throw new NotSupportedException(Resources.CanNotCreateWindow);
             }
 
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
             var windowFrame = (IVsWindowFrame)window.Frame;
             Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
         }
 
         // Overridden Package Implementation.
@@ -73,7 +75,9 @@ namespace Roslyn.SyntaxVisualizer.Extension
             base.Initialize();
 
             // Add our command handlers for menu (commands must exist in the .vsct file).
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
             if (GetService(typeof(IMenuCommandService)) is OleMenuCommandService mcs)
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
             {
                 // Create the command for the tool window.
                 var toolwndCommandID = new CommandID(GuidList.GuidSyntaxVisualizerExtensionCmdSet, (int)PkgCmdIDList.CmdIDRoslynSyntaxVisualizer);


### PR DESCRIPTION
Issue #539 has been filed to address the diagnostics which are now suppressed.