### PR TITLE
Use ReportDiagnostic.Default where analyzers are already enabled by default

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -1201,14 +1201,21 @@ namespace Microsoft.CodeAnalysis.Testing
                 foreach (var diagnostic in analyzer.SupportedDiagnostics)
                 {
                     // make sure the analyzers we are testing are enabled
-                    supportedDiagnosticsSpecificOptions[diagnostic.Id] = diagnostic.DefaultSeverity switch
+                    if (diagnostic.IsEnabledByDefault)
                     {
-                        DiagnosticSeverity.Hidden => ReportDiagnostic.Hidden,
-                        DiagnosticSeverity.Info => ReportDiagnostic.Info,
-                        DiagnosticSeverity.Warning => ReportDiagnostic.Warn,
-                        DiagnosticSeverity.Error => ReportDiagnostic.Error,
-                        _ => throw new InvalidOperationException(),
-                    };
+                        supportedDiagnosticsSpecificOptions[diagnostic.Id] = ReportDiagnostic.Default;
+                    }
+                    else
+                    {
+                        supportedDiagnosticsSpecificOptions[diagnostic.Id] = diagnostic.DefaultSeverity switch
+                        {
+                            DiagnosticSeverity.Hidden => ReportDiagnostic.Hidden,
+                            DiagnosticSeverity.Info => ReportDiagnostic.Info,
+                            DiagnosticSeverity.Warning => ReportDiagnostic.Warn,
+                            DiagnosticSeverity.Error => ReportDiagnostic.Error,
+                            _ => throw new InvalidOperationException(),
+                        };
+                    }
                 }
             }
 


### PR DESCRIPTION
This change allows tests to cover cases where an analyzer is enabled by default, but dynamically changes the severity and the point where diagnostics are reported.