### PR TITLE
Add color picker for syntax classification

### DIFF
--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorHelpers.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorHelpers.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Windows.Media;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    internal static class ColorHelpers
+    {
+        /// <summary>
+        /// From https://en.wikipedia.org/wiki/HSL_and_HSV
+        /// </summary> 
+        internal static Color HSVToColor(double hue, double saturation, double value)
+        {
+            hue = Clamp(hue, 0, 360);
+            saturation = Clamp(saturation, 0, 1);
+            value = Clamp(value, 0, 1);
+
+            byte f(double d)
+            {
+                var k = (d + hue / 60) % 6;
+                var v = value - value * saturation * Math.Max(Math.Min(Math.Min(k, 4 - k), 1), 0);
+                return (byte)Math.Round(v * 255);
+            }
+
+            return Color.FromRgb(f(5), f(3), f(1));
+        }
+
+        internal static double GetHue(Color color)
+            => System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B).GetHue();
+
+        internal static double GetBrightness(Color color)
+            => System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B).GetBrightness();
+
+        internal static double GetSaturation(Color color)
+            => System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B).GetSaturation();
+
+        private static double Clamp(double value, double min, double max)
+            => Math.Max(min, Math.Min(value, max));
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
@@ -4,14 +4,41 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:Roslyn.SyntaxVisualizer.Control"
+             xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              mc:Ignorable="d" 
              x:Name="Control"
              Focusable="False"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <local:PercentConverter x:Key="PercentConverter" />
+        <ControlTemplate x:Uid="ControlTemplate_5" x:Key="ErrorTemplate">
+            <DockPanel x:Uid="DockPanel_1"
+                   LastChildFill="True">
+                <AdornedElementPlaceholder x:Uid="ControlWithError" Name="ControlWithError">
+                    <Border x:Uid="Border_5" BorderBrush="Red" BorderThickness="1" />
+                </AdornedElementPlaceholder>
+                <imaging:CrispImage x:Uid="CrispImage_1"
+                                DockPanel.Dock="Right"
+                                VerticalAlignment="Center"
+                                Moniker="{x:Static catalog:KnownMonikers.StatusInvalid}"
+                                Height="16"
+                                Width="16"
+                                Margin="5,0,0,0"
+                                ToolTip="{Binding ElementName=ControlWithError,Path=AdornedElement.(Validation.Errors)[0].ErrorContent}" />
+            </DockPanel>
+        </ControlTemplate>
+        <Style TargetType="TextBox" BasedOn="{StaticResource {x:Static vsfx:VsResourceKeys.TextBoxStyleKey}}" x:Key="ThemedDialogTextBoxStyle">
+            <Setter x:Uid="Setter_41" Property="Validation.ErrorTemplate" Value="{StaticResource ErrorTemplate}" />
+            <Style.Triggers>
+                <Trigger x:Uid="Trigger_11" Property="Validation.HasError" Value="True">
+                    <Setter x:Uid="Setter_49" Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)[0].ErrorContent}" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
     </UserControl.Resources>
-    <Grid>
+    <Grid Margin="10">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
@@ -30,28 +57,33 @@
                 Hue="{Binding Hue, Mode=TwoWay}" 
                 Width="50"
                 Margin="5, 0, 5, 0" />
-
         </DockPanel>
         <Grid x:Name="ColorDetailsGrd" Grid.Column="1">
             <Grid.Resources>
-                <Style TargetType="Label">
+                <Style TargetType="Label" BasedOn="{StaticResource {x:Static vsfx:VsResourceKeys.ThemedDialogLabelStyleKey}}">
                     <Setter Property="HorizontalAlignment" Value="Right" />
+                    <Setter Property="VerticalAlignment" Value="Bottom" />
                     <Setter Property="Padding" Value="0, 0, 10, 0" />
                     <Setter Property="Margin" Value="0, 5, 0, 5" />
                 </Style>
 
-                <Style TargetType="TextBox">
-                    <Setter Property="Margin" Value="0, 5, 0, 5" />
+                <Style TargetType="TextBox" BasedOn="{StaticResource ThemedDialogTextBoxStyle}">
+                    <!-- Validation indicators have width of 16 and show on the right side, need more margin space on the right-->
+                    <Setter Property="Margin" Value="0, 5, 20, 5" />
                     <Setter Property="Width" Value="100" />
                 </Style>
 
                 <Style TargetType="TextBlock">
+                    <!-- TextBlock doesn't have it's own resource for binding, so instead just make sure the foreground is bound to the same as all the labels -->
+                    <Setter Property="Foreground" Value="{Binding Path=Foreground, ElementName=RedLabel}" />
+                    <Setter Property="Padding" Value="0, 0, 10, 0" />
                     <Setter Property="Margin" Value="0, 5, 0, 5" />
-                    <Setter Property="Width" Value="100" />
+                    <Setter Property="HorizontalAlignment" Value="Left" />
+                    <Setter Property="VerticalAlignment" Value="Bottom" />
                 </Style>
                 <Style TargetType="Rectangle">
                     <Setter Property="Height" Value="25" />
-                    <Setter Property="Margin" Value="5" />
+                    <Setter Property="Margin" Value="0, 5, 10, 5" />
                 </Style>
             </Grid.Resources>
             <Grid.ColumnDefinitions>
@@ -73,7 +105,7 @@
             <!-- Use Polite LiveSettings for values that will change so that screen readers will read off their changes, but not interrupt any current notification being read -->
 
             <Label Content="Red" Grid.Row="0" Grid.Column="0" x:Name="RedLabel" />
-            <TextBox 
+            <TextBox
                 x:Name="Red"
                 Text="{Binding Red}" 
                 Grid.Row="0" 

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Roslyn.SyntaxVisualizer.Control"
              mc:Ignorable="d" 
              x:Name="Control"
