### PR TITLE
Add ProjectState.GeneratedSources API

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -988,6 +988,11 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <see cref="Diagnostic.Location"/>.</returns>
         protected async Task<ImmutableArray<Diagnostic>> GetSortedDiagnosticsAsync(Solution solution, ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableArray<Diagnostic> additionalDiagnostics, CompilerDiagnostics compilerDiagnostics, CancellationToken cancellationToken)
         {
+            if (analyzers.IsEmpty)
+            {
+                analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new EmptyDiagnosticAnalyzer());
+            }
+
             var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
             foreach (var project in solution.Projects)
             {

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/CodeActionTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/CodeActionTest`1.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.Testing
             return state.InheritanceMode != null
                 || state.MarkupHandling != null
                 || state.Sources.Any()
+                || state.GeneratedSources.Any()
                 || state.AdditionalFiles.Any()
                 || state.AnalyzerConfigFiles.Any()
                 || state.AdditionalFilesFactories.Any();
@@ -72,6 +73,7 @@ namespace Microsoft.CodeAnalysis.Testing
         protected static bool HasAnyChange(SolutionState oldState, SolutionState newState)
         {
             return !oldState.Sources.SequenceEqual(newState.Sources, SourceFileEqualityComparer.Instance)
+                || !oldState.GeneratedSources.SequenceEqual(newState.GeneratedSources, SourceFileEqualityComparer.Instance)
                 || !oldState.AdditionalFiles.SequenceEqual(newState.AdditionalFiles, SourceFileEqualityComparer.Instance)
                 || !oldState.AnalyzerConfigFiles.SequenceEqual(newState.AnalyzerConfigFiles, SourceFileEqualityComparer.Instance);
         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Model/EvaluatedProjectState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Model/EvaluatedProjectState.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.Testing.Model
                 state.OutputKind ?? OutputKind.DynamicallyLinkedLibrary,
                 state.DocumentationMode ?? DocumentationMode.Diagnose,
                 state.Sources.ToImmutableArray(),
+                state.GeneratedSources.ToImmutableArray(),
                 state.AdditionalFiles.ToImmutableArray(),
                 state.AnalyzerConfigFiles.ToImmutableArray(),
                 state.AdditionalProjectReferences.ToImmutableArray(),
@@ -37,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Testing.Model
             OutputKind outputKind,
             DocumentationMode documentationMode,
             ImmutableArray<(string filename, SourceText content)> sources,
+            ImmutableArray<(string filename, SourceText content)> generatedSources,
             ImmutableArray<(string filename, SourceText content)> additionalFiles,
             ImmutableArray<(string filename, SourceText content)> analyzerConfigFiles,
             ImmutableArray<string> additionalProjectReferences,
@@ -50,6 +52,7 @@ namespace Microsoft.CodeAnalysis.Testing.Model
             OutputKind = outputKind;
             DocumentationMode = documentationMode;
             Sources = sources;
+            GeneratedSources = generatedSources;
             AdditionalFiles = additionalFiles;
             AnalyzerConfigFiles = analyzerConfigFiles;
             AdditionalProjectReferences = additionalProjectReferences;
@@ -70,6 +73,8 @@ namespace Microsoft.CodeAnalysis.Testing.Model
         public DocumentationMode DocumentationMode { get; }
 
         public ImmutableArray<(string filename, SourceText content)> Sources { get; }
+
+        public ImmutableArray<(string filename, SourceText content)> GeneratedSources { get; }
 
         public ImmutableArray<(string filename, SourceText content)> AdditionalFiles { get; }
 
@@ -109,6 +114,7 @@ namespace Microsoft.CodeAnalysis.Testing.Model
             Optional<OutputKind> outputKind = default,
             Optional<DocumentationMode> documentationMode = default,
             Optional<ImmutableArray<(string filename, SourceText content)>> sources = default,
+            Optional<ImmutableArray<(string filename, SourceText content)>> generatedSources = default,
             Optional<ImmutableArray<(string filename, SourceText content)>> additionalFiles = default,
             Optional<ImmutableArray<(string filename, SourceText content)>> analyzerConfigFiles = default,
             Optional<ImmutableArray<string>> additionalProjectReferences = default,
@@ -123,6 +129,7 @@ namespace Microsoft.CodeAnalysis.Testing.Model
                 GetValueOrDefault(outputKind, OutputKind),
                 GetValueOrDefault(documentationMode, DocumentationMode),
                 GetValueOrDefault(sources, Sources),
+                GetValueOrDefault(generatedSources, GeneratedSources),
                 GetValueOrDefault(additionalFiles, AdditionalFiles),
                 GetValueOrDefault(analyzerConfigFiles, AnalyzerConfigFiles),
                 GetValueOrDefault(additionalProjectReferences, AdditionalProjectReferences),

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ProjectState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ProjectState.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Testing
             Sources = new SourceFileList(DefaultPrefix, DefaultExtension);
 
             Sources.AddRange(sourceState.Sources);
+            GeneratedSources.AddRange(sourceState.GeneratedSources);
             AdditionalFiles.AddRange(sourceState.AdditionalFiles);
             AnalyzerConfigFiles.AddRange(sourceState.AnalyzerConfigFiles);
             AdditionalFilesFactories.AddRange(sourceState.AdditionalFilesFactories);
@@ -63,6 +64,8 @@ namespace Microsoft.CodeAnalysis.Testing
         /// the <see cref="SourceFileList.Add(string)"/> methods.
         /// </summary>
         public SourceFileList Sources { get; }
+
+        public SourceFileCollection GeneratedSources { get; } = new SourceFileCollection();
 
         public SourceFileCollection AdditionalFiles { get; } = new SourceFileCollection();
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -225,6 +225,7 @@ Microsoft.CodeAnalysis.Testing.StateInheritanceMode.Explicit = 1 -> Microsoft.Co
 Microsoft.CodeAnalysis.Testing.TestBehaviors
 Microsoft.CodeAnalysis.Testing.TestBehaviors.None = 0 -> Microsoft.CodeAnalysis.Testing.TestBehaviors
 Microsoft.CodeAnalysis.Testing.TestBehaviors.SkipGeneratedCodeCheck = 1 -> Microsoft.CodeAnalysis.Testing.TestBehaviors
+Microsoft.CodeAnalysis.Testing.TestBehaviors.SkipGeneratedSourcesCheck = 4 -> Microsoft.CodeAnalysis.Testing.TestBehaviors
 Microsoft.CodeAnalysis.Testing.TestBehaviors.SkipSuppressionCheck = 2 -> Microsoft.CodeAnalysis.Testing.TestBehaviors
 Microsoft.CodeAnalysis.Testing.TestFileMarkupParser
 abstract Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.CreateCompilationOptions() -> Microsoft.CodeAnalysis.CompilationOptions

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -127,6 +127,7 @@ Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState.AnalyzerConfigFiles.g
 Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState.AssemblyName.get -> string
 Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState.DocumentationMode.get -> Microsoft.CodeAnalysis.DocumentationMode
 Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState.EvaluatedProjectState(Microsoft.CodeAnalysis.Testing.ProjectState state, Microsoft.CodeAnalysis.Testing.ReferenceAssemblies defaultReferenceAssemblies) -> void
+Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState.GeneratedSources.get -> System.Collections.Immutable.ImmutableArray<(string filename, Microsoft.CodeAnalysis.Text.SourceText content)>
 Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState.Language.get -> string
 Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState.Name.get -> string
 Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState.OutputKind.get -> Microsoft.CodeAnalysis.OutputKind
@@ -151,6 +152,7 @@ Microsoft.CodeAnalysis.Testing.ProjectState.AnalyzerConfigFiles.get -> Microsoft
 Microsoft.CodeAnalysis.Testing.ProjectState.AssemblyName.get -> string
 Microsoft.CodeAnalysis.Testing.ProjectState.DocumentationMode.get -> Microsoft.CodeAnalysis.DocumentationMode?
 Microsoft.CodeAnalysis.Testing.ProjectState.DocumentationMode.set -> void
+Microsoft.CodeAnalysis.Testing.ProjectState.GeneratedSources.get -> Microsoft.CodeAnalysis.Testing.SourceFileCollection
 Microsoft.CodeAnalysis.Testing.ProjectState.Language.get -> string
 Microsoft.CodeAnalysis.Testing.ProjectState.Name.get -> string
 Microsoft.CodeAnalysis.Testing.ProjectState.OutputKind.get -> Microsoft.CodeAnalysis.OutputKind?

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/TestBehaviors.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/TestBehaviors.cs
@@ -36,5 +36,15 @@ namespace Microsoft.CodeAnalysis.Testing
         /// at the beginning of the file.
         /// </summary>
         SkipSuppressionCheck = 0x02,
+
+        /// <summary>
+        /// Skip a verification check that the contents of <see cref="ProjectState.GeneratedSources"/> match the sources
+        /// produced by the active source generators (if any).
+        /// </summary>
+        /// <remarks>
+        /// When this flag is set, the <see cref="ProjectState.GeneratedSources"/> property is completely ignored; tests
+        /// are encouraged to leave it empty for optimal readability.
+        /// </remarks>
+        SkipGeneratedSourcesCheck = 0x04,
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/PublicAPI.Unshipped.txt
@@ -3,10 +3,8 @@ Microsoft.CodeAnalysis.Testing.EmptySourceGeneratorProvider.EmptySourceGenerator
 Microsoft.CodeAnalysis.Testing.EmptySourceGeneratorProvider.Execute(Microsoft.CodeAnalysis.GeneratorExecutionContext context) -> void
 Microsoft.CodeAnalysis.Testing.EmptySourceGeneratorProvider.Initialize(Microsoft.CodeAnalysis.GeneratorInitializationContext context) -> void
 Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>
-Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.FixedCode.set -> void
-Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.FixedState.get -> Microsoft.CodeAnalysis.Testing.SolutionState
 Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.SourceGeneratorTest() -> void
-Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.VerifySourceGeneratorAsync(Microsoft.CodeAnalysis.Testing.SolutionState testState, Microsoft.CodeAnalysis.Testing.SolutionState fixedState, Microsoft.CodeAnalysis.Testing.IVerifier verifier, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>>
+Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.VerifySourceGeneratorAsync(Microsoft.CodeAnalysis.Testing.SolutionState testState, Microsoft.CodeAnalysis.Testing.IVerifier verifier, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>>
 Microsoft.CodeAnalysis.Testing.SourceGeneratorVerifier<TSourceGenerator, TTest, TVerifier>
 Microsoft.CodeAnalysis.Testing.SourceGeneratorVerifier<TSourceGenerator, TTest, TVerifier>.SourceGeneratorVerifier() -> void
 abstract Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.CreateGeneratorDriver(Microsoft.CodeAnalysis.Project project, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator> sourceGenerators) -> Microsoft.CodeAnalysis.GeneratorDriver

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()
-            => new DiagnosticAnalyzer[] { new EmptyDiagnosticAnalyzer() };
+            => Enumerable.Empty<DiagnosticAnalyzer>();
 
         /// <summary>
         /// Returns the source generators being tested - to be implemented in non-abstract class.

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
@@ -42,9 +42,6 @@ namespace Microsoft.CodeAnalysis.Testing
         protected SourceGeneratorTest()
         {
             FixedState = new SolutionState(DefaultTestProjectName, Language, DefaultFilePathPrefix, DefaultFileExt);
-
-            // Disable test behaviors that don't make sense for source generator scenarios
-            TestBehaviors |= TestBehaviors.SkipSuppressionCheck | TestBehaviors.SkipGeneratedCodeCheck;
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
@@ -22,28 +22,6 @@ namespace Microsoft.CodeAnalysis.Testing
     public abstract class SourceGeneratorTest<TVerifier> : AnalyzerTest<TVerifier>
         where TVerifier : IVerifier, new()
     {
-        /// <summary>
-        /// Sets the expected output source file for source generator testing.
-        /// </summary>
-        /// <seealso cref="FixedState"/>
-        public string FixedCode
-        {
-            set
-            {
-                if (value != null)
-                {
-                    FixedState.Sources.Add(value);
-                }
-            }
-        }
-
-        public SolutionState FixedState { get; }
-
-        protected SourceGeneratorTest()
-        {
-            FixedState = new SolutionState(DefaultTestProjectName, Language, DefaultFilePathPrefix, DefaultFileExt);
-        }
-
         protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers()
             => Enumerable.Empty<DiagnosticAnalyzer>();
 
@@ -61,41 +39,33 @@ namespace Microsoft.CodeAnalysis.Testing
             var defaultDiagnostic = GetDefaultDiagnostic(analyzers);
             var supportedDiagnostics = analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics).ToImmutableArray();
             var fixableDiagnostics = ImmutableArray<string>.Empty;
+            var testState = TestState.WithInheritedValuesApplied(null, fixableDiagnostics).WithProcessedMarkup(MarkupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
 
-            var rawTestState = TestState.WithInheritedValuesApplied(null, fixableDiagnostics);
-            var rawFixedState = FixedState.WithInheritedValuesApplied(rawTestState, fixableDiagnostics);
-
-            var testState = rawTestState.WithProcessedMarkup(MarkupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
-            var fixedState = rawFixedState.WithProcessedMarkup(MarkupOptions, defaultDiagnostic, supportedDiagnostics, fixableDiagnostics, DefaultFilePath);
-
-            await VerifyDiagnosticsAsync(new EvaluatedProjectState(testState, ReferenceAssemblies), testState.AdditionalProjects.Values.Select(additionalProject => new EvaluatedProjectState(additionalProject, ReferenceAssemblies)).ToImmutableArray(), testState.ExpectedDiagnostics.ToArray(), Verify.PushContext("Diagnostics of test state"), cancellationToken).ConfigureAwait(false);
-            var diagnostics = await VerifySourceGeneratorAsync(testState, fixedState, Verify, cancellationToken).ConfigureAwait(false);
-            await VerifyDiagnosticsAsync(new EvaluatedProjectState(fixedState, ReferenceAssemblies).WithAdditionalDiagnostics(diagnostics), fixedState.AdditionalProjects.Values.Select(additionalProject => new EvaluatedProjectState(additionalProject, ReferenceAssemblies)).ToImmutableArray(), fixedState.ExpectedDiagnostics.ToArray(), Verify.PushContext("Diagnostics of test state with generated sources"), cancellationToken).ConfigureAwait(false);
+            var diagnostics = await VerifySourceGeneratorAsync(testState, Verify, cancellationToken).ConfigureAwait(false);
+            await VerifyDiagnosticsAsync(new EvaluatedProjectState(testState, ReferenceAssemblies).WithAdditionalDiagnostics(diagnostics), testState.AdditionalProjects.Values.Select(additionalProject => new EvaluatedProjectState(additionalProject, ReferenceAssemblies)).ToImmutableArray(), testState.ExpectedDiagnostics.ToArray(), Verify.PushContext("Diagnostics of test state"), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Called to test a C# source generator when applied on the input source as a string.
         /// </summary>
         /// <param name="testState">The effective input test state.</param>
-        /// <param name="fixedState">The effective test state after the source generators are applied.</param>
         /// <param name="verifier">The verifier to use for test assertions.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected async Task<ImmutableArray<Diagnostic>> VerifySourceGeneratorAsync(SolutionState testState, SolutionState fixedState, IVerifier verifier, CancellationToken cancellationToken)
+        protected async Task<ImmutableArray<Diagnostic>> VerifySourceGeneratorAsync(SolutionState testState, IVerifier verifier, CancellationToken cancellationToken)
         {
-            return await VerifySourceGeneratorAsync(Language, GetSourceGenerators().ToImmutableArray(), testState, fixedState, ApplySourceGeneratorAsync, verifier.PushContext("Source generator application"), cancellationToken);
+            return await VerifySourceGeneratorAsync(Language, GetSourceGenerators().ToImmutableArray(), testState, ApplySourceGeneratorAsync, verifier.PushContext("Source generator application"), cancellationToken);
         }
 
         private async Task<ImmutableArray<Diagnostic>> VerifySourceGeneratorAsync(
             string language,
             ImmutableArray<ISourceGenerator> sourceGenerators,
-            SolutionState oldState,
-            SolutionState newState,
+            SolutionState testState,
             Func<ImmutableArray<ISourceGenerator>, Project, IVerifier, CancellationToken, Task<(Project project, ImmutableArray<Diagnostic> diagnostics)>> getFixedProject,
             IVerifier verifier,
             CancellationToken cancellationToken)
         {
-            var project = await CreateProjectAsync(new EvaluatedProjectState(oldState, ReferenceAssemblies), oldState.AdditionalProjects.Values.Select(additionalProject => new EvaluatedProjectState(additionalProject, ReferenceAssemblies)).ToImmutableArray(), cancellationToken);
+            var project = await CreateProjectAsync(new EvaluatedProjectState(testState, ReferenceAssemblies), testState.AdditionalProjects.Values.Select(additionalProject => new EvaluatedProjectState(additionalProject, ReferenceAssemblies)).ToImmutableArray(), cancellationToken);
             _ = await GetCompilerDiagnosticsAsync(project, verifier, cancellationToken).ConfigureAwait(false);
 
             ImmutableArray<Diagnostic> diagnostics;
@@ -103,29 +73,17 @@ namespace Microsoft.CodeAnalysis.Testing
 
             // After applying the source generator, compare the resulting string to the inputted one
             var updatedDocuments = project.Documents.ToArray();
+            var expectedSources = testState.Sources.Concat(testState.GeneratedSources).ToArray();
 
-            verifier.Equal(newState.Sources.Count, updatedDocuments.Length, $"expected '{nameof(newState)}.{nameof(SolutionState.Sources)}' and '{nameof(updatedDocuments)}' to be equal but '{nameof(newState)}.{nameof(SolutionState.Sources)}' contains '{newState.Sources.Count}' documents and '{nameof(updatedDocuments)}' contains '{updatedDocuments.Length}' documents");
+            verifier.Equal(expectedSources.Length, updatedDocuments.Length, $"expected '{nameof(testState)}.{nameof(SolutionState.Sources)}' with '{nameof(testState)}.{nameof(SolutionState.GeneratedSources)}' to match '{nameof(updatedDocuments)}', but '{nameof(testState)}.{nameof(SolutionState.Sources)}' with '{nameof(testState)}.{nameof(SolutionState.GeneratedSources)}' contains '{expectedSources.Length}' documents and '{nameof(updatedDocuments)}' contains '{updatedDocuments.Length}' documents");
 
             for (var i = 0; i < updatedDocuments.Length; i++)
             {
                 var actual = await GetSourceTextFromDocumentAsync(updatedDocuments[i], cancellationToken).ConfigureAwait(false);
-                verifier.EqualOrDiff(newState.Sources[i].content.ToString(), actual.ToString(), $"content of '{newState.Sources[i].filename}' did not match. Diff shown with expected as baseline:");
-                verifier.Equal(newState.Sources[i].content.Encoding, actual.Encoding, $"encoding of '{newState.Sources[i].filename}' was expected to be '{newState.Sources[i].content.Encoding}' but was '{actual.Encoding}'");
-                verifier.Equal(newState.Sources[i].content.ChecksumAlgorithm, actual.ChecksumAlgorithm, $"checksum algorithm of '{newState.Sources[i].filename}' was expected to be '{newState.Sources[i].content.ChecksumAlgorithm}' but was '{actual.ChecksumAlgorithm}'");
-                verifier.Equal(newState.Sources[i].filename, updatedDocuments[i].Name, $"file name was expected to be '{newState.Sources[i].filename}' but was '{updatedDocuments[i].Name}'");
-            }
-
-            var updatedAdditionalDocuments = project.AdditionalDocuments.ToArray();
-
-            verifier.Equal(newState.AdditionalFiles.Count, updatedAdditionalDocuments.Length, $"expected '{nameof(newState)}.{nameof(SolutionState.AdditionalFiles)}' and '{nameof(updatedAdditionalDocuments)}' to be equal but '{nameof(newState)}.{nameof(SolutionState.AdditionalFiles)}' contains '{newState.AdditionalFiles.Count}' documents and '{nameof(updatedAdditionalDocuments)}' contains '{updatedAdditionalDocuments.Length}' documents");
-
-            for (var i = 0; i < updatedAdditionalDocuments.Length; i++)
-            {
-                var actual = await updatedAdditionalDocuments[i].GetTextAsync(cancellationToken).ConfigureAwait(false);
-                verifier.EqualOrDiff(newState.AdditionalFiles[i].content.ToString(), actual.ToString(), $"content of '{newState.AdditionalFiles[i].filename}' did not match. Diff shown with expected as baseline:");
-                verifier.Equal(newState.AdditionalFiles[i].content.Encoding, actual.Encoding, $"encoding of '{newState.AdditionalFiles[i].filename}' was expected to be '{newState.AdditionalFiles[i].content.Encoding}' but was '{actual.Encoding}'");
-                verifier.Equal(newState.AdditionalFiles[i].content.ChecksumAlgorithm, actual.ChecksumAlgorithm, $"checksum algorithm of '{newState.AdditionalFiles[i].filename}' was expected to be '{newState.AdditionalFiles[i].content.ChecksumAlgorithm}' but was '{actual.ChecksumAlgorithm}'");
-                verifier.Equal(newState.AdditionalFiles[i].filename, updatedAdditionalDocuments[i].Name, $"file name was expected to be '{newState.AdditionalFiles[i].filename}' but was '{updatedAdditionalDocuments[i].Name}'");
+                verifier.EqualOrDiff(expectedSources[i].content.ToString(), actual.ToString(), $"content of '{expectedSources[i].filename}' did not match. Diff shown with expected as baseline:");
+                verifier.Equal(expectedSources[i].content.Encoding, actual.Encoding, $"encoding of '{expectedSources[i].filename}' was expected to be '{expectedSources[i].content.Encoding}' but was '{actual.Encoding}'");
+                verifier.Equal(expectedSources[i].content.ChecksumAlgorithm, actual.ChecksumAlgorithm, $"checksum algorithm of '{expectedSources[i].filename}' was expected to be '{expectedSources[i].content.ChecksumAlgorithm}' but was '{actual.ChecksumAlgorithm}'");
+                verifier.Equal(expectedSources[i].filename, updatedDocuments[i].Name, $"file name was expected to be '{expectedSources[i].filename}' but was '{updatedDocuments[i].Name}'");
             }
 
             return diagnostics;

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
@@ -72,18 +72,21 @@ namespace Microsoft.CodeAnalysis.Testing
             (project, diagnostics) = await getFixedProject(sourceGenerators, project, verifier, cancellationToken).ConfigureAwait(false);
 
             // After applying the source generator, compare the resulting string to the inputted one
-            var updatedDocuments = project.Documents.ToArray();
-            var expectedSources = testState.Sources.Concat(testState.GeneratedSources).ToArray();
-
-            verifier.Equal(expectedSources.Length, updatedDocuments.Length, $"expected '{nameof(testState)}.{nameof(SolutionState.Sources)}' with '{nameof(testState)}.{nameof(SolutionState.GeneratedSources)}' to match '{nameof(updatedDocuments)}', but '{nameof(testState)}.{nameof(SolutionState.Sources)}' with '{nameof(testState)}.{nameof(SolutionState.GeneratedSources)}' contains '{expectedSources.Length}' documents and '{nameof(updatedDocuments)}' contains '{updatedDocuments.Length}' documents");
-
-            for (var i = 0; i < updatedDocuments.Length; i++)
+            if (!TestBehaviors.HasFlag(TestBehaviors.SkipGeneratedSourcesCheck))
             {
-                var actual = await GetSourceTextFromDocumentAsync(updatedDocuments[i], cancellationToken).ConfigureAwait(false);
-                verifier.EqualOrDiff(expectedSources[i].content.ToString(), actual.ToString(), $"content of '{expectedSources[i].filename}' did not match. Diff shown with expected as baseline:");
-                verifier.Equal(expectedSources[i].content.Encoding, actual.Encoding, $"encoding of '{expectedSources[i].filename}' was expected to be '{expectedSources[i].content.Encoding}' but was '{actual.Encoding}'");
-                verifier.Equal(expectedSources[i].content.ChecksumAlgorithm, actual.ChecksumAlgorithm, $"checksum algorithm of '{expectedSources[i].filename}' was expected to be '{expectedSources[i].content.ChecksumAlgorithm}' but was '{actual.ChecksumAlgorithm}'");
-                verifier.Equal(expectedSources[i].filename, updatedDocuments[i].Name, $"file name was expected to be '{expectedSources[i].filename}' but was '{updatedDocuments[i].Name}'");
+                var updatedDocuments = project.Documents.ToArray();
+                var expectedSources = testState.Sources.Concat(testState.GeneratedSources).ToArray();
+
+                verifier.Equal(expectedSources.Length, updatedDocuments.Length, $"expected '{nameof(testState)}.{nameof(SolutionState.Sources)}' with '{nameof(testState)}.{nameof(SolutionState.GeneratedSources)}' to match '{nameof(updatedDocuments)}', but '{nameof(testState)}.{nameof(SolutionState.Sources)}' with '{nameof(testState)}.{nameof(SolutionState.GeneratedSources)}' contains '{expectedSources.Length}' documents and '{nameof(updatedDocuments)}' contains '{updatedDocuments.Length}' documents");
+
+                for (var i = 0; i < updatedDocuments.Length; i++)
+                {
+                    var actual = await GetSourceTextFromDocumentAsync(updatedDocuments[i], cancellationToken).ConfigureAwait(false);
+                    verifier.EqualOrDiff(expectedSources[i].content.ToString(), actual.ToString(), $"content of '{expectedSources[i].filename}' did not match. Diff shown with expected as baseline:");
+                    verifier.Equal(expectedSources[i].content.Encoding, actual.Encoding, $"encoding of '{expectedSources[i].filename}' was expected to be '{expectedSources[i].content.Encoding}' but was '{actual.Encoding}'");
+                    verifier.Equal(expectedSources[i].content.ChecksumAlgorithm, actual.ChecksumAlgorithm, $"checksum algorithm of '{expectedSources[i].filename}' was expected to be '{expectedSources[i].content.ChecksumAlgorithm}' but was '{actual.ChecksumAlgorithm}'");
+                    verifier.Equal(expectedSources[i].filename, updatedDocuments[i].Name, $"file name was expected to be '{expectedSources[i].filename}' but was '{updatedDocuments[i].Name}'");
+                }
             }
 
             return diagnostics;

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests/SourceGeneratorValidationTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests/SourceGeneratorValidationTests.cs
@@ -114,6 +114,27 @@ namespace Microsoft.CodeAnalysis.Testing
             }.RunAsync();
         }
 
+        [Fact]
+        public async Task AddImplicitSimpleFileWithDiagnostic()
+        {
+            await new CSharpSourceGeneratorTest<AddEmptyFileWithDiagnostic>
+            {
+                TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck,
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"{|#0:|}// Comment",
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        // /0/Test0.cs(1,1): warning SG0001: Message
+                        new DiagnosticResult(AddEmptyFileWithDiagnostic.Descriptor).WithLocation(0),
+                    },
+                },
+            }.RunAsync();
+        }
+
         private class CSharpSourceGeneratorTest<TSourceGenerator> : SourceGeneratorTest<DefaultVerifier>
             where TSourceGenerator : ISourceGenerator, new()
         {

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests/SourceGeneratorValidationTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests/SourceGeneratorValidationTests.cs
@@ -26,12 +26,8 @@ namespace Microsoft.CodeAnalysis.Testing
                     {
                         @"// Comment",
                     },
-                },
-                FixedState =
-                {
-                    Sources =
+                    GeneratedSources =
                     {
-                        @"// Comment",
                         ("Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests\\Microsoft.CodeAnalysis.Testing.TestGenerators.AddEmptyFile\\EmptyGeneratedFile.cs", SourceText.From(string.Empty, Encoding.UTF8)),
                     },
                 },
@@ -49,12 +45,8 @@ namespace Microsoft.CodeAnalysis.Testing
                     {
                         @"// Comment",
                     },
-                },
-                FixedState =
-                {
-                    Sources =
+                    GeneratedSources =
                     {
-                        @"// Comment",
                         (typeof(AddEmptyFile), "EmptyGeneratedFile.cs", string.Empty),
                     },
                 },
@@ -72,12 +64,8 @@ namespace Microsoft.CodeAnalysis.Testing
                     {
                         @"// Comment",
                     },
-                },
-                FixedState =
-                {
-                    Sources =
+                    GeneratedSources =
                     {
-                        @"// Comment",
                         (typeof(AddEmptyFile), "EmptyGeneratedFile.cs", SourceText.From(string.Empty, Encoding.UTF8)),
                     },
                 },
@@ -94,10 +82,7 @@ namespace Microsoft.CodeAnalysis.Testing
                     Sources =
                     {
                     },
-                },
-                FixedState =
-                {
-                    Sources =
+                    GeneratedSources =
                     {
                         (typeof(AddEmptyFile), "EmptyGeneratedFile.cs", string.Empty),
                     },
@@ -114,14 +99,10 @@ namespace Microsoft.CodeAnalysis.Testing
                 {
                     Sources =
                     {
-                        @"// Comment",
-                    },
-                },
-                FixedState =
-                {
-                    Sources =
-                    {
                         @"{|#0:|}// Comment",
+                    },
+                    GeneratedSources =
+                    {
                         ("Microsoft.CodeAnalysis.SourceGenerators.Testing.UnitTests\\Microsoft.CodeAnalysis.Testing.TestGenerators.AddEmptyFileWithDiagnostic\\EmptyGeneratedFile.cs", SourceText.From(string.Empty, Encoding.UTF8)),
                     },
                     ExpectedDiagnostics =


### PR DESCRIPTION
* Add `ProjectState.GeneratedSources`. This is the primary property that will eventually allow any test (analyzer, code fix, refactoring, or source generator) to include generated sources.
* Add `TestBehaviors.SkipGeneratedSourcesCheck`, which allows tests to implicitly include source generator outputs (as opposed to verifying that they match the contents of `GeneratedSources`).
* Rewrite source generator testing to no longer verify diagnostics for the intermediate state prior to running source generators.

Closes #754