### PR TITLE
Added closing slash to analyzer reference XML

### DIFF
--- a/samples/CSharp/SourceGenerators/README.md
+++ b/samples/CSharp/SourceGenerators/README.md
@@ -28,7 +28,7 @@ You can add the sample generators to your own project by adding an item group co
 
 ```xml
 <ItemGroup>
-    <Analyzer Include="path\to\SourceGeneratorSamples.dll">
+    <Analyzer Include="path\to\SourceGeneratorSamples.dll"/>
 </ItemGroup>
 ```
 


### PR DESCRIPTION
The XML in the SourceGenerators README is missing a closing slash. This adds it in.