-             Focusable="True"
+             Focusable="False"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <local:PercentConverter x:Key="PercentConverter" />

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
@@ -1,0 +1,109 @@
+﻿<UserControl x:Class="Roslyn.SyntaxVisualizer.Control.ColorPicker"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Roslyn.SyntaxVisualizer.Control"
+             mc:Ignorable="d" 
+             x:Name="Control"
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <UserControl.Resources>
+        <local:PercentConverter x:Key="PercentConverter" />
+    </UserControl.Resources>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <DockPanel x:Name="ColorSelectorsGrid" Grid.Column="0">
+            <local:SaturationBrightnessPicker 
+                DockPanel.Dock="Left"
+                Width="500"
+                Hue="{Binding Hue, Mode=OneWay}"
+                Saturation="{Binding Saturation, Mode=TwoWay}"
+                Brightness="{Binding Brightness, Mode=TwoWay}" />
+
+            <local:HuePicker 
+                DockPanel.Dock="Left"
+                Hue="{Binding Hue, Mode=TwoWay}" 
+                Width="50"
+                Margin="5, 0, 5, 0" />
+            
+        </DockPanel>
+        <Grid x:Name="ColorDetailsGrd" Grid.Column="1">
+            <Grid.Resources>
+                <Style TargetType="Label">
+                    <Setter Property="HorizontalAlignment" Value="Right" />
+                    <Setter Property="Padding" Value="0, 0, 10, 0" />
+                    <Setter Property="Margin" Value="0, 5, 0, 5" />
+                </Style>
+
+                <Style TargetType="TextBox">
+                    <Setter Property="Margin" Value="0, 5, 0, 5" />
+                    <Setter Property="Width" Value="100" />
+                </Style>
+
+                <Style TargetType="TextBlock">
+                    <Setter Property="Margin" Value="0, 5, 0, 5" />
+                    <Setter Property="Width" Value="100" />
+                </Style>
+                <Style TargetType="Rectangle">
+                    <Setter Property="Height" Value="25" />
+                    <Setter Property="Margin" Value="5" />
+                </Style>
+            </Grid.Resources>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Label Content="Red" Grid.Row="0" Grid.Column="0" />
+            <TextBox Text="{Binding Red}" Grid.Row="0" Grid.Column="1" />
+
+            <Label Content="Green" Grid.Row="1" Grid.Column="0" />
+            <TextBox Text="{Binding Green}" Grid.Row="1" Grid.Column="1" />
+
+            <Label Content="Blue" Grid.Row="2" Grid.Column="0" />
+            <TextBox Text="{Binding Blue}" Grid.Row="2" Grid.Column="1" />
+
+            <Label Content="Hex" Grid.Row="3" Grid.Column="0" />
+            <TextBlock Text="{Binding Color}" Grid.Row="3" Grid.Column="1" />
+
+            <Label Content="Hue" Grid.Row="4" Grid.Column="0" />
+            <TextBlock Text="{Binding Hue, StringFormat=N2}" Grid.Row="4" Grid.Column="1" />
+
+            <Label Content="Saturation" Grid.Row="5" Grid.Column="0" />
+            <TextBlock Text="{Binding Saturation, Converter={StaticResource PercentConverter}}" Grid.Row="5" Grid.Column="1" />
+
+            <Label Content="Brightness" Grid.Row="6" Grid.Column="0" />
+            <TextBlock Text="{Binding Brightness, Converter={StaticResource PercentConverter}}" Grid.Row="6" Grid.Column="1" />
+
+            <Label Content="Original Color" Grid.Row="7" Grid.Column="0" />
+            <Rectangle Grid.Row="7" Grid.Column="1">
+                <Rectangle.Fill>
+                    <SolidColorBrush Color="{Binding OriginalColor, Mode=OneWay}" />
+                </Rectangle.Fill>
+            </Rectangle>
+
+            <Label Content="New Color" Grid.Row="8" Grid.Column="0" />
+            <Rectangle Grid.Row="8" Grid.Column="1">
+                <Rectangle.Fill>
+                    <SolidColorBrush Color="{Binding Color, Mode=OneWay}" />
+                </Rectangle.Fill>
+            </Rectangle>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
@@ -7,7 +7,6 @@
              mc:Ignorable="d" 
              x:Name="Control"
              d:DesignHeight="450" d:DesignWidth="800">
-
     <UserControl.Resources>
         <local:PercentConverter x:Key="PercentConverter" />
     </UserControl.Resources>
@@ -30,7 +29,7 @@
                 Hue="{Binding Hue, Mode=TwoWay}" 
                 Width="50"
                 Margin="5, 0, 5, 0" />
-            
+
         </DockPanel>
         <Grid x:Name="ColorDetailsGrd" Grid.Column="1">
             <Grid.Resources>
@@ -70,36 +69,80 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Label Content="Red" Grid.Row="0" Grid.Column="0" />
-            <TextBox Text="{Binding Red}" Grid.Row="0" Grid.Column="1" />
+            <!-- Use Polite LiveSettings for values that will change so that screen readers will read off their changes, but not interrupt any current notification being read -->
 
-            <Label Content="Green" Grid.Row="1" Grid.Column="0" />
-            <TextBox Text="{Binding Green}" Grid.Row="1" Grid.Column="1" />
+            <Label Content="Red" Grid.Row="0" Grid.Column="0" x:Name="RedLabel" />
+            <TextBox 
+                x:Name="Red"
+                Text="{Binding Red}" 
+                Grid.Row="0" 
+                Grid.Column="1" 
+                AutomationProperties.Name="Red" 
+                AutomationProperties.LabeledBy="{Binding ElementName=RedLabel}" 
+                AutomationProperties.LiveSetting="Polite" />
 
-            <Label Content="Blue" Grid.Row="2" Grid.Column="0" />
-            <TextBox Text="{Binding Blue}" Grid.Row="2" Grid.Column="1" />
+            <Label Content="Green" Grid.Row="1" Grid.Column="0" x:Name="GreenLabel" />
+            <TextBox 
+                x:Name="Green"
+                Text="{Binding Green}" 
+                Grid.Row="1" 
+                Grid.Column="1" 
+                AutomationProperties.Name="Green" 
+                AutomationProperties.LabeledBy="{Binding ElementName=GreenLabel}" 
+                AutomationProperties.LiveSetting="Polite" />
 
-            <Label Content="Hex" Grid.Row="3" Grid.Column="0" />
-            <TextBlock Text="{Binding Color}" Grid.Row="3" Grid.Column="1" />
+            <Label Content="Blue" Grid.Row="2" Grid.Column="0" x:Name="BlueLabel" />
+            <TextBox 
+                x:Name="Blue"
+                Text="{Binding Blue}" 
+                Grid.Row="2" 
+                Grid.Column="1" 
+                AutomationProperties.Name="Blue" 
+                AutomationProperties.LabeledBy="{Binding ElementName=BlueLabel}" 
+                AutomationProperties.LiveSetting="Polite" />
 
-            <Label Content="Hue" Grid.Row="4" Grid.Column="0" />
-            <TextBlock Text="{Binding Hue, StringFormat=N2}" Grid.Row="4" Grid.Column="1" />
+            <Label Content="Hex" Grid.Row="3" Grid.Column="0" x:Name="HexLabel" />
+            <TextBlock 
+                Text="{Binding Color}" 
+                Grid.Row="3" 
+                Grid.Column="1" 
+                Focusable="False" 
+                AutomationProperties.LiveSetting="Polite" 
+                AutomationProperties.LabeledBy="{Binding ElementName=HexLabel}" />
 
-            <Label Content="Saturation" Grid.Row="5" Grid.Column="0" />
-            <TextBlock Text="{Binding Saturation, Converter={StaticResource PercentConverter}}" Grid.Row="5" Grid.Column="1" />
+            <Label Content="Hue" Grid.Row="4" Grid.Column="0" x:Name="HueLabel"/>
+            <TextBlock 
+                Text="{Binding Hue, StringFormat=N2}" 
+                Grid.Row="4" 
+                Grid.Column="1" 
+                AutomationProperties.LiveSetting="Polite" 
+                AutomationProperties.LabeledBy="{Binding ElementName=HueLabel}" />
 
