### PR TITLE
Extend AnalyzerTest to support tests for DiagnosticSuppressor analyzers

### DIFF
--- a/Roslyn-SDK.sln
+++ b/Roslyn-SDK.sln
@@ -20,6 +20,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.SyntaxVisualizer.Extension", "src\VisualStudio.Roslyn.SDK\SyntaxVisualizer\Roslyn.SyntaxVisualizer.Extension\Roslyn.SyntaxVisualizer.Extension.csproj", "{BF3477AA-22C9-4751-A4C0-01EF30728AE9}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.CodeAnalysis.Testing", "Microsoft.CodeAnalysis.Testing", "{A3E08CE3-2358-4D36-875B-82C99AC61CD8}"
+	ProjectSection(SolutionItems) = preProject
+		src\Microsoft.CodeAnalysis.Testing\Directory.Build.props = src\Microsoft.CodeAnalysis.Testing\Directory.Build.props
+		src\Microsoft.CodeAnalysis.Testing\Directory.Build.targets = src\Microsoft.CodeAnalysis.Testing\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Analyzer.Testing", "src\Microsoft.CodeAnalysis.Testing\Microsoft.CodeAnalysis.Analyzer.Testing\Microsoft.CodeAnalysis.Analyzer.Testing.csproj", "{36F8BB88-BBDB-4917-BCF4-269E7652A314}"
 EndProject
@@ -193,7 +197,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.ComponentDebugger", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "util", "util", "{7A94E723-ADD6-48C4-BBE7-1D5B311187A8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyVersionGenerator", "src\VisualStudio.Roslyn.SDK\AssemblyVersionGenerator\AssemblyVersionGenerator.csproj", "{AB6B3C69-9F6F-461C-BFD8-D3F25B9F44AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyVersionGenerator", "src\VisualStudio.Roslyn.SDK\AssemblyVersionGenerator\AssemblyVersionGenerator.csproj", "{AB6B3C69-9F6F-461C-BFD8-D3F25B9F44AD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -36,7 +36,7 @@
       <PropertyGroup>
         <Testing_MicrosoftCodeAnalysisWorkspaces_Version>3.8.0</Testing_MicrosoftCodeAnalysisWorkspaces_Version>
         <Testing_MicrosoftCodeAnalysisAnalyzers_Version>3.3.2</Testing_MicrosoftCodeAnalysisAnalyzers_Version>
-        <DefineConstants>$(DefineConstants);DIAG_SUPPORTS_SUPPRESSION</DefineConstants>
+        <DefineConstants Condition="'$(Language)' == 'C#'">$(DefineConstants);DIAG_SUPPORTS_SUPPRESSION</DefineConstants>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -25,6 +25,23 @@
     <TestingLibrarySourceGeneratorTargetFrameworks>netcoreapp3.1;netstandard2.0;net472</TestingLibrarySourceGeneratorTargetFrameworks>
   </PropertyGroup>
 
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'netstandard1.5'">
+      <PropertyGroup>
+        <Testing_MicrosoftCodeAnalysisWorkspaces_Version>1.0.1</Testing_MicrosoftCodeAnalysisWorkspaces_Version>
+        <Testing_MicrosoftCodeAnalysisAnalyzers_Version>2.6.1</Testing_MicrosoftCodeAnalysisAnalyzers_Version>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <Testing_MicrosoftCodeAnalysisWorkspaces_Version>3.8.0</Testing_MicrosoftCodeAnalysisWorkspaces_Version>
+        <Testing_MicrosoftCodeAnalysisAnalyzers_Version>3.3.2</Testing_MicrosoftCodeAnalysisAnalyzers_Version>
+        <DefineConstants>$(DefineConstants);DIAG_SUPPORTS_SUPPRESSION</DefineConstants>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+
   <PropertyGroup Condition="'$(CopyrightMicrosoft)' != ''">
     <Copyright>$(CopyrightMicrosoft)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -1293,7 +1293,9 @@ namespace Microsoft.CodeAnalysis.Testing
             var workspace = CreateWorkspace();
             foreach (var transform in OptionsTransforms)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 workspace.Options = transform(workspace.Options);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             var solution = workspace

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -409,6 +409,14 @@ namespace Microsoft.CodeAnalysis.Testing
                         message);
                 }
 
+#if DIAG_SUPPORTS_SUPPRESSION
+                if (expected.IsSuppressed.HasValue)
+                {
+                    message = FormatVerifierMessage(analyzers, actual.diagnostic, expected, $"Expected diagnostic suppression state to match");
+                    verifier.Equal(expected.IsSuppressed.Value, actual.diagnostic.IsSuppressed, message);
+                }
+#endif
+
                 DiagnosticVerifier?.Invoke(actual.diagnostic, expected, verifier);
             }
         }
