### PR TITLE
Extend AnalyzerTest to support tests for DiagnosticSuppressor analyzers

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -57,7 +57,8 @@ namespace Microsoft.CodeAnalysis.Testing
             DiagnosticOptions options,
             string id,
             LocalizableString? messageFormat,
-            object?[]? messageArguments)
+            object?[]? messageArguments,
+            bool? isSuppressed)
         {
             _spans = spans;
             _suppressMessage = suppressMessage;
@@ -67,6 +68,7 @@ namespace Microsoft.CodeAnalysis.Testing
             Id = id;
             MessageFormat = messageFormat;
             MessageArguments = messageArguments;
+            IsSuppressed = isSuppressed;
         }
 
         /// <summary>
@@ -150,9 +152,19 @@ namespace Microsoft.CodeAnalysis.Testing
         /// </summary>
         /// <value>
         /// <see langword="true"/> if the diagnostic is expected to have a location; otherwise, <see langword="false"/>
-        /// if a no-locatino diagnostic is expected.
+        /// if a no-location diagnostic is expected.
         /// </value>
         public bool HasLocation => !Spans.IsEmpty;
+
+        /// <summary>
+        /// Gets a value indicating whether the diagnostic is expected to be suppressed.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the diagnostic is expected to be suppressed;
+        /// <see langword="false"/> if the diagnostic is expected to be not suppressed;
+        /// <see langword="null"/> if the suppression state should not be tested;
+        /// </value>
+        public bool? IsSuppressed { get; }
 
         /// <summary>
         /// Creates a <see cref="DiagnosticResult"/> for a compiler error with the specified ID.
@@ -186,7 +198,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         /// <summary>
@@ -205,7 +218,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithArguments(params object[] arguments)
@@ -218,7 +232,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: arguments);
+                messageArguments: arguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithMessage(string? message)
@@ -231,7 +246,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithMessageFormat(LocalizableString messageFormat)
@@ -244,7 +260,22 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: messageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
+        }
+
+        public DiagnosticResult WithIsSuppressed(bool? isSuppressed)
+        {
+            return new DiagnosticResult(
+                spans: _spans,
+                suppressMessage: _suppressMessage,
+                message: _message,
+                severity: Severity,
+                options: Options,
+                id: Id,
+                messageFormat: MessageFormat,
+                messageArguments: MessageArguments,
+                isSuppressed: isSuppressed);
         }
 
         public DiagnosticResult WithNoLocation()
@@ -257,7 +288,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithLocation(int line, int column)
@@ -323,7 +355,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         internal DiagnosticResult WithAppliedMarkupLocations(ImmutableDictionary<string, FileLinePositionSpan> markupLocations)
@@ -365,7 +398,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithLineOffset(int offset)
@@ -393,7 +427,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         private DiagnosticResult AppendSpan(FileLinePositionSpan span, DiagnosticLocationOptions options)
@@ -406,7 +441,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public override string ToString()

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -69,6 +69,7 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.DiagnosticResult(Microsoft.CodeA
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.DiagnosticResult(string id, Microsoft.CodeAnalysis.DiagnosticSeverity severity) -> void
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.HasLocation.get -> bool
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Id.get -> string
+Microsoft.CodeAnalysis.Testing.DiagnosticResult.IsSuppressed.get -> bool?
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Message.get -> string
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.MessageArguments.get -> object[]
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.MessageFormat.get -> Microsoft.CodeAnalysis.LocalizableString
@@ -77,6 +78,7 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.Severity.get -> Microsoft.CodeAn
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Spans.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Testing.DiagnosticLocation>
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithArguments(params object[] arguments) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithDefaultPath(string path) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
+Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithIsSuppressed(bool? isSuppressed) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLineOffset(int offset) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(Microsoft.CodeAnalysis.Text.LinePosition location) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(int line, int column) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult


### PR DESCRIPTION
Fixes #914

Live sample usage can be found here: https://github.com/tom-englert/Lazy.Fody/blob/master/Lazy.Fody.Analyzer.Tests/SuppressorTests.cs