### PR TITLE
Source generator test improvements

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -208,6 +208,8 @@ Microsoft.CodeAnalysis.Testing.SolutionState.SolutionState(string name, string l
 Microsoft.CodeAnalysis.Testing.SolutionState.WithInheritedValuesApplied(Microsoft.CodeAnalysis.Testing.SolutionState baseState, System.Collections.Immutable.ImmutableArray<string> fixableDiagnostics) -> Microsoft.CodeAnalysis.Testing.SolutionState
 Microsoft.CodeAnalysis.Testing.SolutionState.WithProcessedMarkup(Microsoft.CodeAnalysis.Testing.MarkupOptions markupOptions, Microsoft.CodeAnalysis.DiagnosticDescriptor defaultDiagnostic, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> supportedDiagnostics, System.Collections.Immutable.ImmutableArray<string> fixableDiagnostics, string defaultPath) -> Microsoft.CodeAnalysis.Testing.SolutionState
 Microsoft.CodeAnalysis.Testing.SourceFileCollection
+Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((System.Type sourceGeneratorType, string filename, Microsoft.CodeAnalysis.Text.SourceText content) file) -> void
+Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((System.Type sourceGeneratorType, string filename, string content) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((string filename, string content) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.SourceFileCollection() -> void
 Microsoft.CodeAnalysis.Testing.SourceFileList

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SourceFileCollection.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SourceFileCollection.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Testing
@@ -12,6 +16,18 @@ namespace Microsoft.CodeAnalysis.Testing
         public void Add((string filename, string content) file)
         {
             Add((file.filename, SourceText.From(file.content)));
+        }
+
+        public void Add((Type sourceGeneratorType, string filename, string content) file)
+        {
+            var contentWithEncoding = SourceText.From(file.content, Encoding.UTF8);
+            Add((file.sourceGeneratorType, file.filename, contentWithEncoding));
+        }
+
+        public void Add((Type sourceGeneratorType, string filename, SourceText content) file)
+        {
+            var generatedPath = Path.Combine(file.sourceGeneratorType.GetTypeInfo().Assembly.GetName().Name ?? string.Empty, file.sourceGeneratorType.FullName!, file.filename);
+            Add((generatedPath, file.content));
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
@@ -60,8 +60,6 @@ namespace Microsoft.CodeAnalysis.Testing
 
         public override async Task RunAsync(CancellationToken cancellationToken = default)
         {
-            Verify.NotEmpty($"{nameof(TestState)}.{nameof(SolutionState.Sources)}", TestState.Sources);
-
             var analyzers = GetDiagnosticAnalyzers().ToArray();
             var defaultDiagnostic = GetDefaultDiagnostic(analyzers);
             var supportedDiagnostics = analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics).ToImmutableArray();

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests/SourceGeneratorValidationTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests/SourceGeneratorValidationTests.cs
@@ -39,6 +39,52 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         [Fact]
+        public async Task AddSimpleFileByGeneratorType()
+        {
+            await new CSharpSourceGeneratorTest<AddEmptyFile>
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"// Comment",
+                    },
+                },
+                FixedState =
+                {
+                    Sources =
+                    {
+                        @"// Comment",
+                        (typeof(AddEmptyFile), "EmptyGeneratedFile.cs", string.Empty),
+                    },
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task AddSimpleFileByGeneratorTypeWithEncoding()
+        {
+            await new CSharpSourceGeneratorTest<AddEmptyFile>
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"// Comment",
+                    },
+                },
+                FixedState =
+                {
+                    Sources =
+                    {
+                        @"// Comment",
+                        (typeof(AddEmptyFile), "EmptyGeneratedFile.cs", SourceText.From(string.Empty, Encoding.UTF8)),
+                    },
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task AddSimpleFileWithDiagnostic()
         {
             await new CSharpSourceGeneratorTest<AddEmptyFileWithDiagnostic>

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests/SourceGeneratorValidationTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests/SourceGeneratorValidationTests.cs
@@ -85,6 +85,27 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         [Fact]
+        public async Task AddSimpleFileToEmptyProject()
+        {
+            await new CSharpSourceGeneratorTest<AddEmptyFile>
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                    },
+                },
+                FixedState =
+                {
+                    Sources =
+                    {
+                        (typeof(AddEmptyFile), "EmptyGeneratedFile.cs", string.Empty),
+                    },
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task AddSimpleFileWithDiagnostic()
         {
             await new CSharpSourceGeneratorTest<AddEmptyFileWithDiagnostic>


### PR DESCRIPTION
Implements two specific changes from #754:

* Automatically generate file paths: https://github.com/dotnet/roslyn-sdk/issues/754#issuecomment-794396923
* Allow empty test inputs: https://github.com/dotnet/roslyn-sdk/issues/754#issuecomment-794388075