### PR TITLE
Add package reference for System.Net.Http

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,6 +71,7 @@
     <VSSDKTemplateWizardInterfaceVersion>12.0.4</VSSDKTemplateWizardInterfaceVersion>
     <!-- Libs -->
     <DiffPlexVersion>1.5.0</DiffPlexVersion>
+    <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <!-- Testing -->
     <MicrosoftCodeAnalysis2PrimaryTestVersion>2.6.1</MicrosoftCodeAnalysis2PrimaryTestVersion>
     <MicrosoftCodeAnalysis3PrimaryTestVersion>3.9.0</MicrosoftCodeAnalysis3PrimaryTestVersion>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -14,7 +14,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -13,4 +13,8 @@
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -88,7 +88,7 @@
   <!-- Public API Analyzer configuration -->
   <ItemGroup>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="$(RoslynDiagnosticsAnalyzersVersion)" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" ExcludeAssets="all" />
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -88,7 +88,7 @@
   <!-- Public API Analyzer configuration -->
   <ItemGroup>
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="$(RoslynDiagnosticsAnalyzersVersion)" PrivateAssets="all" />
-
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" />
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -60,7 +60,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\stylecop.json" Link="stylecop.json" />
     <None Include="$(CodeAnalysisRuleSet)" Condition="'$(CodeAnalysisRuleSet)' != ''" Link="%(Filename)%(Extension)" />
-    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" ExcludeAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -60,6 +60,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\stylecop.json" Link="stylecop.json" />
     <None Include="$(CodeAnalysisRuleSet)" Condition="'$(CodeAnalysisRuleSet)' != ''" Link="%(Filename)%(Extension)" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
A workaround to fix issues: 
https://devdiv.visualstudio.com/DevDiv/_componentGovernance/112744/alert/2980237?typeId=6257816
https://devdiv.visualstudio.com/DevDiv/_componentGovernance/112744/alert/3537864?typeId=6257816

Roslyn-SDK is not using System.Net.Http packages, but because System.Net.Http is involved in NetStandard.Library 1.6.1, and it is restored by default by all NetStandard projects (which includes our projects, and many other libraries)

Explicitly add System.Net.Http 4.3.4 would fix it.

Apparently, the security check tool should not report this, but it is going to block the build starts from 9/30 so we might need this workaround.