@@ -803,6 +811,15 @@ namespace Microsoft.CodeAnalysis.Testing
                     builder.Append(")");
                 }
 
+#if DIAG_SUPPORTS_SUPPRESSION
+                if (diagnostics[i].IsSuppressed)
+                {
+                    builder.Append($".{nameof(DiagnosticResult.WithIsSuppressed)}(");
+                    builder.Append(diagnostics[i].IsSuppressed);
+                    builder.Append(")");
+                }
+#endif
+
                 builder.AppendLine(",");
             }
 
@@ -885,6 +902,15 @@ namespace Microsoft.CodeAnalysis.Testing
                     builder.Append(string.Join(", ", arguments.Select(a => "\"" + a?.ToString() + "\"")));
                     builder.Append(")");
                 }
+
+#if DIAG_SUPPORTS_SUPPRESSION
+                if (diagnostics[i].IsSuppressed.HasValue)
+                {
+                    builder.Append($".{nameof(DiagnosticResult.WithIsSuppressed)}(");
+                    builder.Append(diagnostics[i].IsSuppressed.GetValueOrDefault());
+                    builder.Append(")");
+                }
+#endif
 
                 builder.AppendLine(",");
             }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -411,13 +411,15 @@ namespace Microsoft.CodeAnalysis.Testing
                         message);
                 }
 
-#if DIAG_SUPPORTS_SUPPRESSION
                 if (expected.IsSuppressed.HasValue)
                 {
+#if DIAG_SUPPORTS_SUPPRESSION
                     message = FormatVerifierMessage(analyzers, actual.diagnostic, expected, $"Expected diagnostic suppression state to match");
                     verifier.Equal(expected.IsSuppressed.Value, actual.diagnostic.IsSuppressed, message);
-                }
+#else
+                    throw new NotSupportedException("DiagnosticSuppressors are not supported on this platform.");
 #endif
+                }
 
                 DiagnosticVerifier?.Invoke(actual.diagnostic, expected, verifier);
             }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable warnings
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -1066,7 +1068,7 @@ namespace Microsoft.CodeAnalysis.Testing
             return results.ToImmutableArray();
         }
 
