### PR TITLE
Update to vs-mef 16.1.8

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.0.1" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="15.6.36" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.1.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
 
     <!-- Use PrivateAssets=compile to avoid exposing our NuGet dependencies downstream as public API. -->


### PR DESCRIPTION
Avoids runtime breaking changes due to microsoft/vs-mef#58.