### PR TITLE
Add regression test for DgmlHelper resources

### DIFF
--- a/Roslyn-SDK.sln
+++ b/Roslyn-SDK.sln
@@ -147,6 +147,10 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.Visu
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.NUnit.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.NUnit.UnitTests\Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.NUnit.UnitTests.vbproj", "{023B21F8-09EC-4A67-8AAA-3D110231E7EB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VisualStudio.Roslyn.SDK", "VisualStudio.Roslyn.SDK", "{A3AF556C-276C-49BA-A9ED-E7D42FECAA46}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.SDK.UnitTests", "tests\VisualStudio.Roslyn.SDK\Roslyn.SDK.UnitTests\Roslyn.SDK.UnitTests.csproj", "{11B1F856-9025-4A4C-B90D-B1237743B672}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -417,6 +421,10 @@ Global
 		{023B21F8-09EC-4A67-8AAA-3D110231E7EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{023B21F8-09EC-4A67-8AAA-3D110231E7EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{023B21F8-09EC-4A67-8AAA-3D110231E7EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11B1F856-9025-4A4C-B90D-B1237743B672}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11B1F856-9025-4A4C-B90D-B1237743B672}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11B1F856-9025-4A4C-B90D-B1237743B672}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11B1F856-9025-4A4C-B90D-B1237743B672}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -492,6 +500,8 @@ Global
 		{19DB3193-B920-4C62-ADC1-5071AE989AA5} = {9905147E-CC1F-42A0-BD27-05586C583DF7}
 		{4617ED77-9564-4A06-8F9B-92E5C5523FE1} = {9905147E-CC1F-42A0-BD27-05586C583DF7}
 		{023B21F8-09EC-4A67-8AAA-3D110231E7EB} = {9905147E-CC1F-42A0-BD27-05586C583DF7}
+		{A3AF556C-276C-49BA-A9ED-E7D42FECAA46} = {8C343846-5F9F-4033-9B52-B44C61962449}
+		{11B1F856-9025-4A4C-B90D-B1237743B672} = {A3AF556C-276C-49BA-A9ED-E7D42FECAA46}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {56695AA9-EA80-47A7-8562-E51285906C54}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.DgmlHelper/Roslyn.SyntaxVisualizer.DgmlHelper.vbproj
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.DgmlHelper/Roslyn.SyntaxVisualizer.DgmlHelper.vbproj
@@ -4,6 +4,10 @@
     <IsProductComponent>false</IsProductComponent>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Roslyn.SDK.UnitTests" />
+  </ItemGroup>
+
   <!-- Package References -->
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersionVS2019)" />

--- a/tests/VisualStudio.Roslyn.SDK/Directory.Build.props
+++ b/tests/VisualStudio.Roslyn.SDK/Directory.Build.props
@@ -1,0 +1,48 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>  
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);NU5125;NU3005</NoWarn>
+
+    <!-- Opt-out repo features -->
+    <UsingToolXliff>false</UsingToolXliff>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(Language)' == 'VB'">
+      <PropertyGroup>
+        <LangVersion>15.5</LangVersion>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="'$(Language)' == 'C#'">
+      <PropertyGroup>
+        <LangVersion>8</LangVersion>
+      </PropertyGroup>
+
+      <!-- Nullable reference types -->
+      <PropertyGroup>
+        <Nullable>enable</Nullable>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <!-- StyleCop Analyzers configuration -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\..\RoslynSDK.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="all" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\stylecop.json" Link="stylecop.json" />
+    <None Include="$(CodeAnalysisRuleSet)" Condition="'$(CodeAnalysisRuleSet)' != ''" Link="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/VisualStudio.Roslyn.SDK/Directory.Build.targets
+++ b/tests/VisualStudio.Roslyn.SDK/Directory.Build.targets
@@ -1,0 +1,8 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+  <ItemGroup Condition="'$(UsingToolXUnit)' == 'true' and '$(IsUnitTestProject)' == 'true'">
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+</Project>

--- a/tests/VisualStudio.Roslyn.SDK/Roslyn.SDK.UnitTests/ResourceLocationTests.cs
+++ b/tests/VisualStudio.Roslyn.SDK/Roslyn.SDK.UnitTests/ResourceLocationTests.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    public class ResourceLocationTests
+    {
+        [Fact]
+        [WorkItem(327, "https://github.com/dotnet/roslyn-sdk/issues/327")]
+        public void TestDgmlHelperResources()
+        {
+            Assert.NotNull(Roslyn.SyntaxVisualizer.DgmlHelper.My.Resources.Resources.SyntaxNodeLabel);
+        }
+    }
+}

--- a/tests/VisualStudio.Roslyn.SDK/Roslyn.SDK.UnitTests/Roslyn.SDK.UnitTests.csproj
+++ b/tests/VisualStudio.Roslyn.SDK/Roslyn.SDK.UnitTests/Roslyn.SDK.UnitTests.csproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <RootNamespace>Microsoft.CodeAnalysis.Testing</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.Testing.Utilities\WorkItemAttribute.cs" Link="WorkItemAttribute.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\VisualStudio.Roslyn.SDK\Roslyn.SDK\Roslyn.SDK.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The test is expected to fail in this pull request, in order to validate that the new unit test project is included in the build.

See #327