-        protected virtual Task<Compilation> GetProjectCompilationAsync(Project project, IVerifier verifier, CancellationToken cancellationToken)
+        protected virtual Task<Compilation?> GetProjectCompilationAsync(Project project, IVerifier verifier, CancellationToken cancellationToken)
         {
             return project.GetCompilationAsync(cancellationToken);
         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/CodeActionTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/CodeActionTest`1.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Testing
             var changedProject = solution.GetProject(project.Id);
             if (changedProject != project)
             {
-                project = await RecreateProjectDocumentsAsync(changedProject, verifier, cancellationToken).ConfigureAwait(false);
+                project = await RecreateProjectDocumentsAsync(changedProject!, verifier, cancellationToken).ConfigureAwait(false);
             }
 
             return project;
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Testing
             foreach (var documentId in project.DocumentIds)
             {
                 var document = project.GetDocument(documentId);
-                var initialTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                var initialTree = await document!.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 document = await RecreateDocumentAsync(document, cancellationToken).ConfigureAwait(false);
                 var recreatedTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 if (CodeActionValidationMode != CodeActionValidationMode.None)
@@ -232,15 +232,15 @@ namespace Microsoft.CodeAnalysis.Testing
                         TreeEqualityVisitor.AssertNodesEqual(
                             verifier,
                             SyntaxKindType,
-                            await recreatedTree.GetRootAsync(cancellationToken).ConfigureAwait(false),
-                            await initialTree.GetRootAsync(cancellationToken).ConfigureAwait(false),
+                            await recreatedTree!.GetRootAsync(cancellationToken).ConfigureAwait(false),
+                            await initialTree!.GetRootAsync(cancellationToken).ConfigureAwait(false),
                             checkTrivia: CodeActionValidationMode == CodeActionValidationMode.Full);
                     }
                     catch
                     {
                         // Try to revalidate the tree with a better message
-                        var renderedInitialTree = TreeToString(await initialTree.GetRootAsync(cancellationToken).ConfigureAwait(false), CodeActionValidationMode);
-                        var renderedRecreatedTree = TreeToString(await recreatedTree.GetRootAsync(cancellationToken).ConfigureAwait(false), CodeActionValidationMode);
+                        var renderedInitialTree = TreeToString(await initialTree!.GetRootAsync(cancellationToken).ConfigureAwait(false), CodeActionValidationMode);
+                        var renderedRecreatedTree = TreeToString(await recreatedTree!.GetRootAsync(cancellationToken).ConfigureAwait(false), CodeActionValidationMode);
                         verifier.EqualOrDiff(renderedRecreatedTree, renderedInitialTree);
 
                         // This is not expected to be hit, but it will be hit if the validation failure occurred in a
@@ -415,7 +415,7 @@ namespace Microsoft.CodeAnalysis.Testing
                     else
                     {
                         _verifier.True(actualChild.IsNode);
-                        AssertNodesEqual(expectedChild.AsNode(), actualChild.AsNode(), checkTrivia);
+                        AssertNodesEqual(expectedChild.AsNode()!, actualChild.AsNode()!, checkTrivia);
                     }
                 }
             }
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 _verifier.Equal(expected.GetAnnotations(), actual.GetAnnotations());
                 if (expected.HasStructure)
                 {
-                    AssertNodesEqual(expected.GetStructure(), actual.GetStructure(), checkTrivia);
+                    AssertNodesEqual(expected.GetStructure()!, actual.GetStructure()!, checkTrivia);
                 }
             }
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Testing
         private readonly ImmutableArray<DiagnosticLocation> _spans;
         private readonly bool _suppressMessage;
         private readonly string? _message;
-        private readonly bool? _isSuppressed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DiagnosticResult"/> structure with the specified
@@ -69,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Testing
             Id = id;
             MessageFormat = messageFormat;
             MessageArguments = messageArguments;
-            _isSuppressed = isSuppressed;
+            IsSuppressed = isSuppressed;
         }
 
         /// <summary>
@@ -157,7 +156,6 @@ namespace Microsoft.CodeAnalysis.Testing
         /// </value>
         public bool HasLocation => !Spans.IsEmpty;
 
-#if DIAG_SUPPORTS_SUPPRESSION
         /// <summary>
         /// Gets a value indicating whether the diagnostic is expected to be suppressed.
         /// </summary>
@@ -166,8 +164,7 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <see langword="false"/> if the diagnostic is expected to be not suppressed;
         /// <see langword="null"/> if the suppression state should not be tested;
         /// </value>
-        public bool? IsSuppressed => _isSuppressed;
-#endif
+        public bool? IsSuppressed { get; }
 
         /// <summary>
         /// Creates a <see cref="DiagnosticResult"/> for a compiler error with the specified ID.
@@ -202,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         /// <summary>
@@ -222,7 +219,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithArguments(params object[] arguments)
@@ -236,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: arguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithMessage(string? message)
@@ -250,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithMessageFormat(LocalizableString messageFormat)
@@ -264,10 +261,9 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: messageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
-#if DIAG_SUPPORTS_SUPPRESSION
         public DiagnosticResult WithIsSuppressed(bool? isSuppressed)
         {
             return new DiagnosticResult(
@@ -281,7 +277,6 @@ namespace Microsoft.CodeAnalysis.Testing
                 messageArguments: MessageArguments,
                 isSuppressed: isSuppressed);
         }
-#endif
 
         public DiagnosticResult WithNoLocation()
         {
@@ -294,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithLocation(int line, int column)
@@ -361,7 +356,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         internal DiagnosticResult WithAppliedMarkupLocations(ImmutableDictionary<string, FileLinePositionSpan> markupLocations)
@@ -404,7 +399,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithLineOffset(int offset)
@@ -433,7 +428,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         private DiagnosticResult AppendSpan(FileLinePositionSpan span, DiagnosticLocationOptions options)
@@ -447,7 +442,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: _isSuppressed);
+                isSuppressed: IsSuppressed);
         }
 
         public override string ToString()

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -57,7 +57,8 @@ namespace Microsoft.CodeAnalysis.Testing
             DiagnosticOptions options,
             string id,
             LocalizableString? messageFormat,
-            object?[]? messageArguments)
+            object?[]? messageArguments,
+            bool? isSuppressed)
         {
             _spans = spans;
             _suppressMessage = suppressMessage;
@@ -67,6 +68,7 @@ namespace Microsoft.CodeAnalysis.Testing
             Id = id;
             MessageFormat = messageFormat;
             MessageArguments = messageArguments;
+            IsSuppressed = isSuppressed;
         }
 
         /// <summary>
@@ -150,9 +152,19 @@ namespace Microsoft.CodeAnalysis.Testing
         /// </summary>
         /// <value>
         /// <see langword="true"/> if the diagnostic is expected to have a location; otherwise, <see langword="false"/>
-        /// if a no-locatino diagnostic is expected.
+        /// if a no-location diagnostic is expected.
         /// </value>
         public bool HasLocation => !Spans.IsEmpty;
+
+        /// <summary>
+        /// Gets a value indicating whether the diagnostic is expected to be suppressed.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the diagnostic is expected to be suppressed;
+        /// <see langword="false"/> if the diagnostic is expected to be not suppressed;
+        /// <see langword="null"/> if the suppression state should not be tested;
+        /// </value>
+        public bool? IsSuppressed { get; }
 
         /// <summary>
         /// Creates a <see cref="DiagnosticResult"/> for a compiler error with the specified ID.
@@ -186,7 +198,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         /// <summary>
@@ -205,7 +218,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithArguments(params object[] arguments)
@@ -218,7 +232,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: arguments);
+                messageArguments: arguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithMessage(string? message)
@@ -231,7 +246,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithMessageFormat(LocalizableString messageFormat)
@@ -244,7 +260,22 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: messageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
+        }
+
+        public DiagnosticResult WithIsSuppressed(bool? isSuppressed)
+        {
+            return new DiagnosticResult(
+                spans: _spans,
+                suppressMessage: _suppressMessage,
+                message: _message,
+                severity: Severity,
+                options: Options,
+                id: Id,
+                messageFormat: MessageFormat,
+                messageArguments: MessageArguments,
+                isSuppressed: isSuppressed);
         }
 
         public DiagnosticResult WithNoLocation()
@@ -257,7 +288,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithLocation(int line, int column)
@@ -323,7 +355,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         internal DiagnosticResult WithAppliedMarkupLocations(ImmutableDictionary<string, FileLinePositionSpan> markupLocations)
@@ -365,7 +398,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public DiagnosticResult WithLineOffset(int offset)
@@ -393,7 +427,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         private DiagnosticResult AppendSpan(FileLinePositionSpan span, DiagnosticLocationOptions options)
@@ -406,7 +441,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 options: Options,
                 id: Id,
                 messageFormat: MessageFormat,
-                messageArguments: MessageArguments);
+                messageArguments: MessageArguments,
+                isSuppressed: IsSuppressed);
         }
 
         public override string ToString()

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/DiagnosticResult.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.Testing
         private readonly ImmutableArray<DiagnosticLocation> _spans;
         private readonly bool _suppressMessage;
         private readonly string? _message;
+        private readonly bool? _isSuppressed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DiagnosticResult"/> structure with the specified
@@ -68,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Testing
             Id = id;
             MessageFormat = messageFormat;
             MessageArguments = messageArguments;
-            IsSuppressed = isSuppressed;
+            _isSuppressed = isSuppressed;
         }
 
         /// <summary>
@@ -156,6 +157,7 @@ namespace Microsoft.CodeAnalysis.Testing
         /// </value>
         public bool HasLocation => !Spans.IsEmpty;
 
+#if DIAG_SUPPORTS_SUPPRESSION
         /// <summary>
         /// Gets a value indicating whether the diagnostic is expected to be suppressed.
         /// </summary>
@@ -164,7 +166,8 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <see langword="false"/> if the diagnostic is expected to be not suppressed;
         /// <see langword="null"/> if the suppression state should not be tested;
         /// </value>
-        public bool? IsSuppressed { get; }
+        public bool? IsSuppressed => _isSuppressed;
+#endif
 
         /// <summary>
         /// Creates a <see cref="DiagnosticResult"/> for a compiler error with the specified ID.
@@ -199,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         /// <summary>
@@ -219,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         public DiagnosticResult WithArguments(params object[] arguments)
@@ -233,7 +236,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: arguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         public DiagnosticResult WithMessage(string? message)
@@ -247,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         public DiagnosticResult WithMessageFormat(LocalizableString messageFormat)
@@ -261,9 +264,10 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: messageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
+#if DIAG_SUPPORTS_SUPPRESSION
         public DiagnosticResult WithIsSuppressed(bool? isSuppressed)
         {
             return new DiagnosticResult(
@@ -277,6 +281,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 messageArguments: MessageArguments,
                 isSuppressed: isSuppressed);
         }
+#endif
 
         public DiagnosticResult WithNoLocation()
         {
@@ -289,7 +294,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         public DiagnosticResult WithLocation(int line, int column)
@@ -356,7 +361,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         internal DiagnosticResult WithAppliedMarkupLocations(ImmutableDictionary<string, FileLinePositionSpan> markupLocations)
@@ -399,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         public DiagnosticResult WithLineOffset(int offset)
@@ -428,7 +433,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         private DiagnosticResult AppendSpan(FileLinePositionSpan span, DiagnosticLocationOptions options)
@@ -442,7 +447,7 @@ namespace Microsoft.CodeAnalysis.Testing
                 id: Id,
                 messageFormat: MessageFormat,
                 messageArguments: MessageArguments,
-                isSuppressed: IsSuppressed);
+                isSuppressed: _isSuppressed);
         }
 
         public override string ToString()

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/EmptyDiagnosticAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/EmptyDiagnosticAnalyzer.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CodeAnalysis.Testing
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => ImmutableArray<DiagnosticDescriptor>.Empty;
 
+#pragma warning disable RS1026 // Enable concurrent execution
+#pragma warning disable RS1025 // Configure generated code analysis
         public override void Initialize(AnalysisContext context)
         {
         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -47,8 +47,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Testing_MicrosoftCodeAnalysisWorkspaces_Version)" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.1.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -69,6 +69,7 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.DiagnosticResult(Microsoft.CodeA
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.DiagnosticResult(string id, Microsoft.CodeAnalysis.DiagnosticSeverity severity) -> void
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.HasLocation.get -> bool
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Id.get -> string
+Microsoft.CodeAnalysis.Testing.DiagnosticResult.IsSuppressed.get -> bool?
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Message.get -> string
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.MessageArguments.get -> object[]
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.MessageFormat.get -> Microsoft.CodeAnalysis.LocalizableString
@@ -77,6 +78,7 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.Severity.get -> Microsoft.CodeAn
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.Spans.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Testing.DiagnosticLocation>
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithArguments(params object[] arguments) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithDefaultPath(string path) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
+Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithIsSuppressed(bool? isSuppressed) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLineOffset(int offset) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(Microsoft.CodeAnalysis.Text.LinePosition location) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithLocation(int line, int column) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/TestXmlReferenceResolver.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/TestXmlReferenceResolver.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Testing
         public Dictionary<string, string> XmlReferences { get; } =
             new Dictionary<string, string>();
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             return ReferenceEquals(this, other);
         }
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Testing
             return new MemoryStream(Encoding.UTF8.GetBytes(content));
         }
 
-        public override string? ResolveReference(string path, string baseFilePath)
+        public override string? ResolveReference(string path, string? baseFilePath)
         {
             if (!XmlReferences.ContainsKey(path))
             {

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/TestXmlReferenceResolver.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/TestXmlReferenceResolver.cs
@@ -22,7 +22,9 @@ namespace Microsoft.CodeAnalysis.Testing
 
         public override int GetHashCode()
         {
+#pragma warning disable RS1024 // Compare symbols correctly
             return RuntimeHelpers.GetHashCode(this);
+#pragma warning restore RS1024 // Compare symbols correctly
         }
 
         public override Stream OpenRead(string resolvedPath)

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
   

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing/Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
   

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
   

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.NUnit.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.NUnit/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.NUnit.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing/Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
   

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
@@ -540,7 +540,7 @@ namespace Microsoft.CodeAnalysis.Testing
             {
                 currentIteration++;
 
-                var analyzerDiagnostics = await GetSortedDiagnosticsAsync(project!.Solution, analyzers, additionalDiagnostics: ImmutableArray<(Project project, Diagnostic diagnostic)>.Empty, CompilerDiagnostics, verifier, cancellationToken).ConfigureAwait(false);
+                var analyzerDiagnostics = await GetSortedDiagnosticsAsync(project.Solution, analyzers, additionalDiagnostics: ImmutableArray<(Project project, Diagnostic diagnostic)>.Empty, CompilerDiagnostics, verifier, cancellationToken).ConfigureAwait(false);
                 if (analyzerDiagnostics.Length == 0)
                 {
                     break;
@@ -637,10 +637,10 @@ namespace Microsoft.CodeAnalysis.Testing
             }
             catch (Exception ex)
             {
-                return (project!, ExceptionDispatchInfo.Capture(ex));
+                return (project, ExceptionDispatchInfo.Capture(ex));
             }
 
-            return (project!, null);
+            return (project, null);
         }
 
         private Task<(Project project, ExceptionDispatchInfo? iterationCountFailure)> FixAllAnalyzerDiagnosticsInDocumentAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableArray<CodeFixProvider> codeFixProviders, int? codeFixIndex, string? codeFixEquivalenceKey, Action<CodeAction, IVerifier>? codeActionVerifier, Project project, int numberOfIterations, IVerifier verifier, CancellationToken cancellationToken)
@@ -798,10 +798,10 @@ namespace Microsoft.CodeAnalysis.Testing
             }
             catch (Exception ex)
             {
-                return (project!, ExceptionDispatchInfo.Capture(ex));
+                return (project, ExceptionDispatchInfo.Capture(ex));
             }
 
-            return (project!, null);
+            return (project, null);
         }
 
         /// <summary>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/CodeFixTest`1.cs
@@ -540,7 +540,7 @@ namespace Microsoft.CodeAnalysis.Testing
             {
                 currentIteration++;
 
-                var analyzerDiagnostics = await GetSortedDiagnosticsAsync(project.Solution, analyzers, additionalDiagnostics: ImmutableArray<(Project project, Diagnostic diagnostic)>.Empty, CompilerDiagnostics, verifier, cancellationToken).ConfigureAwait(false);
+                var analyzerDiagnostics = await GetSortedDiagnosticsAsync(project!.Solution, analyzers, additionalDiagnostics: ImmutableArray<(Project project, Diagnostic diagnostic)>.Empty, CompilerDiagnostics, verifier, cancellationToken).ConfigureAwait(false);
                 if (analyzerDiagnostics.Length == 0)
                 {
                     break;
@@ -588,7 +588,7 @@ namespace Microsoft.CodeAnalysis.Testing
                             continue;
                         }
 
-                        var context = new CodeFixContext(fixableDocument, diagnostic, (a, d) => actions.Add(a), cancellationToken);
+                        var context = new CodeFixContext(fixableDocument!, diagnostic, (a, d) => actions.Add(a), cancellationToken);
                         await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
                     }
 
@@ -599,11 +599,11 @@ namespace Microsoft.CodeAnalysis.Testing
                         anyActions = true;
 
                         var originalProjectId = project.Id;
-                        var fixedProject = await ApplyCodeActionAsync(fixableDocument.Project, actionToApply, verifier, cancellationToken).ConfigureAwait(false);
+                        var fixedProject = await ApplyCodeActionAsync(fixableDocument!.Project, actionToApply, verifier, cancellationToken).ConfigureAwait(false);
                         if (fixedProject != fixableDocument.Project)
                         {
                             done = false;
-                            project = fixedProject.Solution.GetProject(originalProjectId);
+                            project = fixedProject.Solution.GetProject(originalProjectId)!;
                             break;
                         }
                     }
