### PR TITLE
Update to DiffPlex 1.5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
     <VSLangProjVersion>16.7.30508.193</VSLangProjVersion>
     <VSSDKTemplateWizardInterfaceVersion>12.0.4</VSSDKTemplateWizardInterfaceVersion>
     <!-- Libs -->
-    <DiffPlexVersion>1.4.4</DiffPlexVersion>
+    <DiffPlexVersion>1.5.0</DiffPlexVersion>
     <!-- Testing -->
     <MicrosoftCodeAnalysis2PrimaryTestVersion>2.6.1</MicrosoftCodeAnalysis2PrimaryTestVersion>
     <MicrosoftCodeAnalysis3PrimaryTestVersion>3.9.0</MicrosoftCodeAnalysis3PrimaryTestVersion>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Extensions/IVerifierExtensions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Extensions/IVerifierExtensions.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using DiffPlex;
+using DiffPlex.Chunkers;
 using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
-using DiffPlex.Model;
 
 namespace Microsoft.CodeAnalysis.Testing
 {
@@ -18,8 +16,9 @@ namespace Microsoft.CodeAnalysis.Testing
     /// </summary>
     public static class IVerifierExtensions
     {
-        private static readonly InlineDiffBuilder s_diffWithoutLineEndings = new InlineDiffBuilder(new Differ());
-        private static readonly InlineDiffBuilder s_diffWithLineEndings = new InlineDiffBuilder(new DifferWithLineEndings());
+        private static readonly IChunker s_lineChunker = new LineChunker();
+        private static readonly IChunker s_lineEndingsPreservingChunker = new LineEndingsPreservingChunker();
+        private static readonly InlineDiffBuilder s_diffBuilder = new InlineDiffBuilder(new Differ());
 
         /// <summary>
         /// Asserts that two strings are equal, and prints a diff between the two if they are not.
@@ -34,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Testing
 
             if (expected != actual)
             {
-                var diff = s_diffWithoutLineEndings.BuildDiffModel(expected, actual, ignoreWhitespace: false);
+                var diff = s_diffBuilder.BuildDiffModel(expected, actual, ignoreWhitespace: false, ignoreCase: false, s_lineChunker);
                 var messageBuilder = new StringBuilder();
                 messageBuilder.AppendLine(
                     string.IsNullOrEmpty(message)
@@ -44,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 if (!diff.Lines.Any(line => line.Type == ChangeType.Inserted || line.Type == ChangeType.Deleted))
                 {
                     // We have a failure only caused by line ending differences; recalculate with line endings visible
-                    diff = s_diffWithLineEndings.BuildDiffModel(expected, actual, ignoreWhitespace: false);
+                    diff = s_diffBuilder.BuildDiffModel(expected, actual, ignoreWhitespace: false, ignoreCase: false, s_lineEndingsPreservingChunker);
                 }
 
                 foreach (var line in diff.Lines)
@@ -62,86 +61,11 @@ namespace Microsoft.CodeAnalysis.Testing
                             break;
                     }
 
-                    messageBuilder.AppendLine(line.Text);
+                    messageBuilder.AppendLine(line.Text.Replace("\r", "<CR>").Replace("\n", "<LF>"));
                 }
 
                 verifier.Fail(messageBuilder.ToString());
             }
-        }
-
-        private class DifferWithLineEndings : IDiffer
-        {
-            private const string CarriageReturnText = "<CR>";
-            private const string LineFeedText = "<LF>";
-
-            private static readonly char[] s_endOfLineCharacters = { '\r', '\n' };
-            private static readonly Differ s_differ = new Differ();
-
-            public DiffResult CreateCharacterDiffs(string oldText, string newText, bool ignoreWhitespace)
-                => s_differ.CreateCharacterDiffs(oldText, newText, ignoreWhitespace);
-
-            public DiffResult CreateCharacterDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase)
-                => s_differ.CreateCharacterDiffs(oldText, newText, ignoreWhitespace, ignoreCase);
-
-            public DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, Func<string, string[]> chunker)
-                => s_differ.CreateCustomDiffs(oldText, newText, ignoreWhiteSpace, chunker);
-
-            public DiffResult CreateCustomDiffs(string oldText, string newText, bool ignoreWhiteSpace, bool ignoreCase, Func<string, string[]> chunker)
-                => s_differ.CreateCustomDiffs(oldText, newText, ignoreWhiteSpace, ignoreCase, chunker);
-
-            public DiffResult CreateLineDiffs(string oldText, string newText, bool ignoreWhitespace)
-                => CreateLineDiffs(oldText, newText, ignoreWhitespace, ignoreCase: false);
-
-            public DiffResult CreateLineDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase)
-            {
-                Func<string, string[]> chunker = s =>
-                {
-                    var lines = new List<string>();
-
-                    var nextChar = 0;
-                    while (nextChar < s.Length)
-                    {
-                        var nextEol = s.IndexOfAny(s_endOfLineCharacters, nextChar);
-                        if (nextEol == -1)
-                        {
-                            lines.Add(s.Substring(nextChar));
-                            break;
-                        }
-
-                        var currentLine = s.Substring(nextChar, nextEol - nextChar);
-
-                        switch (s[nextEol])
-                        {
-                            case '\r':
-                                currentLine += CarriageReturnText;
-                                if (nextEol < s.Length - 1 && s[nextEol + 1] == '\n')
-                                {
-                                    currentLine += LineFeedText;
-                                    nextEol++;
-                                }
-
-                                break;
-
-                            case '\n':
-                                currentLine += LineFeedText;
-                                break;
-                        }
-
-                        lines.Add(currentLine);
-                        nextChar = nextEol + 1;
-                    }
-
-                    return lines.ToArray();
-                };
-
-                return CreateCustomDiffs(oldText, newText, ignoreWhitespace, ignoreCase, chunker);
-            }
-
-            public DiffResult CreateWordDiffs(string oldText, string newText, bool ignoreWhitespace, char[] separators)
-                => s_differ.CreateWordDiffs(oldText, newText, ignoreWhitespace, separators);
-
-            public DiffResult CreateWordDiffs(string oldText, string newText, bool ignoreWhitespace, bool ignoreCase, char[] separators)
-                => s_differ.CreateWordDiffs(oldText, newText, ignoreWhitespace, ignoreCase, separators);
         }
     }
 }


### PR DESCRIPTION
This version offers an `IChunker` interface that eliminates the need to reimplement `IDiffer` entirely. Since the `IDiffer` interface also changed for the 1.5.0 release, this change avoids errors for users who try to update this dependency in downstream projects.