### PR TITLE
Fix MissingManifestResourceException in DgmlHelper

### DIFF
--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.DgmlHelper/Resources.Designer.vb
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.DgmlHelper/Resources.Designer.vb
@@ -43,7 +43,7 @@ Namespace My.Resources
         Friend Shared ReadOnly Property ResourceManager() As Global.System.Resources.ResourceManager
             Get
                 If Object.ReferenceEquals(resourceMan, Nothing) Then
-                    Dim temp As Global.System.Resources.ResourceManager = New Global.System.Resources.ResourceManager("Resources", GetType(Resources).Assembly)
+                    Dim temp As Global.System.Resources.ResourceManager = New Global.System.Resources.ResourceManager("Roslyn.SyntaxVisualizer.DgmlHelper.Resources", GetType(Resources).Assembly)
                     resourceMan = temp
                 End If
                 Return resourceMan


### PR DESCRIPTION
Fixes a crash of the Directed Syntax Graph by using the correct base name for the ResourceManager.
Props to @liuxilu for nudging me in the right direction.