@@ -637,10 +637,10 @@ namespace Microsoft.CodeAnalysis.Testing
             }
             catch (Exception ex)
             {
-                return (project, ExceptionDispatchInfo.Capture(ex));
+                return (project!, ExceptionDispatchInfo.Capture(ex));
             }
 
-            return (project, null);
+            return (project!, null);
         }
 
         private Task<(Project project, ExceptionDispatchInfo? iterationCountFailure)> FixAllAnalyzerDiagnosticsInDocumentAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, ImmutableArray<CodeFixProvider> codeFixProviders, int? codeFixIndex, string? codeFixEquivalenceKey, Action<CodeAction, IVerifier>? codeActionVerifier, Project project, int numberOfIterations, IVerifier verifier, CancellationToken cancellationToken)
@@ -729,7 +729,7 @@ namespace Microsoft.CodeAnalysis.Testing
                         }
 
                         var actionsBuilder = ImmutableArray.CreateBuilder<CodeAction>();
-                        var context = new CodeFixContext(diagnosticDocument, diagnostic, (a, d) => actionsBuilder.Add(a), cancellationToken);
+                        var context = new CodeFixContext(diagnosticDocument!, diagnostic, (a, d) => actionsBuilder.Add(a), cancellationToken);
                         await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
                         actions.AddRange(FilterCodeActions(actionsBuilder.ToImmutable()).Select(action => (action, codeFixProvider)));
                     }
