### PR TITLE
Automatically detect generated code configuration

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerInfo.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerInfo.cs
@@ -1,0 +1,171 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    internal static class AnalyzerInfo
+    {
+        /// <summary>
+        /// The <see cref="Attribute.Attribute()"/> constructor.
+        /// </summary>
+        private static readonly ConstructorInfo AttributeBaseClassCtor = typeof(Attribute).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single(ctor => ctor.GetParameters().Length == 0);
+
+        /// <summary>
+        /// The <see cref="AttributeUsageAttribute(AttributeTargets)"/> constructor.
+        /// </summary>
+        private static readonly ConstructorInfo AttributeUsageCtor = typeof(AttributeUsageAttribute).GetConstructor(new Type[] { typeof(AttributeTargets) })!;
+
+        /// <summary>
+        /// The <see cref="AttributeUsageAttribute.AllowMultiple"/> property.
+        /// </summary>
+        private static readonly PropertyInfo AttributeUsageAllowMultipleProperty = typeof(AttributeUsageAttribute).GetProperty(nameof(AttributeUsageAttribute.AllowMultiple))!;
+
+        private static readonly object s_codeGenerationLock = new object();
+        private static Type? s_generatedAnalysisContextType;
+
+        public static bool HasConfiguredGeneratedCodeAnalysis(DiagnosticAnalyzer analyzer)
+        {
+            var context = CreateAnalysisContext();
+            analyzer.Initialize(context);
+            return context.ConfiguresGeneratedCode;
+        }
+
+        private static CustomAnalysisContext CreateAnalysisContext()
+        {
+            if (s_generatedAnalysisContextType is null)
+            {
+                lock (s_codeGenerationLock)
+                {
+                    if (s_generatedAnalysisContextType is null)
+                    {
+                        s_generatedAnalysisContextType = GenerateAnalysisContextType();
+                    }
+                }
+            }
+
+            return (CustomAnalysisContext)Activator.CreateInstance(s_generatedAnalysisContextType)!;
+        }
+
+        private static Type GenerateAnalysisContextType()
+        {
+            Debug.Assert(Monitor.IsEntered(s_codeGenerationLock), "Assertion failed: Monitor.IsEntered(s_codeGenerationLock)");
+
+            var moduleBuilder = CreateModuleBuilder();
+            var typeBuilder = moduleBuilder.DefineType("CustomAnalysisContextImpl", TypeAttributes.Public, typeof(CustomAnalysisContext));
+            foreach (var method in typeof(AnalysisContext).GetTypeInfo().DeclaredMethods)
+            {
+                if (!method.IsVirtual && !method.IsAbstract)
+                {
+                    continue;
+                }
+
+                if (method.ReturnType != typeof(void))
+                {
+                    continue;
+                }
+
+                var accessAttributes = method.Attributes & MethodAttributes.MemberAccessMask;
+                var methodBuilder = typeBuilder.DefineMethod(method.Name, accessAttributes | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.Virtual, method.ReturnType, method.GetParameters().Select(parameter => parameter.ParameterType).ToArray());
+                if (method.IsGenericMethod)
+                {
+                    var genericParameterBuilders = methodBuilder.DefineGenericParameters(method.GetGenericArguments().Select(type => type.Name).ToArray());
+                    for (var i = 0; i < genericParameterBuilders.Length; i++)
+                    {
+                        var parameterBuilder = genericParameterBuilders[i];
+                        parameterBuilder.SetBaseTypeConstraint(method.GetGenericArguments()[i].GetTypeInfo().BaseType);
+                        parameterBuilder.SetInterfaceConstraints(method.GetGenericArguments()[i].GetTypeInfo().ImplementedInterfaces.ToArray());
+                    }
+                }
+
+                var generator = methodBuilder.GetILGenerator();
+
+                if (method.Name == "ConfigureGeneratedCodeAnalysis")
+                {
+                    var generatedCodeField = typeof(CustomAnalysisContext).GetTypeInfo().DeclaredFields.Single(field => field.Name == nameof(CustomAnalysisContext.ConfiguresGeneratedCode));
+                    generator.Emit(OpCodes.Ldarg_0);
+                    generator.Emit(OpCodes.Ldc_I4_1);
+                    generator.Emit(OpCodes.Stfld, generatedCodeField);
+                }
+
+                generator.Emit(OpCodes.Ret);
+            }
+
+            return typeBuilder.CreateTypeInfo()!.AsType();
+        }
+
+        private static ModuleBuilder CreateModuleBuilder()
+        {
+            var assemblyBuilder = CreateAssemblyBuilder();
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule("codeAnalysisProxies");
+
+            SkipVisibilityChecksFor(assemblyBuilder, moduleBuilder, typeof(CustomAnalysisContext));
+
+            return moduleBuilder;
+        }
+
+        private static AssemblyBuilder CreateAssemblyBuilder()
+        {
+            var assemblyName = new AssemblyName($"codeAnalysisProxies_{Guid.NewGuid()}");
+            return AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndCollect);
+        }
+
+        private static void SkipVisibilityChecksFor(AssemblyBuilder assemblyBuilder, ModuleBuilder moduleBuilder, Type type)
+        {
+            var attributeBuilder = new CustomAttributeBuilder(GetMagicAttributeCtor(moduleBuilder), new object[] { type.GetTypeInfo().Assembly.GetName().Name! });
+            assemblyBuilder.SetCustomAttribute(attributeBuilder);
+        }
+
+        private static ConstructorInfo GetMagicAttributeCtor(ModuleBuilder moduleBuilder)
+        {
+            var magicAttribute = EmitMagicAttribute(moduleBuilder);
+            return magicAttribute.GetConstructor(new Type[] { typeof(string) })!;
+        }
+
+        private static System.Reflection.TypeInfo EmitMagicAttribute(ModuleBuilder moduleBuilder)
+        {
+            var tb = moduleBuilder.DefineType(
+                "System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute",
+                TypeAttributes.NotPublic,
+                typeof(Attribute));
+
+            var attributeUsage = new CustomAttributeBuilder(
+                AttributeUsageCtor,
+                new object[] { AttributeTargets.Assembly },
+                new PropertyInfo[] { AttributeUsageAllowMultipleProperty },
+                new object[] { false });
+            tb.SetCustomAttribute(attributeUsage);
+
+            var cb = tb.DefineConstructor(
+                MethodAttributes.Public |
+                MethodAttributes.HideBySig |
+                MethodAttributes.SpecialName |
+                MethodAttributes.RTSpecialName,
+                CallingConventions.Standard,
+                new Type[] { typeof(string) });
+            cb.DefineParameter(1, ParameterAttributes.None, "assemblyName");
+
+            var il = cb.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, AttributeBaseClassCtor);
+            il.Emit(OpCodes.Ret);
+
+            return tb.CreateTypeInfo()!;
+        }
+
+        internal abstract class CustomAnalysisContext : AnalysisContext
+        {
+            [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "Set via reflection.")]
+            public bool ConfiguresGeneratedCode;
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -241,7 +241,8 @@ namespace Microsoft.CodeAnalysis.Testing
 
         private async Task VerifyGeneratedCodeDiagnosticsAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, (string filename, SourceText content)[] sources, (string filename, SourceText content)[] additionalFiles, ProjectState[] additionalProjects, MetadataReference[] additionalMetadataReferences, DiagnosticResult[] expected, IVerifier verifier, CancellationToken cancellationToken)
         {
-            if (TestBehaviors.HasFlag(TestBehaviors.SkipGeneratedCodeCheck))
+            if (TestBehaviors.HasFlag(TestBehaviors.SkipGeneratedCodeCheck)
+                || analyzers.All(analyzer => AnalyzerInfo.HasConfiguredGeneratedCodeAnalysis(analyzer)))
             {
                 return;
             }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/TestBehaviors.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/TestBehaviors.cs
@@ -21,6 +21,10 @@ namespace Microsoft.CodeAnalysis.Testing
         /// Skip the generated code exclusion check.
         /// </summary>
         /// <remarks>
+        /// <para>This flag is only used in cases where one or more analyzers does not explicitly configure generated
+        /// code analysis via the <see cref="M:Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.ConfigureGeneratedCodeAnalysis(Microsoft.CodeAnalysis.Diagnostics.GeneratedCodeAnalysisFlags)"/>
+        /// API.</para>
+        ///
         /// <para>By default, the analyzer test framework verifies that analyzer which report diagnostics do not report
         /// diagnostics in generated code. While some analyzers, e.g. security analyzers, are expected to report
         /// diagnostics in all code, most analyzers are expected to only report diagnostics in user-created code.</para>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AutoExclusionTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AutoExclusionTests.cs
@@ -39,11 +39,11 @@ End Class
 ";
 
         [Fact]
-        public async Task TestCSharpAnalyzerWithoutExclusionFails()
+        public async Task TestCSharpAnalyzerWithUnspecifiedExclusionFails()
         {
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                await new CSharpReplaceThisWithBaseTest(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics)
+                await new CSharpReplaceThisWithBaseTest(generatedCodeAnalysisFlags: null)
                 {
                     TestCode = ReplaceThisWithBaseTestCode,
                 }.RunAsync();
@@ -58,6 +58,15 @@ End Class
                 "VerifyCS.Diagnostic().WithSpan(4, 23, 4, 27)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
+        }
+
+        [Fact]
+        public async Task TestCSharpAnalyzerWithoutExclusionPasses()
+        {
+            await new CSharpReplaceThisWithBaseTest(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics)
+            {
+                TestCode = ReplaceThisWithBaseTestCode,
+            }.RunAsync();
         }
 
         [Fact]
@@ -124,11 +133,11 @@ End Class
 
         [Fact]
         [WorkItem(159, "https://github.com/dotnet/roslyn-sdk/pull/159")]
-        public async Task TestVisualBasicAnalyzerWithoutExclusionFails()
+        public async Task TestVisualBasicAnalyzerWithUnspecifiedExclusionFails()
         {
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                await new VisualBasicReplaceThisWithBaseTest(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics)
+                await new VisualBasicReplaceThisWithBaseTest(generatedCodeAnalysisFlags: null)
                 {
                     TestCode = ReplaceMyClassWithMyBaseTestCode,
                 }.RunAsync();
@@ -143,6 +152,16 @@ End Class
                 "VerifyVB.Diagnostic().WithSpan(5, 5, 5, 12)," + Environment.NewLine +
                 Environment.NewLine;
             new DefaultVerifier().EqualOrDiff(expected, exception.Message);
+        }
+
+        [Fact]
+        [WorkItem(159, "https://github.com/dotnet/roslyn-sdk/pull/159")]
+        public async Task TestVisualBasicAnalyzerWithoutExclusionPasses()
+        {
+            await new VisualBasicReplaceThisWithBaseTest(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics)
+            {
+                TestCode = ReplaceMyClassWithMyBaseTestCode,
+            }.RunAsync();
         }
 
         [Fact]
@@ -206,9 +225,9 @@ End Class
             internal static readonly DiagnosticDescriptor Descriptor =
                 new DiagnosticDescriptor("ThisToBase", "title", "message", "category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
-            private readonly GeneratedCodeAnalysisFlags _generatedCodeAnalysisFlags;
+            private readonly GeneratedCodeAnalysisFlags? _generatedCodeAnalysisFlags;
 
-            public ReplaceThisWithBaseAnalyzer(GeneratedCodeAnalysisFlags generatedCodeAnalysisFlags)
+            public ReplaceThisWithBaseAnalyzer(GeneratedCodeAnalysisFlags? generatedCodeAnalysisFlags)
             {
                 _generatedCodeAnalysisFlags = generatedCodeAnalysisFlags;
             }
@@ -218,7 +237,10 @@ End Class
             public override void Initialize(AnalysisContext context)
             {
                 context.EnableConcurrentExecution();
-                context.ConfigureGeneratedCodeAnalysis(_generatedCodeAnalysisFlags);
+                if (_generatedCodeAnalysisFlags.HasValue)
+                {
+                    context.ConfigureGeneratedCodeAnalysis(_generatedCodeAnalysisFlags.Value);
+                }
 
                 context.RegisterSyntaxNodeAction(HandleThisExpression, CSharp.SyntaxKind.ThisExpression);
                 context.RegisterSyntaxNodeAction(HandleMyClassExpression, VisualBasic.SyntaxKind.MyClassExpression);
@@ -293,9 +315,9 @@ End Class
 
         private class CSharpReplaceThisWithBaseTest : AnalyzerTest<DefaultVerifier>
         {
-            private readonly GeneratedCodeAnalysisFlags _generatedCodeAnalysisFlags;
+            private readonly GeneratedCodeAnalysisFlags? _generatedCodeAnalysisFlags;
 
-            public CSharpReplaceThisWithBaseTest(GeneratedCodeAnalysisFlags generatedCodeAnalysisFlags)
+            public CSharpReplaceThisWithBaseTest(GeneratedCodeAnalysisFlags? generatedCodeAnalysisFlags)
             {
                 _generatedCodeAnalysisFlags = generatedCodeAnalysisFlags;
             }
@@ -322,9 +344,9 @@ End Class
 
         private class VisualBasicReplaceThisWithBaseTest : AnalyzerTest<DefaultVerifier>
         {
-            private readonly GeneratedCodeAnalysisFlags _generatedCodeAnalysisFlags;
+            private readonly GeneratedCodeAnalysisFlags? _generatedCodeAnalysisFlags;
 
-            public VisualBasicReplaceThisWithBaseTest(GeneratedCodeAnalysisFlags generatedCodeAnalysisFlags)
+            public VisualBasicReplaceThisWithBaseTest(GeneratedCodeAnalysisFlags? generatedCodeAnalysisFlags)
             {
                 _generatedCodeAnalysisFlags = generatedCodeAnalysisFlags;
             }


### PR DESCRIPTION
This change eliminates the need to specify `SkipGeneratedCodeCheck` when the analyzer calls `ConfigureGeneratedCodeAnalysis` explicitly.