### PR TITLE
[Bug fixde] Fixed bug with implicit JObject convertion in source generator mustache sample.

### DIFF
--- a/samples/CSharp/SourceGenerators/SourceGeneratorSamples/MustacheGenerator.cs
+++ b/samples/CSharp/SourceGenerators/SourceGeneratorSamples/MustacheGenerator.cs
@@ -85,7 +85,7 @@ namespace Mustache
         static string SourceFileFromMustachePath(string name, string template, string hash)
         {
             Func<object, string> tree = HandlebarsDotNet.Handlebars.Compile(template);
-            object @object = Newtonsoft.Json.JsonConvert.DeserializeObject(hash);
+            object @object = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, object>>(hash);
             string mustacheText = tree(@object);
 
             return GenerateMustacheClass(name, mustacheText);


### PR DESCRIPTION
In the first sample case of mustache section template in `UseMustacheGenerator.cs`, It would get result: "Hello Chris, You have just won 10000 dollars!".
But it should be "Hello Chris, You have just won 10000 dollars! Well, 10000 dollars, after taxes."
The problem here is the implicit json deserialization, so just add `Dictionary<string, object>` as explict type to get pass.