-            <Label Content="Brightness" Grid.Row="6" Grid.Column="0" />
-            <TextBlock Text="{Binding Brightness, Converter={StaticResource PercentConverter}}" Grid.Row="6" Grid.Column="1" />
+            <Label Content="Saturation" Grid.Row="5" Grid.Column="0" x:Name="SaturationLabel"/>
+            <TextBlock 
+                Text="{Binding Saturation, Converter={StaticResource PercentConverter}}" 
+                Grid.Row="5" 
+                Grid.Column="1" 
+                AutomationProperties.LiveSetting="Polite" 
+                AutomationProperties.LabeledBy="{Binding ElementName=SaturationLabel}" />
 
-            <Label Content="Original Color" Grid.Row="7" Grid.Column="0" />
-            <Rectangle Grid.Row="7" Grid.Column="1">
+            <Label Content="Brightness" Grid.Row="6" Grid.Column="0" x:Name="BrightnessLabel"/>
+            <TextBlock 
+                Text="{Binding Brightness, Converter={StaticResource PercentConverter}}" 
+                Grid.Row="6" 
+                Grid.Column="1" 
+                AutomationProperties.LiveSetting="Polite" 
+                AutomationProperties.LabeledBy="{Binding ElementName=BrightnessLabel}" />
+
+            <Label Content="Original Color" Grid.Row="7" Grid.Column="0" x:Name="OriginalColorLabel" />
+            <Rectangle Grid.Row="7" Grid.Column="1" Focusable="False" AutomationProperties.LabeledBy="{Binding ElementName=OriginalColorLabel}">
                 <Rectangle.Fill>
                     <SolidColorBrush Color="{Binding OriginalColor, Mode=OneWay}" />
                 </Rectangle.Fill>
             </Rectangle>
 
-            <Label Content="New Color" Grid.Row="8" Grid.Column="0" />
-            <Rectangle Grid.Row="8" Grid.Column="1">
+            <Label Content="New Color" Grid.Row="8" Grid.Column="0" x:Name="NewColorLabel" />
+            <Rectangle Grid.Row="8" Grid.Column="1" Focusable="False" AutomationProperties.LabeledBy="{Binding ElementName=NewColorLabel}" >
                 <Rectangle.Fill>
                     <SolidColorBrush Color="{Binding Color, Mode=OneWay}" />
                 </Rectangle.Fill>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
@@ -13,13 +13,17 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <local:PercentConverter x:Key="PercentConverter" />
-        <ControlTemplate x:Uid="ControlTemplate_5" x:Key="ErrorTemplate">
-            <DockPanel x:Uid="DockPanel_1"
-                   LastChildFill="True">
-                <AdornedElementPlaceholder x:Uid="ControlWithError" Name="ControlWithError">
-                    <Border x:Uid="Border_5" BorderBrush="Red" BorderThickness="1" />
+
+        <!-- 
+            The ThemedDialogTextBoxStyleKey has an exception introduced when it's used. ErrorTemplate and ThemedDialogTextBoxStyle can be removed once the bug is fixed
+            https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1198412
+        -->
+        <ControlTemplate x:Key="ErrorTemplate">
+            <DockPanel LastChildFill="True">
+                <AdornedElementPlaceholder Name="ControlWithError">
+                    <Border BorderBrush="Red" BorderThickness="1" />
                 </AdornedElementPlaceholder>
-                <imaging:CrispImage x:Uid="CrispImage_1"
+                <imaging:CrispImage
                                 DockPanel.Dock="Right"
                                 VerticalAlignment="Center"
                                 Moniker="{x:Static catalog:KnownMonikers.StatusInvalid}"
@@ -30,10 +34,10 @@
             </DockPanel>
         </ControlTemplate>
         <Style TargetType="TextBox" BasedOn="{StaticResource {x:Static vsfx:VsResourceKeys.TextBoxStyleKey}}" x:Key="ThemedDialogTextBoxStyle">
-            <Setter x:Uid="Setter_41" Property="Validation.ErrorTemplate" Value="{StaticResource ErrorTemplate}" />
+            <Setter Property="Validation.ErrorTemplate" Value="{StaticResource ErrorTemplate}" />
             <Style.Triggers>
-                <Trigger x:Uid="Trigger_11" Property="Validation.HasError" Value="True">
-                    <Setter x:Uid="Setter_49" Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)[0].ErrorContent}" />
+                <Trigger Property="Validation.HasError" Value="True">
+                    <Setter Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)[0].ErrorContent}" />
                 </Trigger>
             </Style.Triggers>
         </Style>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:Roslyn.SyntaxVisualizer.Control"
              mc:Ignorable="d" 
              x:Name="Control"
+             Focusable="True"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <local:PercentConverter x:Key="PercentConverter" />
@@ -77,6 +78,7 @@
                 Text="{Binding Red}" 
                 Grid.Row="0" 
                 Grid.Column="1" 
+                GotFocus="SelectAllText"
                 AutomationProperties.Name="Red" 
                 AutomationProperties.LabeledBy="{Binding ElementName=RedLabel}" 
                 AutomationProperties.LiveSetting="Polite" />
@@ -87,6 +89,7 @@
                 Text="{Binding Green}" 
                 Grid.Row="1" 
                 Grid.Column="1" 
+                GotFocus="SelectAllText"
                 AutomationProperties.Name="Green" 
                 AutomationProperties.LabeledBy="{Binding ElementName=GreenLabel}" 
                 AutomationProperties.LiveSetting="Polite" />
@@ -97,6 +100,7 @@
                 Text="{Binding Blue}" 
                 Grid.Row="2" 
                 Grid.Column="1" 
+                GotFocus="SelectAllText"
                 AutomationProperties.Name="Blue" 
                 AutomationProperties.LabeledBy="{Binding ElementName=BlueLabel}" 
                 AutomationProperties.LiveSetting="Polite" />

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 
 namespace Roslyn.SyntaxVisualizer.Control
@@ -44,6 +45,9 @@ namespace Roslyn.SyntaxVisualizer.Control
                         break;
                 }
             };
+
+            // Focus the first tab item when the control gets focus
+            GotFocus += (s, e) => MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
         }
 
         public Color Color
@@ -56,6 +60,14 @@ namespace Roslyn.SyntaxVisualizer.Control
         {
             get => (Color)GetValue(OriginalColorProperty);
             set => SetValue(OriginalColorProperty, value);
+        }
+
+        private void SelectAllText(object sender, RoutedEventArgs e)
+        {
+            if (sender is TextBox textBox)
+            {
+                textBox.SelectAll();
+            }
         }
 
         private static void OnColorChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    /// <summary>
