### PR TITLE
Set default severity explicitly

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -1201,7 +1201,14 @@ namespace Microsoft.CodeAnalysis.Testing
                 foreach (var diagnostic in analyzer.SupportedDiagnostics)
                 {
                     // make sure the analyzers we are testing are enabled
-                    supportedDiagnosticsSpecificOptions[diagnostic.Id] = ReportDiagnostic.Default;
+                    supportedDiagnosticsSpecificOptions[diagnostic.Id] = diagnostic.DefaultSeverity switch
+                    {
+                        DiagnosticSeverity.Hidden => ReportDiagnostic.Hidden,
+                        DiagnosticSeverity.Info => ReportDiagnostic.Info,
+                        DiagnosticSeverity.Warning => ReportDiagnostic.Warn,
+                        DiagnosticSeverity.Error => ReportDiagnostic.Error,
+                        _ => throw new InvalidOperationException(),
+                    };
                 }
             }
 


### PR DESCRIPTION
Fixes a failure to automatically enable analyzers in Roslyn 3.8.0-3.final.