@@ -760,9 +760,9 @@ namespace Microsoft.CodeAnalysis.Testing
                 var fixableDocument = project.Solution.GetDocument(firstDiagnostic.Location.SourceTree);
                 var analyzerDiagnosticIds = analyzers.SelectMany(x => x.SupportedDiagnostics).Select(x => x.Id);
                 var compilerDiagnosticIds = codeFixProviders.SelectMany(codeFixProvider => codeFixProvider.FixableDiagnosticIds).Where(x => x.StartsWith("CS", StringComparison.Ordinal) || x.StartsWith("BC", StringComparison.Ordinal));
-                var disabledDiagnosticIds = project.CompilationOptions.SpecificDiagnosticOptions.Where(x => x.Value == ReportDiagnostic.Suppress).Select(x => x.Key);
+                var disabledDiagnosticIds = project.CompilationOptions!.SpecificDiagnosticOptions.Where(x => x.Value == ReportDiagnostic.Suppress).Select(x => x.Key);
                 var relevantIds = analyzerDiagnosticIds.Concat(compilerDiagnosticIds).Except(disabledDiagnosticIds).Distinct();
-                var fixAllContext = new FixAllContext(fixableDocument, effectiveCodeFixProvider, scope, equivalenceKey, relevantIds, fixAllDiagnosticProvider, cancellationToken);
+                var fixAllContext = new FixAllContext(fixableDocument!, effectiveCodeFixProvider!, scope, equivalenceKey!, relevantIds, fixAllDiagnosticProvider, cancellationToken);
 
                 var action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false);
                 if (action == null)
