### PR TITLE
fix "SourceGenerators.sln" project file paths

### DIFF
--- a/samples/CSharp/SourceGenerators/SourceGenerators.sln
+++ b/samples/CSharp/SourceGenerators/SourceGenerators.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30022.13
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceGeneratorSamples", "SourceGeneratorSamples\SourceGeneratorSamples.csproj", "{B452269D-856C-4FE6-8900-3D81461AF864}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceGeneratorSamples", "SourceGeneratorSamples\CSharpSourceGeneratorSamples.csproj", "{B452269D-856C-4FE6-8900-3D81461AF864}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneratedDemo", "GeneratedDemo\GeneratedDemo.csproj", "{DB138C8B-7C34-4AC7-A443-A0B29D1CE8A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneratedDemo", "GeneratedDemo\CSharpGeneratedDemo.csproj", "{DB138C8B-7C34-4AC7-A443-A0B29D1CE8A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
https://github.com/dotnet/roslyn-sdk/commit/3b73f786aadb6b16149a6de024c374a2717f6b30 renamed the `GeneratedDemo.csproj`->`CSharpGeneratedDemo.csproj` and `SourceGeneratorSamples.csproj`->`CSharpSourceGeneratorSamples.csproj` files but `SourceGenerators.sln` was never updated with the new project file names.