### PR TITLE
Restore .cs file for options control

### DIFF
--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptions.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/DebuggerOptions.xaml.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.ComponentDebugger
+{
+    partial class DebuggerOptions
+    {
+        public DebuggerOptions()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Previous merges meant this file was removed.

That meant that when the component loaded, the UI never got the call to `InitializeComponent` 