### PR TITLE
Migrate from MSBuild.Sdk.Extras to Microsoft.NET.Sdk.WindowsDesktop

### DIFF
--- a/samples/CSharp/SolutionExplorer/SolutionExplorer.csproj
+++ b/samples/CSharp/SolutionExplorer/SolutionExplorer.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.65">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <RootNamespace>MSBuildWorkspaceTester</RootNamespace>
     <AssemblyName>SolutionExplorer</AssemblyName>
-    <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
+    <UseWpf>true</UseWpf>
     <OutputType>WinExe</OutputType>
     <AssemblyTitle>MSBuildWorkspaceTester</AssemblyTitle>
     <Company></Company>


### PR DESCRIPTION
Closes #247

I was not able to add the **SolutionExplorer.csproj** project to the solution because dotnet/wpf#3638 means the SDK is currently not able to build WPF projects.