### PR TITLE
Save sample source generator output

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,6 +10,7 @@
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
+    <MicrosoftNetCompilersToolsetVersion>3.7.0-4.20324.3</MicrosoftNetCompilersToolsetVersion>
     <!-- Dependencies -->
     <!-- Roslyn for VS 2019 -->
     <!-- NOTE: Do not upgrade these to be newer than what shipped in VS 2019 since the Syntax Visualizer extension still

--- a/samples/CSharp/SourceGenerators/GeneratedDemo/GeneratedDemo.csproj
+++ b/samples/CSharp/SourceGenerators/GeneratedDemo/GeneratedDemo.csproj
@@ -4,7 +4,13 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>preview</LangVersion>
+    <SaveSourceGeneratorOutput>true</SaveSourceGeneratorOutput>
   </PropertyGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="IntermediateOutputPath" />
+    <CompilerVisibleProperty Include="SaveSourceGeneratorOutput" />
+  </ItemGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="MainSettings.xmlsettings" />

--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/AutoNotifyGenerator.cs
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/AutoNotifyGenerator.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using SourceGeneratorSamples;
 
 namespace Analyzer1
 {
@@ -35,8 +36,10 @@ namespace AutoNotify
 
         public void Execute(SourceGeneratorContext context)
         {
+            string generatedSourceOutputPath = context.TryCreateGeneratedSourceOutputPath();
+
             // add the attribute text
-            context.AddSource("AutoNotifyAttribute", SourceText.From(attributeText, Encoding.UTF8));
+            context.AddSource(generatedSourceOutputPath, "AutoNotifyAttribute", SourceText.From(attributeText, Encoding.UTF8));
 
             // retreive the populated receiver 
             if (!(context.SyntaxReceiver is SyntaxReceiver receiver))
@@ -71,7 +74,7 @@ namespace AutoNotify
             foreach (IGrouping<INamedTypeSymbol, IFieldSymbol> group in fieldSymbols.GroupBy(f => f.ContainingType))
             {
                 string classSource = ProcessClass(group.Key, group.ToList(), attributeSymbol, notifySymbol, context);
-               context.AddSource($"{group.Key.Name}_autoNotify.cs", SourceText.From(classSource, Encoding.UTF8));
+                context.AddSource(generatedSourceOutputPath, $"{group.Key.Name}_autoNotify.cs", SourceText.From(classSource, Encoding.UTF8));
             }
         }
 

--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/AutoNotifyGenerator.cs
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/AutoNotifyGenerator.cs
@@ -39,7 +39,7 @@ namespace AutoNotify
             string generatedSourceOutputPath = context.TryCreateGeneratedSourceOutputPath();
 
             // add the attribute text
-            context.AddSource(generatedSourceOutputPath, "AutoNotifyAttribute", SourceText.From(attributeText, Encoding.UTF8));
+            context.AddSource(generatedSourceOutputPath, "AutoNotifyAttribute.cs", SourceText.From(attributeText, Encoding.UTF8));
 
             // retreive the populated receiver 
             if (!(context.SyntaxReceiver is SyntaxReceiver receiver))

--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/HelloWorldGenerator.cs
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/HelloWorldGenerator.cs
@@ -11,6 +11,8 @@ namespace SourceGeneratorSamples
     {
         public void Execute(SourceGeneratorContext context)
         {
+            string generatedSourceOutputPath = context.TryCreateGeneratedSourceOutputPath();
+
             // begin creating the source we'll inject into the users compilation
             StringBuilder sourceBuilder = new StringBuilder(@"
 using System;
@@ -40,7 +42,7 @@ namespace HelloWorldGenerated
 }");
 
             // inject the created source into the users compilation
-            context.AddSource("helloWorldGenerated", SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
+            context.AddSource(generatedSourceOutputPath, "helloWorldGenerated", SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
         }
 
         public void Initialize(InitializationContext context)

--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/HelloWorldGenerator.cs
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/HelloWorldGenerator.cs
@@ -42,7 +42,7 @@ namespace HelloWorldGenerated
 }");
 
             // inject the created source into the users compilation
-            context.AddSource(generatedSourceOutputPath, "helloWorldGenerated", SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
+            context.AddSource(generatedSourceOutputPath, "helloWorldGenerated.cs", SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
         }
 
         public void Initialize(InitializationContext context)

--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SettingsXmlGenerator.cs
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SettingsXmlGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using SourceGeneratorSamples;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,15 +24,17 @@ namespace XmlSettings
 ";
         public void Execute(SourceGeneratorContext context)
         {
+            string generatedSourceOutputPath = context.TryCreateGeneratedSourceOutputPath();
+
             // Using the context, get any additional files that end in .xmlsettings
             IEnumerable<AdditionalText> settingsFiles = context.AdditionalFiles.Where(at => at.Path.EndsWith(".xmlsettings"));
             foreach (AdditionalText settingsFile in settingsFiles)
             {
-                ProcessSettingsFile(settingsFile, context);
+                ProcessSettingsFile(settingsFile, context, generatedSourceOutputPath);
             }
         }
         
-        private void ProcessSettingsFile(AdditionalText xmlFile, SourceGeneratorContext context)
+        private void ProcessSettingsFile(AdditionalText xmlFile, SourceGeneratorContext context, string generatedSourceOutputPath)
         {
             // try and load the settings file
             XmlDocument xmlDoc = new XmlDocument();
@@ -98,7 +101,7 @@ public {settingType} {settingName}
 
             sb.Append("} } }");
 
-            context.AddSource($"Settings_{name}", SourceText.From(sb.ToString(), Encoding.UTF8));
+            context.AddSource(generatedSourceOutputPath, $"Settings_{name}", SourceText.From(sb.ToString(), Encoding.UTF8));
         }
      
         public void Initialize(InitializationContext context)

--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SettingsXmlGenerator.cs
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SettingsXmlGenerator.cs
@@ -101,7 +101,7 @@ public {settingType} {settingName}
 
             sb.Append("} } }");
 
-            context.AddSource(generatedSourceOutputPath, $"Settings_{name}", SourceText.From(sb.ToString(), Encoding.UTF8));
+            context.AddSource(generatedSourceOutputPath, $"Settings_{name}.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
         }
      
         public void Initialize(InitializationContext context)

--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SourceGeneratorContextExtensions.cs
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SourceGeneratorContextExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace SourceGeneratorSamples
+{
+    internal static class SourceGeneratorContextExtensions
+    {
+        public static string TryCreateGeneratedSourceOutputPath(this SourceGeneratorContext context)
+        {
+            string generatedSourceOutputPath = null;
+            if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.SaveSourceGeneratorOutput", out string saveSourceGeneratorOutputValue)
+                && bool.TryParse(saveSourceGeneratorOutputValue, out bool saveSourceGeneratorOutput)
+                && saveSourceGeneratorOutput
+                && context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.IntermediateOutputPath", out string intermediateOutputPath))
+            {
+                generatedSourceOutputPath = Path.Combine(intermediateOutputPath, "Generated");
+                Directory.CreateDirectory(generatedSourceOutputPath);
+            }
+
+            return generatedSourceOutputPath;
+        }
+
+        public static void AddSource(this SourceGeneratorContext context, string generatedSourceOutputPath, string hintName, SourceText sourceText)
+        {
+            if (generatedSourceOutputPath is object && !Path.IsPathRooted(hintName) && !hintName.Contains(".."))
+            {
+                using FileStream stream = File.OpenWrite(Path.Combine(generatedSourceOutputPath, hintName));
+                using TextWriter writer = new StreamWriter(stream, sourceText.Encoding ?? Encoding.UTF8, bufferSize: 8192, leaveOpen: true);
+                sourceText.Write(writer, context.CancellationToken);
+            }
+
+            context.AddSource(hintName, sourceText);
+        }
+    }
+}

--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SourceGeneratorSamples.csproj
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/SourceGeneratorSamples.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0-3.20207.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0-beta2.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0-4.20324.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Generalizes the pattern described in https://github.com/dotnet/roslyn-sdk/issues/526#issuecomment-630770165, and makes the generation a characteristic of the target project instead of the source generator.