@@ -771,11 +771,11 @@ namespace Microsoft.CodeAnalysis.Testing
                 }
 
                 var originalProjectId = project.Id;
-                var fixedProject = await ApplyCodeActionAsync(fixableDocument.Project, action, verifier, cancellationToken).ConfigureAwait(false);
+                var fixedProject = await ApplyCodeActionAsync(fixableDocument!.Project, action, verifier, cancellationToken).ConfigureAwait(false);
                 if (fixedProject != fixableDocument.Project)
                 {
                     done = false;
-                    project = fixedProject.Solution.GetProject(originalProjectId);
+                    project = fixedProject.Solution.GetProject(originalProjectId)!;
                 }
 
                 if (CodeFixTestBehaviors.HasFlag(CodeFixTestBehaviors.FixOne))
@@ -798,10 +798,10 @@ namespace Microsoft.CodeAnalysis.Testing
             }
             catch (Exception ex)
             {
-                return (project, ExceptionDispatchInfo.Capture(ex));
+                return (project!, ExceptionDispatchInfo.Capture(ex));
             }
 
-            return (project, null);
+            return (project!, null);
         }
 
         /// <summary>
@@ -817,7 +817,7 @@ namespace Microsoft.CodeAnalysis.Testing
             foreach (var document in project.Documents)
             {
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                allDiagnostics = allDiagnostics.AddRange(semanticModel.GetDiagnostics(cancellationToken: cancellationToken));
+                allDiagnostics = allDiagnostics.AddRange(semanticModel!.GetDiagnostics(cancellationToken: cancellationToken));
             }
 
             return allDiagnostics;

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/EmptyCodeFixProvider.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/EmptyCodeFixProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 
@@ -12,6 +13,7 @@ namespace Microsoft.CodeAnalysis.Testing
     /// Defines a <see cref="CodeFixProvider"/> which does not support any diagnostic IDs or register code fixes for any
     /// diagnostics.
     /// </summary>