+    /// Interaction logic for ColorPicker.xaml
+    /// </summary>
+    public partial class ColorPicker : UserControl
+    {
+        public static readonly DependencyProperty ColorProperty = DependencyProperty.Register(
+            nameof(Color),
+            typeof(Color),
+            typeof(ColorPicker),
+            new PropertyMetadata(Colors.Red, OnColorChanged));
+
+        public static readonly DependencyProperty OriginalColorProperty = DependencyProperty.Register(
+            nameof(OriginalColor),
+            typeof(Color),
+            typeof(ColorPicker),
+            new PropertyMetadata(Colors.Red, OnOriginalColorChanged));
+
+        public ColorPicker()
+        {
+            var vm = new ColorPickerViewModel();
+            DataContext = vm;
+            InitializeComponent();
+
+            vm.PropertyChanged += (s, a) =>
+            {
+                switch (a.PropertyName)
+                {
+                    case nameof(ColorPickerViewModel.Color):
+                        Color = vm.Color;
+                        break;
+
+                    case nameof(ColorPickerViewModel.OriginalColor):
+                        OriginalColor = vm.OriginalColor;
+                        break;
+                }
+            };
+        }
+
+        public Color Color
+        {
+            get => (Color)GetValue(ColorProperty);
+            set => SetValue(ColorProperty, value);
+        }
+
+        public Color OriginalColor
+        {
+            get => (Color)GetValue(OriginalColorProperty);
+            set => SetValue(OriginalColorProperty, value);
+        }
+
+        private static void OnColorChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+            var colorPicker = (ColorPicker)o;
+            var vm = (ColorPickerViewModel)colorPicker.DataContext;
+            vm.Color = (Color)e.NewValue;
+        }
+
+        private static void OnOriginalColorChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+            var colorPicker = (ColorPicker)o;
+            var vm = (ColorPickerViewModel)colorPicker.DataContext;
+            vm.OriginalColor = (Color)e.NewValue;
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPicker.xaml.cs
@@ -45,9 +45,6 @@ namespace Roslyn.SyntaxVisualizer.Control
                         break;
                 }
             };
