### PR TITLE
Add main to yml trigger list

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -12,6 +12,7 @@ variables:
 # Branches that trigger a build on commit
 trigger:
 - master
+- main
 
 stages:
 - stage: build


### PR DESCRIPTION
Adds main to yml trigger list while we switch from master -> main. Hopefully keeping master in the trigger list for now avoids the build breakage seen yesterday in the roslyn repo. Once the transition is complete, master will be removed from the list and I will fix up the rest of the references in the repo.