+#pragma warning disable RS1016 // "This helper type for unit testing is never actually provided as an analyzer for projects to consume."
     public sealed class EmptyCodeFixProvider : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/EnsureNoWorkspacesDesktopReferenceB.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/EnsureNoWorkspacesDesktopReferenceB.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.CodeAnalysis
 {
+    /* This is no longer valid, FileTextLoader is now in Microsoft.CodeAnalysis.Workspaces.Common!
     /// <summary>
     /// This class will fail to compile (CS0419 Ambiguous reference in cref attribute) if the project contains a
     /// reference to Microsoft.CodeAnalysis.Workspaces.Desktop.
@@ -13,6 +14,7 @@ namespace Microsoft.CodeAnalysis
     internal class EnsureNoWorkspacesDesktopReference
     {
     }
+    */
 }
 
 #endif

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeFix.Testing/Microsoft.CodeAnalysis.CodeFix.Testing.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Testing_MicrosoftCodeAnalysisWorkspaces_Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/CodeRefactoringTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/CodeRefactoringTest`1.cs
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.Testing
 
                 foreach (var codeRefactoringProvider in codeRefactoringProviders)
                 {
-                    var context = new CodeRefactoringContext(triggerDocument, location.SourceSpan, actions.Add, cancellationToken);
+                    var context = new CodeRefactoringContext(triggerDocument!, location.SourceSpan, actions.Add, cancellationToken);
                     await codeRefactoringProvider.ComputeRefactoringsAsync(context).ConfigureAwait(false);
                 }
 
@@ -262,11 +262,11 @@ namespace Microsoft.CodeAnalysis.Testing
                     anyActions = true;
 
                     var originalProjectId = project.Id;
-                    var fixedProject = await ApplyCodeActionAsync(triggerDocument.Project, actionToApply, verifier, cancellationToken).ConfigureAwait(false);
+                    var fixedProject = await ApplyCodeActionAsync(triggerDocument!.Project, actionToApply, verifier, cancellationToken).ConfigureAwait(false);
                     if (fixedProject != triggerDocument.Project)
                     {
                         done = false;
-                        project = fixedProject.Solution.GetProject(originalProjectId);
+                        project = fixedProject.Solution.GetProject(originalProjectId)!;
                         break;
                     }
                 }
@@ -294,10 +294,10 @@ namespace Microsoft.CodeAnalysis.Testing
             }
             catch (Exception ex)
             {
-                return (project, ExceptionDispatchInfo.Capture(ex));
+                return (project!, ExceptionDispatchInfo.Capture(ex));
             }
 
-            return (project, null);
+            return (project!, null);
 
             async Task<Location> GetTriggerLocationAsync()
             {
@@ -306,10 +306,10 @@ namespace Microsoft.CodeAnalysis.Testing
 
                 var documentIds = project.Solution.GetDocumentIdsWithFilePath(triggerSpan.Spans[0].Span.Path);
                 var document = project.Solution.GetDocument(documentIds.Single());
-                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var text = await document!.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
-                return Location.Create(tree, text.Lines.GetTextSpan(span));
+                return Location.Create(tree!, text.Lines.GetTextSpan(span));
             }
         }
 
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.Testing
             foreach (var document in project.Documents)
             {
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                allDiagnostics = allDiagnostics.AddRange(semanticModel.GetDiagnostics(cancellationToken: cancellationToken));
+                allDiagnostics = allDiagnostics.AddRange(semanticModel!.GetDiagnostics(cancellationToken: cancellationToken));
             }
 
             return allDiagnostics;

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/CodeRefactoringTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/CodeRefactoringTest`1.cs
@@ -294,10 +294,10 @@ namespace Microsoft.CodeAnalysis.Testing
             }
             catch (Exception ex)
             {
-                return (project!, ExceptionDispatchInfo.Capture(ex));
+                return (project, ExceptionDispatchInfo.Capture(ex));
             }
 
