### PR TITLE
Change occurrences of master to main

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -11,7 +11,6 @@ variables:
 
 # Branches that trigger a build on commit
 trigger:
-- master
 - main
 
 stages:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | Branch | Status |
 |:------:|:------:|
 |dev16.0.x|[![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/roslyn-sdk/public-CI?branchName=dev16.0.x&label=build)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=137&branchName=dev16.0.x)|
-|master|[![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/roslyn-sdk/public-CI?branchName=master&label=build)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=137&branchName=master)|
+|main|[![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/roslyn-sdk/public-CI?branchName=main&label=build)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=137&branchName=main)|
 
 # What is the Roslyn-SDK?
 

--- a/samples/CSharp/SourceGenerators/README.md
+++ b/samples/CSharp/SourceGenerators/README.md
@@ -3,7 +3,7 @@
 
 These samples are for an in-progress feature of Roslyn. As such they may change or break as the feature is developed, and no level of support is implied.
 
-For more infomation on the Source Generators feature, see the [design document](https://github.com/dotnet/roslyn/blob/master/docs/features/source-generators.md).
+For more infomation on the Source Generators feature, see the [design document](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.md).
 
 Prerequisites
 -----

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Analyzer/DiagnosticAnalyzer.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/Analyzer/DiagnosticAnalyzer.cs
@@ -16,7 +16,7 @@ namespace $saferootprojectname$
         public const string DiagnosticId = "$saferootidentifiername$";
 
         // You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
-        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
+        // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Localizing%20Analyzers.md for more on localization
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AnalyzerTitle), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AnalyzerDescription), Resources.ResourceManager, typeof(Resources));
@@ -32,7 +32,7 @@ namespace $saferootprojectname$
             context.EnableConcurrentExecution();
 
             // TODO: Consider registering other actions that act on syntax instead of or in addition to symbols
-            // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
+            // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
             context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
         }
 

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/CodeFix/CodeFixProvider.cs
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/CSharp/Diagnostic/CodeFix/CodeFixProvider.cs
@@ -25,7 +25,7 @@ namespace $saferootprojectname$
 
         public sealed override FixAllProvider GetFixAllProvider()
         {
-            // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+            // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
             return WellKnownFixAllProviders.BatchFixer;
         }
 

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Analyzer/DiagnosticAnalyzer.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/Analyzer/DiagnosticAnalyzer.vb
@@ -15,7 +15,7 @@ Public Class $saferootidentifiername$Analyzer
     Public Const DiagnosticId = "$saferootidentifiername$"
 
     ' You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
-    ' See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
+    ' See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Localizing%20Analyzers.md for more on localization
     Private Shared ReadOnly Title As LocalizableString = New LocalizableResourceString(NameOf(My.Resources.AnalyzerTitle), My.Resources.ResourceManager, GetType(My.Resources.Resources))
     Private Shared ReadOnly MessageFormat As LocalizableString = New LocalizableResourceString(NameOf(My.Resources.AnalyzerMessageFormat), My.Resources.ResourceManager, GetType(My.Resources.Resources))
     Private Shared ReadOnly Description As LocalizableString = New LocalizableResourceString(NameOf(My.Resources.AnalyzerDescription), My.Resources.ResourceManager, GetType(My.Resources.Resources))
@@ -34,7 +34,7 @@ Public Class $saferootidentifiername$Analyzer
         context.EnableConcurrentExecution()
 
         ' TODO: Consider registering other actions that act on syntax instead of or in addition to symbols
-        ' See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
+        ' See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
         context.RegisterSymbolAction(AddressOf AnalyzeSymbol, SymbolKind.NamedType)
     End Sub
 

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/CodeFix/CodeFixProvider.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/CodeFix/CodeFixProvider.vb
@@ -24,7 +24,7 @@ Public Class $saferootidentifiername$CodeFixProvider
     End Property
 
     Public NotOverridable Overrides Function GetFixAllProvider() As FixAllProvider
-        ' See https://github.com/dotnet/roslyn/blob/maindocs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        ' See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
         Return WellKnownFixAllProviders.BatchFixer
     End Function
 

--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/CodeFix/CodeFixProvider.vb
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK/ProjectTemplates/VisualBasic/Diagnostic/CodeFix/CodeFixProvider.vb
@@ -24,7 +24,7 @@ Public Class $saferootidentifiername$CodeFixProvider
     End Property
 
     Public NotOverridable Overrides Function GetFixAllProvider() As FixAllProvider
-        ' See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        ' See https://github.com/dotnet/roslyn/blob/maindocs/analyzers/FixAllProvider.md for more information on Fix All Providers
         Return WellKnownFixAllProviders.BatchFixer
     End Function
 


### PR DESCRIPTION
Switches occurrences of master to main and removes master from the yml pipeline. Some links to other dotnet repos will be broken, but since all dotnet repos are scheduled to switch over to main this sprint, this should be temporary.
`eng/common` files have been left purposely untouched since it appears modifying them may break things.