### PR TITLE
Added AnalyzerTest.RunAsync overload accepting array of expected Diagnostic results.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Testing
             }
         }
 
-        protected override async Task RunImplAsync(CancellationToken cancellationToken)
+        protected async Task RunImplAsync(CancellationToken cancellationToken)
         {
             Verify.NotEmpty($"{nameof(TestState)}.{nameof(SolutionState.Sources)}", TestState.Sources);
 
@@ -247,6 +247,12 @@ namespace Microsoft.CodeAnalysis.Testing
 
                 await VerifyFixAsync(testState, fixedState, batchFixedState, Verify, cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        protected override async Task RunImplAsync(DiagnosticResult[] expectedDiagnostics, CancellationToken cancellationToken)
+        {
+            _ = expectedDiagnostics;
+            await RunImplAsync(cancellationToken);
         }
 
         private bool CodeFixExpected()

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/CodeRefactoringTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/CodeRefactoringTest`1.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <returns>The <see cref="CodeRefactoringProvider"/> to be used.</returns>
         protected abstract IEnumerable<CodeRefactoringProvider> GetCodeRefactoringProviders();
 
-        protected override async Task RunImplAsync(CancellationToken cancellationToken)
+        protected async Task RunImplAsync(CancellationToken cancellationToken)
         {
             Verify.NotEmpty($"{nameof(TestState)}.{nameof(SolutionState.Sources)}", TestState.Sources);
 
@@ -107,6 +107,12 @@ namespace Microsoft.CodeAnalysis.Testing
                 Verify.True(triggerSpan.HasValue, "Expected the test to include a single trigger span for refactoring");
                 return triggerSpan!.Value;
             }
+        }
+
+        protected override async Task RunImplAsync(DiagnosticResult[] expectedDiagnostics, CancellationToken cancellationToken)
+        {
+            _ = expectedDiagnostics;
+            await RunImplAsync(cancellationToken);
         }
 
         private bool CodeActionExpected()


### PR DESCRIPTION
This will make it easier for developers having an hard time with making a function that's goal is to be used by all of their tests (even if some of them expects to test that they generate a Diagnostic while other tests might verify that they do not.

Fixes https://github.com/dotnet/roslyn-sdk/issues/860.