-            return (project!, null);
+            return (project, null);
 
             async Task<Location> GetTriggerLocationAsync()
             {

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/EnsureNoWorkspacesDesktopReferenceB.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/EnsureNoWorkspacesDesktopReferenceB.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.CodeAnalysis
 {
+    /* This is no longer valid, FileTextLoader is now in Microsoft.CodeAnalysis.Workspaces.Common!
     /// <summary>
     /// This class will fail to compile (CS0419 Ambiguous reference in cref attribute) if the project contains a
     /// reference to Microsoft.CodeAnalysis.Workspaces.Desktop.
@@ -13,6 +14,7 @@ namespace Microsoft.CodeAnalysis
     internal class EnsureNoWorkspacesDesktopReference
     {
     }
+    */
 }
 
 #endif

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing/Microsoft.CodeAnalysis.CodeRefactoring.Testing.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(Testing_MicrosoftCodeAnalysisWorkspaces_Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Testing
             await VerifyDiagnosticsAsync(new EvaluatedProjectState(testState, ReferenceAssemblies).WithAdditionalDiagnostics(diagnostics), testState.AdditionalProjects.Values.Select(additionalProject => new EvaluatedProjectState(additionalProject, ReferenceAssemblies)).ToImmutableArray(), testState.ExpectedDiagnostics.ToArray(), Verify.PushContext("Diagnostics of test state"), cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<Compilation> GetProjectCompilationAsync(Project project, IVerifier verifier, CancellationToken cancellationToken)
+        protected override async Task<Compilation?> GetProjectCompilationAsync(Project project, IVerifier verifier, CancellationToken cancellationToken)
         {
             var (finalProject, diagnostics) = await ApplySourceGeneratorAsync(GetSourceGenerators().ToImmutableArray(), project, verifier, cancellationToken).ConfigureAwait(false);
             return (await finalProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false))!;

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest.vbproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit.vbproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit.vbproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing/Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.vbproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest.vbproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.NUnit.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.NUnit.vbproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit.vbproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.vbproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest.vbproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.NUnit.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.NUnit/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.NUnit.vbproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit.vbproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.vbproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing/Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.vbproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Testing_MicrosoftCodeAnalysisAnalyzers_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This implements scenario 1 from #915  by conditionally selecting dependencies and extend the analyzer validation code.