-
-            // Focus the first tab item when the control gets focus
-            GotFocus += (s, e) => MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
         }
 
         public Color Color

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerViewModel.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerViewModel.cs
@@ -1,0 +1,218 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Media;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    internal class ColorPickerViewModel : INotifyPropertyChanged
+    {
+        private UpdateBehavior _updateBehavior = UpdateBehavior.None;
+        public ColorPickerViewModel()
+        {
+        }
+
+        private Color _originalColor;
+        public Color OriginalColor
+        {
+            get => _originalColor;
+            set => SetProperty(ref _originalColor, value);
+        }
+
+        private Color _color;
+        public Color Color
+        {
+            get => _color;
+            set
+            {
+                if (!SetProperty(ref _color, value))
+                {
+                    return;
+                }
+
+                if (_updateBehavior != UpdateBehavior.FromComponent)
+                {
+                    UpdateColorComponents();
+                }
+            }
+        }
+
+        private double _hue;
+        public double Hue
+        {
+            get => _hue;
+            set
+            {
+                if (!SetProperty(ref _hue, value))
+                {
+                    return;
+                }
+
+                if (_updateBehavior == UpdateBehavior.None)
+                {
+                    UpdateColorFromHSB();
+                }
+            }
+        }
+
+        private double _saturation;
+        public double Saturation
+        {
+            get => _saturation;
+            set
+            {
+                if (!SetProperty(ref _saturation, value))
+                {
+                    return;
+                }
+
+                if (_updateBehavior == UpdateBehavior.None)
+                {
+                    UpdateColorFromHSB();
+                }
+            }
+        }
+
+        private double _brightness;
+        public double Brightness
+        {
+            get => _brightness;
+            set
+            {
+                if (!SetProperty(ref _brightness, value))
+                {
+                    return;
+                }
+
+                if (_updateBehavior == UpdateBehavior.None)
+                {
+                    UpdateColorFromHSB();
+                }
+            }
+        }
+
+        private byte _red;
+        public byte Red
+        {
+            get => _red;
+            set
+            {
+                if (!SetProperty(ref _red, value))
+                {
+                    return;
+                }
+
+                if (_updateBehavior == UpdateBehavior.None)
+                {
+                    UpdateColorFromRGB();
+                }
+            }
+        }
+
+        private byte _green;
+        public byte Green
+        {
+            get => _green;
+            set
+            {
+                if (!SetProperty(ref _green, value))
+                {
+                    return;
+                }
+
+                if (_updateBehavior == UpdateBehavior.None)
+                {
+                    UpdateColorFromRGB();
+                }
+            }
+        }
+
+        private byte _blue;
+        public byte Blue
+        {
+            get => _blue;
+            set
+            {
+                if (!SetProperty(ref _blue, value))
+                {
+                    return;
+                }
+
+                if (_updateBehavior == UpdateBehavior.None)
+                {
+                    UpdateColorFromRGB();
+                }
+            }
+        }
+
+        private void UpdateColorFromRGB()
+        {
+            _updateBehavior = UpdateBehavior.FromComponent;
+
+            Color = Color.FromRgb(Red, Green, Blue);
+            Hue = ColorHelpers.GetHue(Color);
+            Saturation = ColorHelpers.GetSaturation(Color);
+            Brightness = ColorHelpers.GetSaturation(Color);
+
+            _updateBehavior = UpdateBehavior.None;
+        }
+
+        private void UpdateColorFromHSB()
+        {
+            _updateBehavior = UpdateBehavior.FromComponent;
+
+            Color = ColorHelpers.HSVToColor(Hue, Saturation, Brightness);
+            Red = Color.R;
+            Green = Color.G;
+            Blue = Color.B;
+
+            _updateBehavior = UpdateBehavior.None;
+        }
+
+        private void UpdateColorComponents()
+        {
+            _updateBehavior = UpdateBehavior.FromColor;
+
+            Red = Color.R;
+            Green = Color.G;
+            Blue = Color.B;
+            Hue = ColorHelpers.GetHue(Color);
+            Saturation = ColorHelpers.GetSaturation(Color);
+            Brightness = ColorHelpers.GetSaturation(Color);
+
+            _updateBehavior = UpdateBehavior.None;
+        }
+
+        #region NotifyPropertyChanged
+        public event PropertyChangedEventHandler PropertyChanged;
+        private bool SetProperty<T>(ref T backingField, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (EqualityComparer<T>.Default.Equals(backingField, value))
+            {
+                return false;
+            }
+
+            backingField = value;
+            NotifyPropertyChanged(propertyName);
+            return true;
+        }
+
+        private void NotifyPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        #endregion
+
+        private enum UpdateBehavior
+        {
+            None,
+            
+            /// <summary>
+            /// Update is triggered from the Color property being updated
+            /// </summary>
+            FromColor,
+
+            /// <summary>
+            /// Update is triggered from a component of Color, such as Hue
+            /// </summary>
+            FromComponent
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml
@@ -4,8 +4,16 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Roslyn.SyntaxVisualizer.Control"
+        xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+        xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+        xmlns:vs2="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+        xmlns:vs3="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
         mc:Ignorable="d"
         ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+        vs2:ImageThemingUtilities.ThemeScrollBars="True"
+        Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}"
         Title="Color Picker" Height="450" Width="800">
     <Grid>
         <Grid.RowDefinitions>
@@ -14,9 +22,9 @@
         </Grid.RowDefinitions>
 
         <local:ColorPicker Grid.Row="0" x:Name="ColorPicker" Color="{Binding Color}" OriginalColor="{Binding Color, Mode=OneTime}" />
-        <StackPanel Grid.Row="1" HorizontalAlignment="Right" Orientation="Horizontal">
+        <StackPanel Grid.Row="1" HorizontalAlignment="Right" Orientation="Horizontal" Margin="0, 0, 10, 5">
             <StackPanel.Resources>
-                <Style TargetType="Button">
+                <Style TargetType="Button" BasedOn="{StaticResource {x:Static vsfx:VsResourceKeys.ThemedDialogButtonStyleKey}}">
                     <Setter Property="Margin" Value="5" />
                     <Setter Property="Padding" Value="5" />
                     <Setter Property="MinWidth" Value="40" />

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml
@@ -1,0 +1,29 @@
+﻿<Window x:Class="Roslyn.SyntaxVisualizer.Control.ColorPickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Roslyn.SyntaxVisualizer.Control"
+        mc:Ignorable="d"
+        ResizeMode="NoResize"
+        Title="Color Picker" Height="450" Width="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <local:ColorPicker Grid.Row="0" x:Name="ColorPicker" Color="{Binding Color}" OriginalColor="{Binding Color, Mode=OneTime}" />
+        <StackPanel Grid.Row="1" HorizontalAlignment="Right" Orientation="Horizontal">
+            <StackPanel.Resources>
+                <Style TargetType="Button">
+                    <Setter Property="Margin" Value="5" />
+                    <Setter Property="Padding" Value="5" />
+                    <Setter Property="MinWidth" Value="40" />
+                </Style>
+            </StackPanel.Resources>
+            <Button x:Name="OkButton" Content="Ok" Click="OkButton_Click" />
+            <Button x:Name="CancelButton" Content="Cancel" Click="CancelButton_Click" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    /// <summary>
+    /// Interaction logic for ColorPickerWindow.xaml
+    /// </summary>
+    public partial class ColorPickerWindow : Window
+    {
+        public Color Color { get; private set; }
+
+        public ColorPickerWindow(Color color)
+        {
+            InitializeComponent();
+
+            ColorPicker.OriginalColor = color;
+            ColorPicker.Color = color;
+        }
+
+        private void OkButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+
+            Color = ColorPicker.Color;
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Media;
 
 namespace Roslyn.SyntaxVisualizer.Control
@@ -18,8 +19,8 @@ namespace Roslyn.SyntaxVisualizer.Control
             ColorPicker.OriginalColor = color;
             ColorPicker.Color = color;
 
-            // Focus the color picker control on load
-            Loaded += (s, e) => ColorPicker.Focus();
+            // Focus the first tab item when the window loads
+            Loaded += (s, e) => MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
         }
 
         private void OkButton_Click(object sender, RoutedEventArgs e)

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ColorPickerWindow.xaml.cs
@@ -17,6 +17,9 @@ namespace Roslyn.SyntaxVisualizer.Control
 
             ColorPicker.OriginalColor = color;
             ColorPicker.Color = color;
+
+            // Focus the color picker control on load
+            Loaded += (s, e) => ColorPicker.Focus();
         }
 
         private void OkButton_Click(object sender, RoutedEventArgs e)

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ControlExtensions.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/ControlExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    internal static class ControlExtensions
+    {
+        internal static Point Clamp(this Point p, FrameworkElement element)
+        {
+            var pos = Mouse.GetPosition(element);
+            pos.X = Math.Min(Math.Max(0, pos.X), element.ActualWidth);
+            pos.Y = Math.Min(Math.Max(0, pos.Y), element.ActualHeight);
+            return pos;
+        }
+
+        internal static Color GetColorAtOffset(this GradientStopCollection collection, double offset)
+        {
+            GradientStop[] stops = collection.OrderBy(x => x.Offset).ToArray();
+            if (offset <= 0)
+            {
+                return stops[0].Color;
+            }
+            else if (offset >= 1)
+            {
+                return stops[stops.Length - 1].Color;
+            }
+
+            GradientStop left = stops[0];
+            GradientStop right = null;
+
+            foreach (GradientStop stop in stops)
+            {
+                if (stop.Offset >= offset)
+                {
+                    right = stop;
+                    break;
+                }
+
+                left = stop;
+            }
+
+            double percent = Math.Round((offset - left.Offset) / (right.Offset - left.Offset), 3);
+            byte a = (byte)((right.Color.A - left.Color.A) * percent + left.Color.A);
+            byte r = (byte)((right.Color.R - left.Color.R) * percent + left.Color.R);
+            byte g = (byte)((right.Color.G - left.Color.G) * percent + left.Color.G);
+            byte b = (byte)((right.Color.B - left.Color.B) * percent + left.Color.B);
+            return Color.FromArgb(a, r, g, b);
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/FontsAndColorsHelper.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/FontsAndColorsHelper.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Windows.Media;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    public static class FontsAndColorsHelper
+    {
+        private static readonly Guid TextEditorMEFItemsColorCategory = new Guid("75a05685-00a8-4ded-bae5-e7a50bfa929a");
+
+        public static Color? GetColorForClassification(ClassifiedSpan classifiedSpan)
+        {
+            if (string.IsNullOrEmpty(classifiedSpan.ClassificationType))
+            {
+                return null;
+            }
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var fontsAndColorStorage = ServiceProvider.GlobalProvider.GetService<SVsFontAndColorStorage, IVsFontAndColorStorage>();
+
+            if (fontsAndColorStorage is null)
+            {
+                return null;
+            }
+
+            // Open Text Editor category for readonly access.
+            if (fontsAndColorStorage.OpenCategory(TextEditorMEFItemsColorCategory, (uint)(__FCSTORAGEFLAGS.FCSF_READONLY | __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS | __FCSTORAGEFLAGS.FCSF_NOAUTOCOLORS)) != VSConstants.S_OK)
+            {
+                // We were unable to access color information.
+                return null;
+            }
+
+            try
+            {
+                var colorItems = new ColorableItemInfo[1];
+                if (fontsAndColorStorage.GetItem(classifiedSpan.ClassificationType, colorItems) != VSConstants.S_OK)
+                {
+                    return null;
+                }
+
+                var colorItem = colorItems[0];
+
+                var fontAndColorUtilities = (IVsFontAndColorUtilities)fontsAndColorStorage;
+                var foregroundColorRef = colorItem.crForeground;
+
+                if (fontAndColorUtilities.GetColorType(foregroundColorRef, out var foregroundColorType) != VSConstants.S_OK)
+                {
+                    // Without being able to check color type, we cannot make a determination.
+                    return null;
+                }
+
+                // Since the color type isn't default then it has been customized, we will
+                // perform an additional check for RGB colors to see if the customized color
+                // matches the color scheme color.
+                if (foregroundColorType != (int)__VSCOLORTYPE.CT_RAW)
+                {
+                    return null;
+                }
+
+                var colorBytes = BitConverter.GetBytes(foregroundColorRef);
+                return Color.FromRgb(colorBytes[0], colorBytes[1], colorBytes[2]);
+            }
+            finally
+            {
+                fontsAndColorStorage.CloseCategory();
+            }
+        }
+
+        internal static void UpdateClassificationColor(ClassifiedSpan classifiedSpan, Color selectedColor)
+        {
+            if (string.IsNullOrEmpty(classifiedSpan.ClassificationType))
+            {
+                return;
+            }
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var fontsAndColorStorage = ServiceProvider.GlobalProvider.GetService<SVsFontAndColorStorage, IVsFontAndColorStorage>();
+
+            if (fontsAndColorStorage is null)
+            {
+                return;
+            }
+
+            // Open Text Editor category for readonly access.
+            if (fontsAndColorStorage.OpenCategory(TextEditorMEFItemsColorCategory, (uint)(__FCSTORAGEFLAGS.FCSF_PROPAGATECHANGES | __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS)) != VSConstants.S_OK)
+            {
+                // We were unable to access color information.
+                return;
+            }
+
+            try
+            {
+                var colorItems = new ColorableItemInfo[1];
+                if (fontsAndColorStorage.GetItem(classifiedSpan.ClassificationType, colorItems) != VSConstants.S_OK)
+                {
+                    return;
+                }
+
+                var colorItem = colorItems[0];
+
+                colorItem.crForeground = BitConverter.ToUInt32(
+                    new byte[] {
+                        selectedColor.R, 
+                        selectedColor.G, 
+                        selectedColor.B,  
+                        0 // Alpha
+                    }, 0);
+
+                if (fontsAndColorStorage.SetItem(classifiedSpan.ClassificationType, new[] { colorItem }) != VSConstants.S_OK)
+                {
+                    throw new Exception();
+                }
+            }
+            finally
+            {
+                fontsAndColorStorage.CloseCategory();
+            }
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/FontsAndColorsHelper.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/FontsAndColorsHelper.cs
@@ -53,9 +53,8 @@ namespace Roslyn.SyntaxVisualizer.Control
                     return null;
                 }
 
-                // Since the color type isn't default then it has been customized, we will
-                // perform an additional check for RGB colors to see if the customized color
-                // matches the color scheme color.
+                // If the color is not CT_RAW then foregroundColorRef doesn't
+                // regpresent the RGB values for the color and we can't interpret them.
                 if (foregroundColorType != (int)__VSCOLORTYPE.CT_RAW)
                 {
                     return null;
@@ -86,7 +85,8 @@ namespace Roslyn.SyntaxVisualizer.Control
                 return;
             }
 
-            // Open Text Editor category for readonly access.
+            // Open Text Editor to make changes. Make sure LOADDEFAULTS is passed so any default 
+            // values can be modified as well.
             if (fontsAndColorStorage.OpenCategory(TextEditorMEFItemsColorCategory, (uint)(__FCSTORAGEFLAGS.FCSF_PROPAGATECHANGES | __FCSTORAGEFLAGS.FCSF_LOADDEFAULTS)) != VSConstants.S_OK)
             {
                 // We were unable to access color information.

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/HuePicker.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/HuePicker.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="Roslyn.SyntaxVisualizer.Control.HuePicker"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             x:Name="Control"
+             mc:Ignorable="d" 
+             SnapsToDevicePixels="True"
+             Background="Transparent"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Rectangle>
+            <Rectangle.Fill>
+                <LinearGradientBrush StartPoint="0,0" EndPoint="0,1" x:Name="Gradients">
+                    <LinearGradientBrush.GradientStops>
+                        <GradientStop Color="#FF0000" Offset="0" />
+                        <GradientStop Color="#FFFF00" Offset="0.167" />
+                        <GradientStop Color="#00FF00" Offset="0.333" />
+                        <GradientStop Color="#00FFFF" Offset="0.5" />
+                        <GradientStop Color="#0000FF" Offset="0.667" />
+                        <GradientStop Color="#FF00FF" Offset="0.833" />
+                        <GradientStop Color="#FF0000" Offset="1" />
+                    </LinearGradientBrush.GradientStops>
+                </LinearGradientBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+    </Grid>
+</UserControl>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/HuePicker.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/HuePicker.xaml.cs
@@ -1,0 +1,163 @@
+﻿using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    /// <summary>
+    /// Interaction logic for HuePicker.xaml
+    /// </summary>
+    public partial class HuePicker : UserControl
+    {
+        public static readonly DependencyProperty HueProperty
+            = DependencyProperty.Register(
+                nameof(Hue),
+                typeof(double),
+                typeof(HuePicker), 
+                new PropertyMetadata(0.0, OnHueChanged));
+
+
+        private readonly HuePickerAdorner _adorner;
+        private bool _isMouseUpdate = false;
+
+        public HuePicker()
+        {
+            InitializeComponent();
+
+            Loaded += OnLoaded;
+            _adorner = new HuePickerAdorner(this);
+        }
+
+        public double Hue
+        {
+            get => (double)GetValue(HueProperty);
+            set => SetValue(HueProperty, value);
+        }
+
+        private static void OnHueChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+            var huePicker = (HuePicker)o;
+            Debug.WriteLine($"OnHueChanged: {e.NewValue}");
+            if (huePicker._isMouseUpdate)
+            {
+                return;
+            }
+
+            var hue = (double)e.NewValue;
+            var percent = hue / 360;
+
+            huePicker.UpdateAdornment(ColorHelpers.HSVToColor(hue, 1, 1), percent);
+        }
+
+        private void UpdateAdornment(Color color, double percent)
+        {
+            _adorner.VerticalPercent = percent;
+            _adorner.Color = color;
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            base.OnMouseMove(e);
+
+            if (e.LeftButton != MouseButtonState.Pressed)
+            {
+                return;
+            }
+
+            Mouse.Capture(this);
+
+            Update(e.GetPosition(this).Clamp(this));
+        }
+
+        protected override void OnMouseUp(MouseButtonEventArgs e)
+        {
+            base.OnMouseUp(e);
+            Mouse.Capture(null);
+            Update(e.GetPosition(this).Clamp(this));
+        }
+
+        private void Update(Point mousePos)
+        {
+            _isMouseUpdate = true;
+
+            var verticalPercent = mousePos.Y / ActualHeight;
+            var color = Gradients.GradientStops.GetColorAtOffset(verticalPercent);
+            UpdateAdornment(color, verticalPercent);
+
+            var hue = ColorHelpers.GetHue(color);
+            Debug.WriteLine($"Updating hue to {hue}");
+            Hue = hue;
+
+            _isMouseUpdate = false;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            _adorner.ElementSize = new Rect(new Size(ActualWidth, ActualHeight));
+            AdornerLayer.GetAdornerLayer(this).Add(_adorner);
+        }
+
+        internal class HuePickerAdorner : Adorner
+        {
+            private static readonly DependencyProperty VerticalPercentProperty
+                = DependencyProperty.Register(nameof(VerticalPercent), typeof(double), typeof(HuePickerAdorner), new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.AffectsRender));
+            private static readonly DependencyProperty ColorProperty
+                = DependencyProperty.Register(nameof(Color), typeof(Color), typeof(HuePickerAdorner), new FrameworkPropertyMetadata(Colors.Red, FrameworkPropertyMetadataOptions.AffectsRender));
+            private static readonly Pen Pen = new Pen(Brushes.Black, 1);
+            private Brush _brush = Brushes.Red;
+
+            public HuePickerAdorner(UIElement adornedElement)
+                : base(adornedElement)
+            {
+                IsHitTestVisible = false;
+            }
+
+            public double VerticalPercent
+            {
+                get => (double)GetValue(VerticalPercentProperty);
+                set => SetValue(VerticalPercentProperty, value);
+            }
+
+            public Color Color
+            {
+                get => (Color)GetValue(ColorProperty);
+                set
+                {
+                    SetValue(ColorProperty, value);
+                    _brush = new SolidColorBrush(value);
+                }
+            }
+
+            public Rect ElementSize { get; set; }
+
+            protected override void OnRender(DrawingContext drawingContext)
+            {
+                base.OnRender(drawingContext);
+                var width = 5;
+                var y = ElementSize.Height * VerticalPercent;
+                var x = 5;
+
+                var triangleGeometry = new StreamGeometry();
+                using (var context = triangleGeometry.Open())
+                {
+                    context.BeginFigure(new Point(x, y + width / 2), true, true);
+                    context.LineTo(new Point(x + width, y), true, false);
+                    context.LineTo(new Point(x, y - width / 2), true, false);
+                }
+
+                var rightTri = triangleGeometry.Clone();
+                var transformGroup = new TransformGroup();
+                transformGroup.Children.Add(new ScaleTransform(-1, 1));
+                transformGroup.Children.Add(new TranslateTransform(ElementSize.Width, 0));
+                rightTri.Transform = transformGroup;
+
+
+                drawingContext.DrawGeometry(_brush, Pen, triangleGeometry);
+                drawingContext.DrawGeometry(_brush, Pen, rightTri);
+            }
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/HueToColorConverter.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/HueToColorConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    public class HueToColorConverter : IValueConverter
+    {
+        public object Convert(object obj, Type targetType, object parameter, CultureInfo culture)
+        {
+            var hue = (double)obj;
+            var saturation = 1.0d;
+            var value = 1.0d;
+
+            return ColorHelpers.HSVToColor(hue, saturation, value);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var color = (Color)value;
+            return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B).GetHue();
+        }
+
+
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/PercentConverter.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/PercentConverter.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    public class PercentConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => (int)((double)value * 100);
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => (int)value / 100.0d;
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/Roslyn.SyntaxVisualizer.Control.csproj
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/Roslyn.SyntaxVisualizer.Control.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisCommonVersionVS2019)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersionVS2019)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVisualBasicVersionVS2019)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.3.1" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop110Version)" />

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/Roslyn.SyntaxVisualizer.Control.csproj
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/Roslyn.SyntaxVisualizer.Control.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisCommonVersionVS2019)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersionVS2019)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVisualBasicVersionVS2019)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonVersionVS2019)" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop110Version)" />

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SaturationBrightnessPicker.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SaturationBrightnessPicker.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl x:Class="Roslyn.SyntaxVisualizer.Control.SaturationBrightnessPicker"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Roslyn.SyntaxVisualizer.Control"
+             mc:Ignorable="d" 
+             Background="Black"
+             x:Name="Control"
+             SnapsToDevicePixels="True"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <local:HueToColorConverter x:Key="HueConverter" />
+    </UserControl.Resources>
+    <Grid>
+        <Rectangle>
+            <Rectangle.Fill>
+                <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                    <LinearGradientBrush.GradientStops>
+                        <GradientStop Color="White" Offset="0" />
+                        <GradientStop Color="{Binding ElementName=Control, Path=Hue, Converter={StaticResource HueConverter}, Mode=OneWay}" Offset="1" />
+                    </LinearGradientBrush.GradientStops>
+                </LinearGradientBrush>
+            </Rectangle.Fill>
+            <Rectangle.OpacityMask>
+                <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                    <LinearGradientBrush.GradientStops>
+                        <GradientStop Color="#FFFFFFFF" Offset="0" />
+                        <GradientStop Color="#00000000" Offset="1" />
+                    </LinearGradientBrush.GradientStops>
+                </LinearGradientBrush>
+            </Rectangle.OpacityMask>
+        </Rectangle>
+    </Grid>
+</UserControl>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SaturationBrightnessPicker.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SaturationBrightnessPicker.xaml.cs
@@ -1,0 +1,160 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Roslyn.SyntaxVisualizer.Control
+{
+    /// <summary>
+    /// Interaction logic for SaturationBrightnessPicker.xaml
+    /// </summary>
+    public partial class SaturationBrightnessPicker : UserControl
+    {
+        public static readonly DependencyProperty HueProperty
+            = DependencyProperty.Register(
+                nameof(Hue),
+                typeof(double),
+                typeof(SaturationBrightnessPicker),
+                new PropertyMetadata(0.0));
+
+        public static readonly DependencyProperty SaturationProperty
+            = DependencyProperty.Register(
+                nameof(Saturation), 
+                typeof(double), 
+                typeof(SaturationBrightnessPicker), 
+                new PropertyMetadata(0.0, OnSaturationChanged));
+
+        public static readonly DependencyProperty BrightnessProperty
+            = DependencyProperty.Register(
+                nameof(Brightness), 
+                typeof(double), 
+                typeof(SaturationBrightnessPicker), 
+                new PropertyMetadata(0.0, OnBrightnessChanged));
+
+        private readonly SaturationBrightnessPickerAdorner _adorner;
+
+        private bool _inMouseUpdate = false;
+
+        public SaturationBrightnessPicker()
+        {
+            InitializeComponent();
+            _adorner = new SaturationBrightnessPickerAdorner(this);
+            Loaded += SaturationBrightnessPickerOnLoaded;
+        }
+
+        public double Hue
+        {
+            get => (double)GetValue(HueProperty);
+            set => SetValue(HueProperty, value);
+        }
+
+        public double Saturation
+        {
+            get => (double)GetValue(SaturationProperty);
+            set => SetValue(SaturationProperty, value);
+        }
+
+        public double Brightness
+        {
+            get => (double)GetValue(BrightnessProperty);
+            set => SetValue(BrightnessProperty, value);
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            base.OnMouseMove(e);
+
+            if (e.LeftButton != MouseButtonState.Pressed)
+            {
+                return;
+            }
+
+            Mouse.Capture(this);
+            var pos = e.GetPosition(this).Clamp(this);
+            Update(pos);
+        }
+
+        protected override void OnMouseUp(MouseButtonEventArgs e)
+        {
+            base.OnMouseUp(e);
+            Mouse.Capture(null);
+            var pos = e.GetPosition(this).Clamp(this);
+            Update(pos);
+        }
+
+        private static void OnSaturationChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+            var picker = (SaturationBrightnessPicker)o;
+
+            if (picker._inMouseUpdate)
+            {
+                return;
+            }
+
+            var sat = (double)e.NewValue;
+            var pos = picker._adorner.Position;
+            picker._adorner.Position = new Point(sat * picker.ActualWidth, pos.Y);
+        }
+
+        private static void OnBrightnessChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+            var picker = (SaturationBrightnessPicker)o;
+
+            if (picker._inMouseUpdate)
+            {
+                return;
+            }
+
+            var bright = (double)e.NewValue;
+            var pos = picker._adorner.Position;
+            picker._adorner.Position = new Point(pos.X, (1 - bright) * picker.ActualHeight);
+        }
+
+        private void SaturationBrightnessPickerOnLoaded(object sender, RoutedEventArgs e)
+        {
+            AdornerLayer.GetAdornerLayer(this).Add(_adorner);
+            _adorner.Position = new Point(Saturation * ActualWidth, (1 - Brightness) * ActualHeight);
+        }
+
+        private void Update(Point p)
+        {
+            _inMouseUpdate = true;
+
+            _adorner.Position = p;
+            Saturation = p.X / ActualWidth;
+            Brightness = 1 - (p.Y / ActualHeight); // directions reversed
+
+            _inMouseUpdate = false;
+        }
+
+        internal class SaturationBrightnessPickerAdorner : Adorner
+        {
+            private static readonly DependencyProperty PositionProperty
+                = DependencyProperty.Register(nameof(Position), typeof(Point), typeof(SaturationBrightnessPickerAdorner), new FrameworkPropertyMetadata(new Point(), FrameworkPropertyMetadataOptions.AffectsRender));
+            private static readonly Brush FillBrush = Brushes.Transparent;
+            private static readonly Pen InnerRingPen = new Pen(Brushes.White, 2);
+            private static readonly Pen OuterRingPen = new Pen(Brushes.Black, 2);
+
+            internal SaturationBrightnessPickerAdorner(UIElement adornedElement)
+                : base(adornedElement)
+            {
+                IsHitTestVisible = false;
+            }
+
+            internal Point Position
+            {
+                get => (Point)GetValue(PositionProperty);
+                set => SetValue(PositionProperty, value);
+            }
+
+            protected override void OnRender(DrawingContext drawingContext)
+            {
+                base.OnRender(drawingContext);
+
+                drawingContext.DrawEllipse(FillBrush, InnerRingPen, Position, 4, 4);
+                drawingContext.DrawEllipse(FillBrush, OuterRingPen, Position, 6, 6);
+            }
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
@@ -237,7 +237,7 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <Label Name="colorKindText" Padding="5,2,5,2" Grid.Column="0" />
-                        <Button Name="colorPickerButton" Width="30" Margin="5, 0, 5, 0" Grid.Column="1" />
+                        <Button Name="colorPickerButton" Width="30" Margin="5, 0, 5, 0" Grid.Column="1" AutomationProperties.Name="Color Picker" />
                     </Grid>
                 </Grid>
             </Border>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml
@@ -5,7 +5,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:vsui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0" 
+             xmlns:control="clr-namespace:Roslyn.SyntaxVisualizer.Control"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="300">
     <UserControl.Resources>
@@ -218,6 +219,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
@@ -228,6 +230,15 @@
                     <Label Grid.Row="1" Grid.Column="1" Name="typeValueLabel" Padding="5,2,5,2"/>
                     <Label Grid.Row="2" Grid.Column="0" Name="kindTextLabel" Visibility="Hidden" Content="Kind" Padding="5,2,5,2" Margin="20,0,0,0"/>
                     <Label Grid.Row="2" Grid.Column="1" Name="kindValueLabel" Padding="5,2,5,2"/>
+                    <Label Grid.Row="3" Grid.Column="0" Name="colorLabel" Content="Classification" Padding="5,2,5,2" Margin="20, 0, 0, 0" Visibility="Hidden" />
+                    <Grid Grid.Row="3" Grid.Column="1" Visibility="Hidden" x:Name="colorPickerGrid">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Label Name="colorKindText" Padding="5,2,5,2" Grid.Column="0" />
+                        <Button Name="colorPickerButton" Width="30" Margin="5, 0, 5, 0" Grid.Column="1" />
+                    </Grid>
                 </Grid>
             </Border>
             <WindowsFormsHost Grid.Row="1" x:Name="windowsFormsHost" Padding="0" />

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -8,6 +9,7 @@ using System.Windows.Controls;
 using System.Windows.Threading;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -268,7 +270,7 @@ namespace Roslyn.SyntaxVisualizer.Extension
                         // Display the SyntaxTree.
                         if (contentType.IsOfType(VisualBasicContentType) || contentType.IsOfType(CSharpContentType))
                         {
-                            syntaxVisualizer.DisplaySyntaxTree(activeSyntaxTree, activeSemanticModel);
+                            syntaxVisualizer.DisplaySyntaxTree(activeSyntaxTree, activeSemanticModel, workspace: document.Project.Solution.Workspace);
                         }
 
                         NavigateFromSource();


### PR DESCRIPTION
Syntax classification and the settings for it aren't really easy to find in Tools > Options > Fonts and Colors. This introduces an easier way to set colors by following the syntax tree. If a TextSpan is classified (using our public API for classification) then we use it to get the VS color settings for that classification and display to the user, allowing it to be changed. 

Most of the code changes are adding a color picker since I couldn't find one in VS or WPF readily. Heavily motivated from https://github.com/dsafa/wpf-color-picker 

Fonts and colors settings ported with help from @JoeRobich 

# Blue Theme Example

![classification_themed_blue_mode](https://user-images.githubusercontent.com/475144/92529141-da8e1600-f1de-11ea-960e-aabb7acb937c.gif)

# Dark Theme Example

![classification_themed_dark_mode](https://user-images.githubusercontent.com/475144/92529117-d3ff9e80-f1de-11ea-9e48-a9e08a21b345.gif)
