### PR TITLE
Add component debugger

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,6 +6,7 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/Roslyn-SDK.sln
+++ b/Roslyn-SDK.sln
@@ -189,6 +189,8 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.Visu
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit.UnitTests", "tests\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit.UnitTests\Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit.UnitTests.vbproj", "{92BD1781-5DB4-4F72-BCCB-0D64C0790A2B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.ComponentDebugger", "src\VisualStudio.Roslyn.SDK\ComponentDebugger\Roslyn.ComponentDebugger.csproj", "{7E91C1C7-A836-4378-8ABC-9298C13228D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -539,6 +541,10 @@ Global
 		{92BD1781-5DB4-4F72-BCCB-0D64C0790A2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{92BD1781-5DB4-4F72-BCCB-0D64C0790A2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{92BD1781-5DB4-4F72-BCCB-0D64C0790A2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E91C1C7-A836-4378-8ABC-9298C13228D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E91C1C7-A836-4378-8ABC-9298C13228D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E91C1C7-A836-4378-8ABC-9298C13228D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E91C1C7-A836-4378-8ABC-9298C13228D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -635,6 +641,7 @@ Global
 		{7D9C0EF5-7383-4E35-811B-3288B3C806F3} = {9905147E-CC1F-42A0-BD27-05586C583DF7}
 		{7C3FE60E-055B-4E0C-BB85-C7E94A640074} = {9905147E-CC1F-42A0-BD27-05586C583DF7}
 		{92BD1781-5DB4-4F72-BCCB-0D64C0790A2B} = {9905147E-CC1F-42A0-BD27-05586C583DF7}
+		{7E91C1C7-A836-4378-8ABC-9298C13228D1} = {F9B73995-76C6-4056-ADA9-18342F951361}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {56695AA9-EA80-47A7-8562-E51285906C54}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
-    <MicrosoftNetCompilersToolsetVersion>3.8.0-4.20464.1</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.8.0-5.final</MicrosoftNetCompilersToolsetVersion>
     <!-- Force prior version due to https://github.com/microsoft/vstest/pull/2192 and https://github.com/microsoft/vstest/pull/2067 -->
     <MicrosoftNETTestSdkVersion>16.1.1</MicrosoftNETTestSdkVersion>
   </PropertyGroup>

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/CapabilityProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/CapabilityProvider.cs
@@ -14,11 +14,14 @@ namespace Roslyn.ComponentDebugger
     [AppliesTo(ProjectCapabilities.CSharp + " | " + ProjectCapabilities.VB)]
     public class CapabilityProvider : ConfiguredProjectCapabilitiesProviderBase
     {
+        private readonly IProjectSnapshotService snapshotService;
+
         [ImportingConstructor]
         [System.Obsolete("This exported object must be obtained through the MEF export provider.", error: true)]
-        public CapabilityProvider(ConfiguredProject configuredProject)
+        public CapabilityProvider(ConfiguredProject configuredProject, IProjectSnapshotService snapshotService)
             : base(nameof(CapabilityProvider), configuredProject)
         {
+            this.snapshotService = snapshotService;
         }
 
         protected override async Task<ImmutableHashSet<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
@@ -26,22 +29,15 @@ namespace Roslyn.ComponentDebugger
             // an alternative design could be to have 'IsRoslynComponent' just define the <Capability... directly in the managed.core targets
             // but that would require a specific roslyn version to work, this allows it to be backwards compatible with older SDKs
             var caps = Empty.CapabilitiesSet;
-            if (await IsRoslynComponentAsync(this.ConfiguredProject, cancellationToken).ConfigureAwait(false))
+
+            var snapshot = await snapshotService.GetLatestVersionAsync(ConfiguredProject, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var isRoslynComponentProperty = snapshot.Value.ProjectInstance.GetPropertyValue(Constants.RoslynComponentPropertyName);
+            var isComponent = string.Compare(isRoslynComponentProperty.Trim(), "true", System.StringComparison.OrdinalIgnoreCase) == 0;
+            if (isComponent)
             {
                 caps = caps.Add(Constants.RoslynComponentCapability);
             }
             return caps;
         }
-
-        private static Task<bool> IsRoslynComponentAsync(ConfiguredProject configuredProject, CancellationToken token = default) 
-            => configuredProject.Services.ProjectLockService.ReadLockAsync(
-                    async access =>
-                    {
-                        var project = await access.GetProjectAsync(configuredProject).ConfigureAwait(false);
-                        var isRoslynComponentProperty = project.GetProperty(Constants.RoslynComponentPropertyName);
-                        var isComponent = string.Compare(isRoslynComponentProperty?.EvaluatedValue.Trim(), "true", System.StringComparison.OrdinalIgnoreCase) == 0;
-                        return isComponent;
-                    },
-                    token);
     }
 }

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/CapabilityProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/CapabilityProvider.cs
@@ -23,7 +23,8 @@ namespace Roslyn.ComponentDebugger
 
         protected override async Task<ImmutableHashSet<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
         {
-            // PROTOTYPE: an alternative could be to have 'IsRoslynComponent' just define the <Capability... directly in the managed.core targets?
+            // an alternative design could be to have 'IsRoslynComponent' just define the <Capability... directly in the managed.core targets
+            // but that would require a specific roslyn version to work, this allows it to be backwards compatible with older SDKs
             var caps = Empty.CapabilitiesSet;
             if (await IsRoslynComponentAsync(this.ConfiguredProject, cancellationToken).ConfigureAwait(false))
             {

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/CapabilityProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/CapabilityProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.ProjectSystem;
 namespace Roslyn.ComponentDebugger
 {
     [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectCapabilitiesProvider))]
-    [AppliesTo(ProjectCapabilities.CSharp)]
+    [AppliesTo(ProjectCapabilities.CSharp + " | " + ProjectCapabilities.VB)]
     public class CapabilityProvider : ConfiguredProjectCapabilitiesProviderBase
     {
         [ImportingConstructor]

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/CapabilityProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/CapabilityProvider.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem;
+
+namespace Roslyn.ComponentDebugger
+{
+    [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectCapabilitiesProvider))]
+    [AppliesTo(ProjectCapabilities.CSharp)]
+    public class CapabilityProvider : ConfiguredProjectCapabilitiesProviderBase
+    {
+        [ImportingConstructor]
+        [System.Obsolete("This exported object must be obtained through the MEF export provider.", error: true)]
+        public CapabilityProvider(ConfiguredProject configuredProject)
+            : base(nameof(CapabilityProvider), configuredProject)
+        {
+        }
+
+        protected override async Task<ImmutableHashSet<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
+        {
+            // PROTOTYPE: an alternative could be to have 'IsRoslynComponent' just define the <Capability... directly in the managed.core targets?
+            var caps = Empty.CapabilitiesSet;
+            if (await IsRoslynComponentAsync(this.ConfiguredProject, cancellationToken).ConfigureAwait(false))
+            {
+                caps = caps.Add(Constants.RoslynComponentCapability);
+            }
+            return caps;
+        }
+
+        private static Task<bool> IsRoslynComponentAsync(ConfiguredProject configuredProject, CancellationToken token = default) 
+            => configuredProject.Services.ProjectLockService.ReadLockAsync(
+                    async access =>
+                    {
+                        var project = await access.GetProjectAsync(configuredProject).ConfigureAwait(false);
+                        var isRoslynComponentProperty = project.GetProperty(Constants.RoslynComponentPropertyName);
+                        var isComponent = string.Compare(isRoslynComponentProperty?.EvaluatedValue.Trim(), "true", System.StringComparison.OrdinalIgnoreCase) == 0;
+                        return isComponent;
+                    },
+                    token);
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Constants.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Constants.cs
@@ -4,7 +4,7 @@
 
 namespace Roslyn.ComponentDebugger
 {
-    internal class Constants
+    internal static class Constants
     {
         public const string RoslynComponentPropertyName = "IsRoslynComponent";
 

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Constants.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Constants.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.ComponentDebugger
+{
+    internal class Constants
+    {
+        public const string RoslynComponentPropertyName = "IsRoslynComponent";
+
+        public const string RoslynComponentCapability = "RoslynComponent";
+
+        public const string CommandName = "DebugRoslynComponent";
+
+        public const string TargetProjectPropertyName = "targetProject";
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebugProfileProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebugProfileProvider.cs
@@ -83,13 +83,24 @@ namespace Roslyn.ComponentDebugger
 
         private static bool TryGetTargetProject(ConfiguredProject project, ILaunchProfile? profile, out UnconfiguredProject? targetProject)
         {
-            var targetProjectPath = profile?.OtherSettings?.ContainsKey(Constants.TargetProjectPropertyName) == true
-                                    ? profile.OtherSettings[Constants.TargetProjectPropertyName].ToString()
-                                    : string.Empty;
+            targetProject = null;
+            if (TryGetOtherSettingAsString(profile, Constants.TargetProjectPropertyName, out var targetProjectPath))
+            {
+                // PROTOTYPE: we should eval / expand the path to work with env/msbuild variables etc.
+                targetProject = project.Services.ProjectService.LoadedUnconfiguredProjects.SingleOrDefault(p => p.FullPath == targetProjectPath);
+            }
 
-            // PROTOTYPE: we should eval / expand the path to work with env/msbuild variables etc.
-            targetProject = project.Services.ProjectService.LoadedUnconfiguredProjects.SingleOrDefault(p => p.FullPath == targetProjectPath);
             return targetProject is object;
+        }
+
+        private static bool TryGetOtherSettingAsString(ILaunchProfile? profile, string key, out string? value)
+        {
+            value = null;
+            if (profile?.OtherSettings?.ContainsKey(key) == true)
+            {
+                value = profile.OtherSettings[key] as string;
+            }
+            return value is string;
         }
     }
 }

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebugProfileProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebugProfileProvider.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+namespace Roslyn.ComponentDebugger
+{
+    [Export(typeof(IDebugProfileLaunchTargetsProvider))]
+    [AppliesTo(Constants.RoslynComponentCapability)]
+    public class DebugProfileProvider : IDebugProfileLaunchTargetsProvider
+    {
+        private readonly ConfiguredProject _configuredProject;
+
+        private readonly string _compilerRoot;
+
+        [ImportingConstructor]
+        [Obsolete("This exported object must be obtained through the MEF export provider.", error: true)]
+        public DebugProfileProvider(ConfiguredProject configuredProject, SVsServiceProvider? serviceProvider)
+        {
+            _configuredProject = configuredProject;
+            _compilerRoot = GetCompilerRoot(serviceProvider);
+        }
+
+        public Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile) => Task.CompletedTask;
+
+        public Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile) => Task.CompletedTask;
+
+        public bool SupportsProfile(ILaunchProfile? profile) => Constants.CommandName.Equals(profile?.CommandName, StringComparison.OrdinalIgnoreCase);
+
+        public async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile? profile)
+        {
+            // set up the managed (net fx) debugger to start a process
+            var settings = new DebugLaunchSettings(launchOptions)
+            {
+                LaunchDebugEngineGuid = Microsoft.VisualStudio.ProjectSystem.Debug.DebuggerEngines.ManagedOnlyEngine,
+                LaunchOperation = DebugLaunchOperation.CreateProcess
+            };
+
+            // try and get the target project
+            if (TryGetTargetProject(_configuredProject, profile, out var targetProjectUnconfigured))
+            {
+                settings.CurrentDirectory = Path.GetDirectoryName(targetProjectUnconfigured!.FullPath);
+                var compiler = _configuredProject.Capabilities.Contains(ProjectCapabilities.VB) ? "vbc.exe" : "csc.exe";
+                settings.Executable = Path.Combine(_compilerRoot, compiler);
+
+                // try and get the configured version of the target project
+                var targetProject = await targetProjectUnconfigured.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
+                if (targetProject is object)
+                {
+                    // get its compilation args
+                    var args = await targetProject.GetCompilationArgumentsAsync().ConfigureAwait(false);
+
+                    // append the command line args to the debugger launch
+                    settings.Arguments = string.Join(" ", args);
+                }
+            }
+
+            //PROTOTYPE: we probably shouldn't return anything when we couldn't figure it out
+            return new IDebugLaunchSettings[] { settings };
+        }
+
+        private static string GetCompilerRoot(SVsServiceProvider? serviceProvider)
+        {
+            // PROTOTYPE: we should try and work out the compiler location from the project itself
+            object rootDir = string.Empty;
+            var shell = (IVsShell?)serviceProvider?.GetService(typeof(SVsShell));
+            shell?.GetProperty((int)__VSSPROPID2.VSSPROPID_InstallRootDir, out rootDir);
+            return Path.Combine((string)rootDir, "MSBuild", "Current", "Bin", "Roslyn");
+        }
+
+        private static bool TryGetTargetProject(ConfiguredProject project, ILaunchProfile? profile, out UnconfiguredProject? targetProject)
+        {
+            var targetProjectPath = profile?.OtherSettings?.ContainsKey(Constants.TargetProjectPropertyName) == true
+                                    ? profile.OtherSettings[Constants.TargetProjectPropertyName].ToString()
+                                    : string.Empty;
+
+            // PROTOTYPE: we should eval / expand the path to work with env/msbuild variables etc.
+            targetProject = project.Services.ProjectService.LoadedUnconfiguredProjects.SingleOrDefault(p => p.FullPath == targetProjectPath);
+            return targetProject is object;
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebugProfileProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebugProfileProvider.cs
@@ -40,7 +40,7 @@ namespace Roslyn.ComponentDebugger
 
         public Task OnBeforeLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile) => Task.CompletedTask;
 
-        public bool SupportsProfile(ILaunchProfile? profile) => Constants.CommandName.Equals(profile?.CommandName, StringComparison.OrdinalIgnoreCase);
+        public bool SupportsProfile(ILaunchProfile? profile) => Constants.CommandName.Equals(profile?.CommandName, StringComparison.Ordinal);
 
         public async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile? profile)
         {

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptions.xaml
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptions.xaml
@@ -12,7 +12,7 @@
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
-        <!-- PROTOTYPE: Localization -->
+        <!-- https://github.com/dotnet/roslyn-sdk/issues/730 : Localization -->
         <Label Margin="4,4,3,5">Target Project:</Label>
         <ComboBox Grid.Column="1" Margin="5,7,2,6" ItemsSource="{Binding ProjectNames}" SelectedIndex="{Binding SelectedProjectIndex, Mode=TwoWay}" />
     </Grid>

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptions.xaml
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptions.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl x:Class="Roslyn.ComponentDebugger.DebuggerOptions"
+             x:ClassModifier="internal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="Auto"
+             HorizontalAlignment="Left"
+             VerticalAlignment="Top">
+    <Grid Margin="0,2,0,0">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="158" />
+            <ColumnDefinition Width="350" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <!-- PROTOTYPE: Localization -->
+        <Label Margin="4,4,3,5">Target Project:</Label>
+        <ComboBox Grid.Column="1" Margin="5,7,2,6" ItemsSource="{Binding ProjectNames}" SelectedIndex="{Binding SelectedProjectIndex, Mode=TwoWay}" />
+    </Grid>
+</UserControl>

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptions.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptions.xaml.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Controls;
+
+namespace Roslyn.ComponentDebugger
+{
+    /// <summary>
+    /// Interaction logic for DebuggerOptions.xaml
+    /// </summary>
+    internal sealed partial class DebuggerOptions : UserControl
+    {
+        public DebuggerOptions()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptionsViewModel.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptionsViewModel.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Roslyn.ComponentDebugger
+{
+    internal class DebuggerOptionsViewModel : INotifyPropertyChanged
+    {
+        private IWritableLaunchProfile? _launchProfile;
+
+        private readonly ImmutableArray<ConfiguredProject> _targetProjects;
+
+        private readonly IEnumerable<string> _targetProjectNames;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public DebuggerOptionsViewModel(ImmutableArray<ConfiguredProject> targetProjects)
+        {
+            _targetProjects = targetProjects;
+            _targetProjectNames = _targetProjects.Select(t => Path.GetFileNameWithoutExtension(t.UnconfiguredProject.FullPath));
+        }
+
+        public IEnumerable<string> ProjectNames { get => _targetProjectNames; }
+
+        public IWritableLaunchProfile? LaunchProfile
+        {
+            get => _launchProfile;
+            set
+            {
+                _launchProfile = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedProjectIndex)));
+            }
+        }
+
+        public int SelectedProjectIndex
+        {
+            get
+            {
+                if (LaunchProfile?.OtherSettings.ContainsKey(Constants.TargetProjectPropertyName) == true)
+                {
+                    var target = LaunchProfile.OtherSettings[Constants.TargetProjectPropertyName].ToString();
+                    for (var i = 0; i < _targetProjects.Length; i++)
+                    {
+                        if (_targetProjects[i].UnconfiguredProject.FullPath.Equals(target, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return i;
+                        }
+                    }
+                }
+                return -1;
+            }
+            set
+            {
+                if (LaunchProfile is object)
+                {
+                    var newTargetProject = _targetProjects[value].UnconfiguredProject;
+                    LaunchProfile.OtherSettings[Constants.TargetProjectPropertyName] = newTargetProject.FullPath;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedProjectIndex)));
+                }
+            }
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/LaunchSettingsProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/LaunchSettingsProvider.cs
@@ -71,18 +71,15 @@ namespace Roslyn.ComponentDebugger
                     var targetProject = await targetProjectUnconfigured.LoadConfiguredProjectAsync(configuredProject.ProjectConfiguration).ConfigureAwait(false);
                     if (targetProject is object)
                     {
-                        // https://github.com/dotnet/roslyn-sdk/issues/731: the below is deadlocking on certain projects. for now just list them all
-                        targetProjects.Add(targetProject);
-
                         // check if the args contain the project as an analyzer ref
-                        //foreach (var arg in await targetProject.GetCompilationArgumentsAsync().ConfigureAwait(false))
-                        //{
-                        //    if (arg.StartsWith("/analyzer", StringComparison.OrdinalIgnoreCase)
-                        //        && arg.EndsWith(target, StringComparison.OrdinalIgnoreCase))
-                        //    {
-                        //        targetProjects.Add(targetProject);
-                        //    }
-                        //}
+                        foreach (var arg in await targetProject.GetCompilationArgumentsAsync().ConfigureAwait(false))
+                        {
+                            if (arg.StartsWith("/analyzer", StringComparison.OrdinalIgnoreCase)
+                                && arg.EndsWith(target, StringComparison.OrdinalIgnoreCase))
+                            {
+                                targetProjects.Add(targetProject);
+                            }
+                        }
                     }
                 }
             }

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/LaunchSettingsProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/LaunchSettingsProvider.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Roslyn.ComponentDebugger
+{
+    [Export(typeof(ILaunchSettingsUIProvider))]
+    [AppliesTo(Constants.RoslynComponentCapability)]
+    public class LaunchSettingsProvider : ILaunchSettingsUIProvider
+    {
+        private readonly UnconfiguredProject _unconfiguredProject;
+        private readonly AsyncLazy<DebuggerOptionsViewModel> _viewModel;
+
+        [ImportingConstructor]
+        [Obsolete("This exported object must be obtained through the MEF export provider.", error: true)]
+        public LaunchSettingsProvider(UnconfiguredProject unconfiguredProject)
+        {
+            _unconfiguredProject = unconfiguredProject;
+            _viewModel = new AsyncLazy<DebuggerOptionsViewModel>(GetViewModelAsync, ThreadHelper.JoinableTaskFactory);
+        }
+
+        public string CommandName { get => Constants.CommandName; }
+
+        //PROTOTYPE: Localization
+        public string FriendlyName { get => "Roslyn Component"; }
+
+        public UserControl? CustomUI { get => new DebuggerOptions() { DataContext = _viewModel.GetValue() }; }
+
+        public void ProfileSelected(IWritableLaunchSettings curSettings)
+        {
+            // Update the viewmodel's current profile.
+            this._viewModel.GetValue().LaunchProfile = curSettings?.ActiveProfile;
+        }
+
+        public bool ShouldEnableProperty(string propertyName)
+        {
+            // PROTOTYPE: we disable all the default options for a debugger.
+            // we might want to enable env vars and (potentially) the exe to allow
+            // customization of the compiler used?
+            return false;
+        }
+
+        private async Task<DebuggerOptionsViewModel> GetViewModelAsync()
+        {
+            var targetProjects = ArrayBuilder<ConfiguredProject>.GetInstance();
+
+            // PROTOTYPE: we'll assume the target projects are in the same configuration as this one (can they be different?)
+            var configuredProject = await _unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
+            if (configuredProject is object)
+            {
+                // PROTOTYPE: there is presumably a project system way of doing this?
+                var projectArgs = await configuredProject.GetCompilationArgumentsAsync().ConfigureAwait(false);
+                var targetArg = projectArgs.LastOrDefault(a => a.StartsWith("/out:", StringComparison.OrdinalIgnoreCase));
+                var target = Path.GetFileName(targetArg);
+
+                var projectService = configuredProject.Services.ProjectService;
+                foreach (var targetProjectUnconfigured in projectService.LoadedUnconfiguredProjects)
+                {
+                    var targetProject = await targetProjectUnconfigured.LoadConfiguredProjectAsync(configuredProject.ProjectConfiguration).ConfigureAwait(false);
+                    if (targetProject is object)
+                    {
+                        //PROTOTYPE: the below is deadlocking on certain projects. for now just list them all
+                        targetProjects.Add(targetProject);
+
+                        // check if the args contain the project as an analyzer ref
+                        //foreach (var arg in await targetProject.GetCompilationArgumentsAsync().ConfigureAwait(false))
+                        //{
+                        //    if (arg.StartsWith("/analyzer", StringComparison.OrdinalIgnoreCase)
+                        //        && arg.EndsWith(target, StringComparison.OrdinalIgnoreCase))
+                        //    {
+                        //        targetProjects.Add(targetProject);
+                        //    }
+                        //}
+                    }
+                }
+            }
+
+            return new DebuggerOptionsViewModel(targetProjects.ToImmutableAndFree());
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/LaunchSettingsProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/LaunchSettingsProvider.cs
@@ -33,7 +33,7 @@ namespace Roslyn.ComponentDebugger
 
         public string CommandName { get => Constants.CommandName; }
 
-        //PROTOTYPE: Localization
+        // https://github.com/dotnet/roslyn-sdk/issues/730 : localization
         public string FriendlyName { get => "Roslyn Component"; }
 
         public UserControl? CustomUI { get => new DebuggerOptions() { DataContext = _viewModel.GetValue() }; }
@@ -46,8 +46,8 @@ namespace Roslyn.ComponentDebugger
 
         public bool ShouldEnableProperty(string propertyName)
         {
-            // PROTOTYPE: we disable all the default options for a debugger.
-            // we might want to enable env vars and (potentially) the exe to allow
+            // we disable all the default options for a debugger.
+            // in the future we might want to enable env vars and (potentially) the exe to allow
             // customization of the compiler used?
             return false;
         }
@@ -56,11 +56,11 @@ namespace Roslyn.ComponentDebugger
         {
             var targetProjects = ArrayBuilder<ConfiguredProject>.GetInstance();
 
-            // PROTOTYPE: we'll assume the target projects are in the same configuration as this one (can they be different?)
+            // NOTE: we assume the target projects are in the same configuration as this one (can they be different?)
             var configuredProject = await _unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
             if (configuredProject is object)
             {
-                // PROTOTYPE: there is presumably a project system way of doing this?
+                // get the output assembly for this project
                 var projectArgs = await configuredProject.GetCompilationArgumentsAsync().ConfigureAwait(false);
                 var targetArg = projectArgs.LastOrDefault(a => a.StartsWith("/out:", StringComparison.OrdinalIgnoreCase));
                 var target = Path.GetFileName(targetArg);
@@ -71,7 +71,7 @@ namespace Roslyn.ComponentDebugger
                     var targetProject = await targetProjectUnconfigured.LoadConfiguredProjectAsync(configuredProject.ProjectConfiguration).ConfigureAwait(false);
                     if (targetProject is object)
                     {
-                        //PROTOTYPE: the below is deadlocking on certain projects. for now just list them all
+                        // https://github.com/dotnet/roslyn-sdk/issues/731: the below is deadlocking on certain projects. for now just list them all
                         targetProjects.Add(targetProject);
 
                         // check if the args contain the project as an analyzer ref

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/ProjectUtilities.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/ProjectUtilities.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem;
+
+namespace Roslyn.ComponentDebugger
+{
+    public static class ProjectUtilities
+    {
+        // PROTOTYPE: is there a way to get this other than hardcoding it?
+        static readonly string[] CommandLineSchemaRuleNames = new[] { "CompilerCommandLineArgs" };
+
+        public static async Task<IList<string>> GetCompilationArgumentsAsync(this ConfiguredProject project)
+        {
+            if (project is null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            var args = ImmutableArray<string>.Empty;
+
+            var subscriptionService = project.Services.ProjectSubscription;
+            if (subscriptionService is object)
+            {
+                // get the latest snapshot of the command line args rules
+                var snapshots = await subscriptionService.JointRuleSource.GetLatestVersionAsync(project, CommandLineSchemaRuleNames).ConfigureAwait(false);
+                var latest = snapshots.Values.FirstOrDefault();
+
+                // extract the actual command line arguments
+                args = latest?.Items.Keys.ToImmutableArray() ?? args;
+            }
+
+            return args;
+        }
+    }
+}

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Roslyn.ComponentDebugger</RootNamespace>
+    <TargetFramework>net472</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="16.8.1-beta1-928-02" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="16.8.1-beta1-928-02" PrivateAssets="all" />
+    <PackageReference Include="NuGet.VisualStudio" Version="5.8.0-preview.2.6776" PrivateAssets="all" />
+    <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version=" 5.8.0-preview.2.6776" PrivateAssets="all" />
+
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="DebuggerOptions.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+</Project>

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Roslyn.ComponentDebugger</RootNamespace>
     <TargetFramework>net472</TargetFramework>
     <Nullable>enable</Nullable>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
@@ -21,15 +22,8 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EnvDTE" Version="16.9.30921.310" PrivateAssets="all" />
-    <PackageReference Include="EnvDTE80" Version="16.9.30921.310" PrivateAssets="all" />
-    <PackageReference Include="EnvDTE90" Version="16.9.30921.310" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="16.9.30921.310" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.ServiceHub.Framework" Version="2.7.339" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="16.8.1-beta1-928-02" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="16.8.1-beta1-928-02" PrivateAssets="all" />
-    <PackageReference Include="NuGet.VisualStudio" Version="5.8.0-preview.2.6776" PrivateAssets="all" />
-    <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version=" 5.8.0-preview.2.6776" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="16.8.1-beta1-1008-05" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="16.8.1-beta1-1008-05" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="DebuggerOptions.xaml">

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -21,11 +21,15 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="EnvDTE" Version="16.9.30921.310" PrivateAssets="all" />
+    <PackageReference Include="EnvDTE80" Version="16.9.30921.310" PrivateAssets="all" />
+    <PackageReference Include="EnvDTE90" Version="16.9.30921.310" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Embeddable" Version="16.9.30921.310" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.ServiceHub.Framework" Version="2.7.339" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="16.8.1-beta1-928-02" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="16.8.1-beta1-928-02" PrivateAssets="all" />
     <PackageReference Include="NuGet.VisualStudio" Version="5.8.0-preview.2.6776" PrivateAssets="all" />
     <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version=" 5.8.0-preview.2.6776" PrivateAssets="all" />
-
   </ItemGroup>
   <ItemGroup>
     <Page Include="DebuggerOptions.xaml">

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -24,6 +24,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="16.8.1-beta1-1008-05" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Version="16.8.1-beta1-1008-05" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="16.7.30329.63" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.6-alpha" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="16.8.30705.32" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="16.8.30705.32" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime" Version="16.8.30705.32" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.ServiceHub.Framework" Version="2.7.339" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="DebuggerOptions.xaml">

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="16.8.30705.32" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="16.8.30705.32" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime" Version="16.8.30705.32" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.ServiceHub.Framework" Version="2.7.339" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.ServiceHub.Framework" Version="2.7.100" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="DebuggerOptions.xaml">

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.6-alpha" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="16.8.30705.32" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="16.8.30705.32" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.1.DesignTime" Version="16.8.30705.32" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime" Version="16.8.30705.32" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ServiceHub.Framework" Version="2.7.100" PrivateAssets="all" />
   </ItemGroup>

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Roslyn.ComponentDebugger</RootNamespace>
     <TargetFramework>net472</TargetFramework>
     <Nullable>enable</Nullable>
-    <NoWarn>NU1603</NoWarn>
+    <NoWarn>NU1603;NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/Roslyn.SDK.csproj
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/Roslyn.SDK.csproj
@@ -128,4 +128,7 @@
       <Ngen>false</Ngen>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/Roslyn.SDK.csproj
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/Roslyn.SDK.csproj
@@ -120,5 +120,12 @@
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Ngen>false</Ngen>
     </ProjectReference>
+    <ProjectReference Include="..\ComponentDebugger\Roslyn.ComponentDebugger.csproj">
+      <Name>Roslyn.ComponentDebugger</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
+      <Ngen>false</Ngen>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/source.extension.vsixmanifest
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/source.extension.vsixmanifest
@@ -30,6 +30,7 @@
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="VBRefactoring"/>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Roslyn.SyntaxVisualizer.Extension" Path="|Roslyn.SyntaxVisualizer.Extension;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Roslyn.ComponentDebugger" Path="|Roslyn.ComponentDebugger|" />
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Adds the prototype Roslyn component debugger to the SDK.

## UX

User adds `<IsRoslynComponent>true</IsRoslynComponent>` to their generator project file

This enables the 'Roslyn Component' debugger option in debug settings (Project Properties -> Debug)

![image](https://user-images.githubusercontent.com/16246502/107443300-705f0180-6aed-11eb-8e08-80e2f91af689.png)

A user chooses the appropriate target project

![image](https://user-images.githubusercontent.com/16246502/107443332-7d7bf080-6aed-11eb-8086-4713c3e19930.png)

User F5's the generator project which starts CSC.exe/VBC.exe building the target project allowing them to debug the generator code.

## Known Issues

- Project filtering was hanging on some projects, so is disabled for now. The UI just displays all available projects as targets.
- Localization support is missing
- Target framework support when multi-targeting. Can we add another option?

## FAQ

1. How will this work with VSCode?
    - VSCode supports launchsettings.json so we should be able to write an equivalent VSCode extension that reads the target and does the launching
