### PR TITLE
Add custom verifiers to the test project

### DIFF
--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Test.csproj
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Test.csproj
@@ -11,9 +11,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.0.1-beta1.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.0.1-beta1.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.0.1-beta1.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.0.1-beta1.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.0.1-beta1.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.0.1-beta1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Test.vstemplate
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Test.vstemplate
@@ -19,6 +19,21 @@
   <TemplateContent>
     <Project TargetFileName="$safeprojectname$.csproj" File="Test.csproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="$saferootidentifiername$UnitTests.cs">UnitTests.cs</ProjectItem>
+
+      <!-- File names are shortened to avoid PathTooLongException on project creation... -->
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpAnalyzerVerifier`1.cs">Verifiers\CSAnalyzerVerifier`1.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpAnalyzerVerifier`1+Test.cs">Verifiers\CSAnalyzerVerifier`1+Test.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpCodeFixVerifier`2.cs">Verifiers\CSCodeFixVerifier`2.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpCodeFixVerifier`2+Test.cs">Verifiers\CSCodeFixVerifier`2+Test.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpCodeRefactoringVerifier`1.cs">Verifiers\CSRefactoringVerifier`1.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpCodeRefactoringVerifier`1+Test.cs">Verifiers\CSRefactoringVerifier`1+Test.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpVerifierHelper.cs">Verifiers\CSVerifierHelper.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicAnalyzerVerifier`1.cs">Verifiers\VBAnalyzerVerifier`1.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicAnalyzerVerifier`1+Test.cs">Verifiers\VBAnalyzerVerifier`1+Test.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicCodeFixVerifier`2.cs">Verifiers\VBCodeFixVerifier`2.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicCodeFixVerifier`2+Test.cs">Verifiers\VBCodeFixVerifier`2+Test.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicCodeRefactoringVerifier`1.cs">Verifiers\VBRefactoringVerifier`1.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicCodeRefactoringVerifier`1+Test.cs">Verifiers\VBRefactoringVerifier`1+Test.cs</ProjectItem>
     </Project>
   </TemplateContent>
   <WizardExtension>

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/UnitTests.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/UnitTests.cs
@@ -1,19 +1,13 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Threading;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
-using $saferootprojectname$;
-using Verify = Microsoft.CodeAnalysis.CSharp.Testing.MSTest.CodeFixVerifier<
+using VerifyCS = $safeprojectname$.CSharpCodeFixVerifier<
     $saferootprojectname$.$saferootidentifiername$Analyzer,
     $saferootprojectname$.$saferootidentifiername$CodeFixProvider>;
 
 namespace $safeprojectname$
 {
     [TestClass]
-    public class UnitTest
+    public class $saferootidentifiername$UnitTest
     {
         //No diagnostics expected to show up
         [TestMethod]
@@ -21,7 +15,7 @@ namespace $safeprojectname$
         {
             var test = @"";
 
-            await Verify.VerifyAnalyzerAsync(test);
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         //Diagnostic and CodeFix both triggered and checked for
@@ -38,7 +32,7 @@ namespace $safeprojectname$
 
     namespace ConsoleApplication1
     {
-        class TypeName
+        class {|#0:TypeName|}
         {   
         }
     }";
@@ -58,8 +52,8 @@ namespace $safeprojectname$
         }
     }";
 
-            var expected = Verify.Diagnostic("$saferootidentifiername$").WithLocation(11, 15).WithArguments("TypeName");
-            await Verify.VerifyCodeFixAsync(test, expected, fixtest);
+            var expected = VerifyCS.Diagnostic("$saferootidentifiername$").WithLocation(0).WithArguments("TypeName");
+            await VerifyCS.VerifyCodeFixAsync(test, expected, fixtest);
         }
     }
 }

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSAnalyzerVerifier`1+Test.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSAnalyzerVerifier`1+Test.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace $safeprojectname$
+{
+    public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public class Test : CSharpAnalyzerTest<TAnalyzer, MSTestVerifier>
+        {
+            public Test()
+            {
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    return solution;
+                });
+            }
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSAnalyzerVerifier`1.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSAnalyzerVerifier`1.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace $safeprojectname$
+{
+    public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSCodeFixVerifier`2+Test.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSCodeFixVerifier`2+Test.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace $safeprojectname$
+{
+    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, MSTestVerifier>
+        {
+            public Test()
+            {
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    return solution;
+                });
+            }
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSCodeFixVerifier`2.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSCodeFixVerifier`2.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace $safeprojectname$
+{
+    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSRefactoringVerifier`1+Test.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSRefactoringVerifier`1+Test.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace $safeprojectname$
+{
+    public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
+        where TCodeRefactoring : CodeRefactoringProvider, new()
+    {
+        public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, MSTestVerifier>
+        {
+            public Test()
+            {
+                SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    return solution;
+                });
+            }
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSRefactoringVerifier`1.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSRefactoringVerifier`1.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace $safeprojectname$
+{
+    public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
+        where TCodeRefactoring : CodeRefactoringProvider, new()
+    {
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
+        public static async Task VerifyRefactoringAsync(string source, string fixedSource)
+        {
+            await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+        }
+
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
+        {
+            await VerifyRefactoringAsync(source, new[] { expected }, fixedSource);
+        }
+
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSVerifierHelper.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/CSVerifierHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace $safeprojectname$
+{
+    internal static class CSharpVerifierHelper
+    {
+        /// <summary>
+        /// By default, the compiler reports diagnostics for nullable reference types at
+        /// <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating
+        /// diagnostics at <see cref="DiagnosticSeverity.Error"/>. This map contains all compiler diagnostic IDs
+        /// related to nullability mapped to <see cref="ReportDiagnostic.Error"/>, which is then used to enable all
+        /// of these warnings for default validation during analyzer and code fix tests.
+        /// </summary>
+        internal static ImmutableDictionary<string, ReportDiagnostic> NullableWarnings { get; } = GetNullableWarningsFromCompiler();
+
+        private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
+        {
+            string[] args = { "/warnaserror:nullable" };
+            var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
+            var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
+
+            // Workaround for https://github.com/dotnet/roslyn/issues/41610
+            nullableWarnings = nullableWarnings
+                .SetItem("CS8632", ReportDiagnostic.Error)
+                .SetItem("CS8669", ReportDiagnostic.Error);
+
+            return nullableWarnings;
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBAnalyzerVerifier`1+Test.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBAnalyzerVerifier`1+Test.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace $safeprojectname$
+{
+    public static partial class VisualBasicAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public class Test : VisualBasicAnalyzerTest<TAnalyzer, MSTestVerifier>
+        {
+            public Test()
+            {
+            }
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBAnalyzerVerifier`1.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBAnalyzerVerifier`1.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace $safeprojectname$
+{
+    public static partial class VisualBasicAnalyzerVerifier<TAnalyzer>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => VisualBasicAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => VisualBasicAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => VisualBasicAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBCodeFixVerifier`2+Test.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBCodeFixVerifier`2+Test.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace $safeprojectname$
+{
+    public static partial class VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        public class Test : VisualBasicCodeFixTest<TAnalyzer, TCodeFix, MSTestVerifier>
+        {
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBCodeFixVerifier`2.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBCodeFixVerifier`2.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace $safeprojectname$
+{
+    public static partial class VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix>
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TCodeFix : CodeFixProvider, new()
+    {
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
+        public static DiagnosticResult Diagnostic()
+            => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic();
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
+        public static DiagnosticResult Diagnostic(string diagnosticId)
+            => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(diagnosticId);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+            => VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(descriptor);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+
+        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBRefactoringVerifier`1+Test.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBRefactoringVerifier`1+Test.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+
+namespace $safeprojectname$
+{
+    public static partial class VisualBasicCodeRefactoringVerifier<TCodeRefactoring>
+        where TCodeRefactoring : CodeRefactoringProvider, new()
+    {
+        public class Test : VisualBasicCodeRefactoringTest<TCodeRefactoring, MSTestVerifier>
+        {
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBRefactoringVerifier`1.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Test/Verifiers/VBRefactoringVerifier`1.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace $safeprojectname$
+{
+    public static partial class VisualBasicCodeRefactoringVerifier<TCodeRefactoring>
+        where TCodeRefactoring : CodeRefactoringProvider, new()
+    {
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
+        public static async Task VerifyRefactoringAsync(string source, string fixedSource)
+        {
+            await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+        }
+
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
+        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
+        {
+            await VerifyRefactoringAsync(source, new[] { expected }, fixedSource);
+        }
+
+        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
+        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        {
+            var test = new Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Test.vstemplate
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Test.vstemplate
@@ -19,6 +19,21 @@
   <TemplateContent>
     <Project TargetFileName="$safeprojectname$.vbproj" File="UnitTestProject.vbproj" ReplaceParameters="true">
       <ProjectItem ReplaceParameters="true" TargetFileName="$saferootprojectname$UnitTests.vb">UnitTests.vb</ProjectItem>
+
+      <!-- File names are shortened to avoid PathTooLongException on project creation... -->
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpAnalyzerVerifier`1.vb">Verifiers\CSAnalyzerVerifier`1.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpAnalyzerVerifier`1+Test.vb">Verifiers\CSAnalyzerVerifier`1+Test.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpCodeFixVerifier`2.vb">Verifiers\CSCodeFixVerifier`2.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpCodeFixVerifier`2+Test.vb">Verifiers\CSCodeFixVerifier`2+Test.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpCodeRefactoringVerifier`1.vb">Verifiers\CSRefactoringVerifier`1.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpCodeRefactoringVerifier`1+Test.vb">Verifiers\CSRefactoringVerifier`1+Test.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="CSharpVerifierHelper.vb">Verifiers\CSVerifierHelper.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicAnalyzerVerifier`1.vb">Verifiers\VBAnalyzerVerifier`1.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicAnalyzerVerifier`1+Test.vb">Verifiers\VBAnalyzerVerifier`1+Test.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicCodeFixVerifier`2.vb">Verifiers\VBCodeFixVerifier`2.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicCodeFixVerifier`2+Test.vb">Verifiers\VBCodeFixVerifier`2+Test.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicCodeRefactoringVerifier`1.vb">Verifiers\VBRefactoringVerifier`1.vb</ProjectItem>
+      <ProjectItem ReplaceParameters="true" TargetFileName="VisualBasicCodeRefactoringVerifier`1+Test.vb">Verifiers\VBRefactoringVerifier`1+Test.vb</ProjectItem>
     </Project>
   </TemplateContent>
   <WizardExtension>

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/UnitTestProject.vbproj
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/UnitTestProject.vbproj
@@ -11,6 +11,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.0.1-beta1.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.0.1-beta1.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.0.1-beta1.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.0.1-beta1.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.0.1-beta1.*" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.0.1-beta1.*" />

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/UnitTests.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/UnitTests.vb
@@ -1,23 +1,17 @@
-﻿Imports $saferootprojectname$
-Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.CodeFixes
-Imports Microsoft.CodeAnalysis.Diagnostics
-Imports Microsoft.VisualStudio.TestTools.UnitTesting
-Imports System.Threading
-Imports System.Threading.Tasks
-Imports Verify = Microsoft.CodeAnalysis.VisualBasic.Testing.MSTest.CodeFixVerifier(
+﻿Imports Microsoft.VisualStudio.TestTools.UnitTesting
+Imports VerifyVB = $safeprojectname$.VisualBasicCodeFixVerifier(
     Of $saferootprojectname$.$saferootidentifiername$Analyzer,
     $saferootprojectname$.$saferootidentifiername$CodeFixProvider)
 
 Namespace $safeprojectname$
     <TestClass>
-    Public Class UnitTest
+    Public Class $saferootidentifiername$UnitTest
 
         'No diagnostics expected to show up
         <TestMethod>
         Public Async Function TestMethod1() As Task
             Dim test = ""
-            Await Verify.VerifyAnalyzerAsync(test)
+            Await VerifyVB.VerifyAnalyzerAsync(test)
         End Function
 
         'Diagnostic And CodeFix both triggered And checked for
@@ -25,26 +19,25 @@ Namespace $safeprojectname$
         Public Async Function TestMethod2() As Task
 
             Dim test = "
-Module Module1
+Class {|#0:TypeName|}
 
     Sub Main()
 
     End Sub
 
-End Module"
+End Class"
 
             Dim fixtest = "
-Module MODULE1
+Class TYPENAME
 
     Sub Main()
 
     End Sub
 
-End Module"
+End Class"
 
-            Dim expected = Verify.Diagnostic("$saferootidentifiername$").WithLocation(2, 8).WithArguments("Module1")
-            Await Verify.VerifyCodeFixAsync(test, expected, fixtest)
+            Dim expected = VerifyVB.Diagnostic("$saferootidentifiername$").WithLocation(0).WithArguments("TypeName")
+            Await VerifyVB.VerifyCodeFixAsync(test, expected, fixtest)
         End Function
-
     End Class
 End Namespace

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSAnalyzerVerifier`1+Test.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSAnalyzerVerifier`1+Test.vb
@@ -1,0 +1,21 @@
+﻿Imports Microsoft.CodeAnalysis.CSharp.Testing
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+
+Partial Public NotInheritable Class CSharpAnalyzerVerifier(Of TAnalyzer As {DiagnosticAnalyzer, New})
+    Public Class Test
+        Inherits CSharpAnalyzerTest(Of TAnalyzer, MSTestVerifier)
+
+        Public Sub New()
+            SolutionTransforms.Add(
+                Function(solution, projectId)
+                    Dim compilationOptions = solution.GetProject(projectId).CompilationOptions
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings))
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions)
+
+                    Return solution
+                End Function)
+        End Sub
+    End Class
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSAnalyzerVerifier`1.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSAnalyzerVerifier`1.vb
@@ -1,0 +1,40 @@
+﻿Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CSharp.Testing
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Testing
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+
+Partial Public NotInheritable Class CSharpAnalyzerVerifier(Of TAnalyzer As {DiagnosticAnalyzer, New})
+
+    Private Sub New()
+        Throw New NotSupportedException()
+    End Sub
+
+    ''' <inheritdoc cref="AnalyzerVerifier(Of TAnalyzer, TTest, TVerifier).Diagnostic()"/>
+    Public Shared Function Diagnostic() As DiagnosticResult
+        Return CSharpAnalyzerVerifier(Of TAnalyzer, MSTestVerifier).Diagnostic()
+    End Function
+
+    ''' <inheritdoc cref="AnalyzerVerifier(Of TAnalyzer, TTest, TVerifier).Diagnostic(String)"/>
+    Public Shared Function Diagnostic(diagnosticId As String) As DiagnosticResult
+        Return CSharpAnalyzerVerifier(Of TAnalyzer, MSTestVerifier).Diagnostic(diagnosticId)
+    End Function
+
+    ''' <inheritdoc cref="AnalyzerVerifier(Of TAnalyzer, TTest, TVerifier).Diagnostic(DiagnosticDescriptor)"/>
+    Public Shared Function Diagnostic(descriptor As DiagnosticDescriptor) As DiagnosticResult
+        Return CSharpAnalyzerVerifier(Of TAnalyzer, MSTestVerifier).Diagnostic(descriptor)
+    End Function
+
+    ''' <inheritdoc cref="AnalyzerVerifier(Of TAnalyzer, TTest, TVerifier).VerifyAnalyzerAsync(String, DiagnosticResult())"/>
+    Public Shared Async Function VerifyAnalyzerAsync(source As String, ParamArray expected As DiagnosticResult()) As Task
+        Dim test As New Test With
+        {
+        .TestCode = source
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected)
+        Await test.RunAsync(CancellationToken.None)
+    End Function
+
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSCodeFixVerifier`2+Test.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSCodeFixVerifier`2+Test.vb
@@ -1,0 +1,22 @@
+﻿Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.CSharp.Testing
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+
+Partial Public NotInheritable Class CSharpCodeFixVerifier(Of TAnalyzer As {DiagnosticAnalyzer, New}, TCodeFix As {CodeFixProvider, New})
+    Public Class Test
+        Inherits CSharpCodeFixTest(Of TAnalyzer, TCodeFix, MSTestVerifier)
+
+        Public Sub New()
+            SolutionTransforms.Add(
+                Function(solution, projectId)
+                    Dim compilationOptions = solution.GetProject(projectId).CompilationOptions
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings))
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions)
+
+                    Return solution
+                End Function)
+        End Sub
+    End Class
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSCodeFixVerifier`2.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSCodeFixVerifier`2.vb
@@ -1,0 +1,63 @@
+﻿Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.CSharp.Testing
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Testing
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+
+Partial Public NotInheritable Class CSharpCodeFixVerifier(Of TAnalyzer As {DiagnosticAnalyzer, New}, TCodeFix As {CodeFixProvider, New})
+
+    Private Sub New()
+        Throw New NotSupportedException()
+    End Sub
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).Diagnostic()"/>
+    Public Shared Function Diagnostic() As DiagnosticResult
+        Return CSharpCodeFixVerifier(Of TAnalyzer, TCodeFix, MSTestVerifier).Diagnostic()
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).Diagnostic(String)"/>
+    Public Shared Function Diagnostic(diagnosticId As String) As DiagnosticResult
+        Return CSharpCodeFixVerifier(Of TAnalyzer, TCodeFix, MSTestVerifier).Diagnostic(diagnosticId)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).Diagnostic(DiagnosticDescriptor)"/>
+    Public Shared Function Diagnostic(descriptor As DiagnosticDescriptor) As DiagnosticResult
+        Return CSharpCodeFixVerifier(Of TAnalyzer, TCodeFix, MSTestVerifier).Diagnostic(descriptor)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).VerifyAnalyzerAsync(String, DiagnosticResult())"/>
+    Public Shared Async Function VerifyAnalyzerAsync(source As String, ParamArray expected As DiagnosticResult()) As Task
+        Dim test As New Test With
+        {
+        .TestCode = source
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected)
+        Await test.RunAsync(CancellationToken.None)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).VerifyCodeFixAsync(String, String)"/>
+    Public Shared Async Function VerifyCodeFixAsync(source As String, fixedSource As String) As Task
+        Await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).VerifyCodeFixAsync(String, DiagnosticResult, String)"/>
+    Public Shared Async Function VerifyCodeFixAsync(source As String, expected As DiagnosticResult, fixedSource As String) As Task
+        Await VerifyCodeFixAsync(source, {expected}, fixedSource)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).VerifyCodeFixAsync(String, DiagnosticResult(), String)"/>
+    Public Shared Async Function VerifyCodeFixAsync(source As String, expected As DiagnosticResult(), fixedSource As String) As Task
+        Dim test As New Test With
+        {
+        .TestCode = source,
+        .FixedCode = fixedSource
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected)
+        Await test.RunAsync(CancellationToken.None)
+    End Function
+
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSRefactoringVerifier`1+Test.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSRefactoringVerifier`1+Test.vb
@@ -1,0 +1,21 @@
+﻿Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.CSharp.Testing
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+
+Partial Public NotInheritable Class CSharpCodeRefactoringVerifier(Of TCodeRefactoring As {CodeRefactoringProvider, New})
+    Public Class Test
+        Inherits CSharpCodeRefactoringTest(Of TCodeRefactoring, MSTestVerifier)
+
+        Public Sub New()
+            SolutionTransforms.Add(
+                Function(solution, projectId)
+                    Dim compilationOptions = solution.GetProject(projectId).CompilationOptions
+                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings))
+                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions)
+
+                    Return solution
+                End Function)
+        End Sub
+    End Class
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSRefactoringVerifier`1.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSRefactoringVerifier`1.vb
@@ -1,0 +1,33 @@
+﻿Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Testing
+
+Partial Public NotInheritable Class CSharpCodeRefactoringVerifier(Of TCodeRefactoring As {CodeRefactoringProvider, New})
+
+    Private Sub New()
+        Throw New NotSupportedException()
+    End Sub
+
+    ''' <inheritdoc cref="CodeRefactoringVerifier(Of TCodeRefactoring, TTest, TVerifier).VerifyRefactoringAsync(String, String)"/>
+    Public Shared Async Function VerifyRefactoringAsync(source As String, fixedSource As String) As Task
+        Await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource)
+    End Function
+
+    ''' <inheritdoc cref="CodeRefactoringVerifier(Of TCodeRefactoring, TTest, TVerifier).VerifyRefactoringAsync(String, DiagnosticResult, String)"/>
+    Public Shared Async Function VerifyRefactoringAsync(source As String, expected As DiagnosticResult, fixedSource As String) As Task
+        Await VerifyRefactoringAsync(source, {expected}, fixedSource)
+    End Function
+
+    ''' <inheritdoc cref="CodeRefactoringVerifier(Of TCodeRefactoring, TTest, TVerifier).VerifyRefactoringAsync(String, DiagnosticResult(), String)"/>
+    Public Shared Async Function VerifyRefactoringAsync(source As String, expected As DiagnosticResult(), fixedSource As String) As Task
+        Dim test As New Test With
+        {
+        .TestCode = source,
+        .FixedCode = fixedSource
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected)
+        Await test.RunAsync(CancellationToken.None)
+    End Function
+
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSVerifierHelper.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/CSVerifierHelper.vb
@@ -1,0 +1,27 @@
+﻿Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CSharp
+
+Friend Module CSharpVerifierHelper
+    ''' <summary>
+    ''' By default, the compiler reports diagnostics for nullable reference types at
+    ''' <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating
+    ''' diagnostics at <see cref="DiagnosticSeverity.Error"/>. This map contains all compiler diagnostic IDs
+    ''' related to nullability mapped to <see cref="ReportDiagnostic.Error"/>, which is then used to enable all
+    ''' of these warnings for default validation during analyzer and code fix tests.
+    ''' </summary>
+    Friend ReadOnly Property NullableWarnings As ImmutableDictionary(Of String, ReportDiagnostic) = GetNullableWarningsFromCompiler()
+
+    Private Function GetNullableWarningsFromCompiler() As ImmutableDictionary(Of String, ReportDiagnostic)
+        Dim args = {"/warnaserror:nullable"}
+        Dim commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory:=Environment.CurrentDirectory, sdkDirectory:=Environment.CurrentDirectory)
+        Dim nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions
+
+        ' Workaround for https://github.com/dotnet/roslyn/issues/41610
+        nullableWarnings = nullableWarnings _
+            .SetItem("CS8632", ReportDiagnostic.Error) _
+            .SetItem("CS8669", ReportDiagnostic.Error)
+
+        Return nullableWarnings
+    End Function
+End Module

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBAnalyzerVerifier`1+Test.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBAnalyzerVerifier`1+Test.vb
@@ -1,0 +1,12 @@
+﻿Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+Imports Microsoft.CodeAnalysis.VisualBasic.Testing
+
+Partial Public NotInheritable Class VisualBasicAnalyzerVerifier(Of TAnalyzer As {DiagnosticAnalyzer, New})
+    Public Class Test
+        Inherits VisualBasicAnalyzerTest(Of TAnalyzer, MSTestVerifier)
+
+        Public Sub New()
+        End Sub
+    End Class
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBAnalyzerVerifier`1.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBAnalyzerVerifier`1.vb
@@ -1,0 +1,40 @@
+﻿Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Testing
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+Imports Microsoft.CodeAnalysis.VisualBasic.Testing
+
+Partial Public NotInheritable Class VisualBasicAnalyzerVerifier(Of TAnalyzer As {DiagnosticAnalyzer, New})
+
+    Private Sub New()
+        Throw New NotSupportedException()
+    End Sub
+
+    ''' <inheritdoc cref="AnalyzerVerifier(Of TAnalyzer, TTest, TVerifier).Diagnostic()"/>
+    Public Shared Function Diagnostic() As DiagnosticResult
+        Return VisualBasicAnalyzerVerifier(Of TAnalyzer, MSTestVerifier).Diagnostic()
+    End Function
+
+    ''' <inheritdoc cref="AnalyzerVerifier(Of TAnalyzer, TTest, TVerifier).Diagnostic(String)"/>
+    Public Shared Function Diagnostic(diagnosticId As String) As DiagnosticResult
+        Return VisualBasicAnalyzerVerifier(Of TAnalyzer, MSTestVerifier).Diagnostic(diagnosticId)
+    End Function
+
+    ''' <inheritdoc cref="AnalyzerVerifier(Of TAnalyzer, TTest, TVerifier).Diagnostic(DiagnosticDescriptor)"/>
+    Public Shared Function Diagnostic(descriptor As DiagnosticDescriptor) As DiagnosticResult
+        Return VisualBasicAnalyzerVerifier(Of TAnalyzer, MSTestVerifier).Diagnostic(descriptor)
+    End Function
+
+    ''' <inheritdoc cref="AnalyzerVerifier(Of TAnalyzer, TTest, TVerifier).VerifyAnalyzerAsync(String, DiagnosticResult())"/>
+    Public Shared Async Function VerifyAnalyzerAsync(source As String, ParamArray expected As DiagnosticResult()) As Task
+        Dim test As New Test With
+        {
+        .TestCode = source
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected)
+        Await test.RunAsync(CancellationToken.None)
+    End Function
+
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBCodeFixVerifier`2+Test.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBCodeFixVerifier`2+Test.vb
@@ -1,0 +1,11 @@
+﻿Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+Imports Microsoft.CodeAnalysis.VisualBasic.Testing
+
+Partial Public NotInheritable Class VisualBasicCodeFixVerifier(Of TAnalyzer As {DiagnosticAnalyzer, New}, TCodeFix As {CodeFixProvider, New})
+    Public Class Test
+        Inherits VisualBasicCodeFixTest(Of TAnalyzer, TCodeFix, MSTestVerifier)
+
+    End Class
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBCodeFixVerifier`2.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBCodeFixVerifier`2.vb
@@ -1,0 +1,63 @@
+﻿Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Testing
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+Imports Microsoft.CodeAnalysis.VisualBasic.Testing
+
+Partial Public NotInheritable Class VisualBasicCodeFixVerifier(Of TAnalyzer As {DiagnosticAnalyzer, New}, TCodeFix As {CodeFixProvider, New})
+
+    Private Sub New()
+        Throw New NotSupportedException()
+    End Sub
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).Diagnostic()"/>
+    Public Shared Function Diagnostic() As DiagnosticResult
+        Return VisualBasicCodeFixVerifier(Of TAnalyzer, TCodeFix, MSTestVerifier).Diagnostic()
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).Diagnostic(String)"/>
+    Public Shared Function Diagnostic(diagnosticId As String) As DiagnosticResult
+        Return VisualBasicCodeFixVerifier(Of TAnalyzer, TCodeFix, MSTestVerifier).Diagnostic(diagnosticId)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).Diagnostic(DiagnosticDescriptor)"/>
+    Public Shared Function Diagnostic(descriptor As DiagnosticDescriptor) As DiagnosticResult
+        Return VisualBasicCodeFixVerifier(Of TAnalyzer, TCodeFix, MSTestVerifier).Diagnostic(descriptor)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).VerifyAnalyzerAsync(String, DiagnosticResult())"/>
+    Public Shared Async Function VerifyAnalyzerAsync(source As String, ParamArray expected As DiagnosticResult()) As Task
+        Dim test As New Test With
+        {
+        .TestCode = source
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected)
+        Await test.RunAsync(CancellationToken.None)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).VerifyCodeFixAsync(String, String)"/>
+    Public Shared Async Function VerifyCodeFixAsync(source As String, fixedSource As String) As Task
+        Await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).VerifyCodeFixAsync(String, DiagnosticResult, String)"/>
+    Public Shared Async Function VerifyCodeFixAsync(source As String, expected As DiagnosticResult, fixedSource As String) As Task
+        Await VerifyCodeFixAsync(source, {expected}, fixedSource)
+    End Function
+
+    ''' <inheritdoc cref="CodeFixVerifier(Of TAnalyzer, TCodeFix, TTest, TVerifier).VerifyCodeFixAsync(String, DiagnosticResult(), String)"/>
+    Public Shared Async Function VerifyCodeFixAsync(source As String, expected As DiagnosticResult(), fixedSource As String) As Task
+        Dim test As New Test With
+        {
+        .TestCode = source,
+        .FixedCode = fixedSource
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected)
+        Await test.RunAsync(CancellationToken.None)
+    End Function
+
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBRefactoringVerifier`1+Test.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBRefactoringVerifier`1+Test.vb
@@ -1,0 +1,10 @@
+﻿Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
+Imports Microsoft.CodeAnalysis.VisualBasic.Testing
+
+Partial Public NotInheritable Class VisualBasicCodeRefactoringVerifier(Of TCodeRefactoring As {CodeRefactoringProvider, New})
+    Public Class Test
+        Inherits VisualBasicCodeRefactoringTest(Of TCodeRefactoring, MSTestVerifier)
+
+    End Class
+End Class

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBRefactoringVerifier`1.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Test/Verifiers/VBRefactoringVerifier`1.vb
@@ -1,0 +1,33 @@
+﻿Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Testing
+
+Partial Public NotInheritable Class VisualBasicCodeRefactoringVerifier(Of TCodeRefactoring As {CodeRefactoringProvider, New})
+
+    Private Sub New()
+        Throw New NotSupportedException()
+    End Sub
+
+    ''' <inheritdoc cref="CodeRefactoringVerifier(Of TCodeRefactoring, TTest, TVerifier).VerifyRefactoringAsync(String, String)"/>
+    Public Shared Async Function VerifyRefactoringAsync(source As String, fixedSource As String) As Task
+        Await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource)
+    End Function
+
+    ''' <inheritdoc cref="CodeRefactoringVerifier(Of TCodeRefactoring, TTest, TVerifier).VerifyRefactoringAsync(String, DiagnosticResult, String)"/>
+    Public Shared Async Function VerifyRefactoringAsync(source As String, expected As DiagnosticResult, fixedSource As String) As Task
+        Await VerifyRefactoringAsync(source, {expected}, fixedSource)
+    End Function
+
+    ''' <inheritdoc cref="CodeRefactoringVerifier(Of TCodeRefactoring, TTest, TVerifier).VerifyRefactoringAsync(String, DiagnosticResult(), String)"/>
+    Public Shared Async Function VerifyRefactoringAsync(source As String, expected As DiagnosticResult(), fixedSource As String) As Task
+        Dim test As New Test With
+        {
+        .TestCode = source,
+        .FixedCode = fixedSource
+        }
+
+        test.ExpectedDiagnostics.AddRange(expected)
+        Await test.RunAsync(CancellationToken.None)
+    End Function
+
+End Class


### PR DESCRIPTION
Add verifier implementations, which are used to customize test framework behavior in the context of a specific analyzer project.