### PR TITLE
Support unit testing for nested refactorings.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/CodeRefactoringTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/CodeRefactoringTest`1.cs
@@ -218,7 +218,8 @@ namespace Microsoft.CodeAnalysis.Testing
                     await codeRefactoringProvider.ComputeRefactoringsAsync(context).ConfigureAwait(false);
                 }
 
-                var actionToApply = TryGetCodeActionToApply(actions.ToImmutable(), codeActionIndex, codeActionEquivalenceKey, verifier);
+                var filteredActions = FilterCodeActions(actions.ToImmutable());
+                var actionToApply = TryGetCodeActionToApply(filteredActions, codeActionIndex, codeActionEquivalenceKey, verifier);
                 if (actionToApply != null)
                 {
                     anyActions = true;


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn-sdk/pull/497.  Applies the same logic to refactorings for testing nested items that already exists for codefixes.