### PR TITLE
Handle case of null packageStream

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
@@ -355,16 +355,33 @@ namespace Microsoft.CodeAnalysis.Testing
                             continue;
                         }
 
-                        await PackageExtractor.ExtractPackageAsync(
+                        if (downloadResult.Status == DownloadResourceResultStatus.AvailableWithoutStream)
+                        {
+                            await PackageExtractor.ExtractPackageAsync(
 #if !NET452 && !NETSTANDARD1_5
 #pragma warning disable SA1114 // Parameter list should follow declaration
-                            downloadResult.PackageSource,
+                                downloadResult.PackageSource,
 #pragma warning restore SA1114 // Parameter list should follow declaration
 #endif
-                            downloadResult.PackageStream,
-                            localPathResolver,
-                            packageExtractionContext,
-                            cancellationToken);
+                                downloadResult.PackageReader,
+                                localPathResolver,
+                                packageExtractionContext,
+                                cancellationToken);
+                        }
+                        else
+                        {
+                            Debug.Assert(downloadResult.PackageStream != null, "PackageStream should not be null if download result status != DownloadResourceResultStatus.AvailableWithoutStream");
+                            await PackageExtractor.ExtractPackageAsync(
+#if !NET452 && !NETSTANDARD1_5
+#pragma warning disable SA1114 // Parameter list should follow declaration
+                                downloadResult.PackageSource,
+#pragma warning restore SA1114 // Parameter list should follow declaration
+#endif
+                                downloadResult.PackageStream,
+                                localPathResolver,
+                                packageExtractionContext,
+                                cancellationToken);
+                        }
 
                         installedPath = GetInstalledPath(localPathResolver, globalPathResolver, packageToInstall);
                         packageReader = downloadResult.PackageReader;


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn-sdk/issues/974

TBH, I do not know whether this is the right fix (or even a fix). 

I am following this pattern:
https://github.com/nuget/nuget.client/blob/0ff5f67097522299620f34bd13f92d3d58e41f93/src/NuGet.Core/NuGet.PackageManagement/Projects/FolderNuGetProject.cs#L166-L188

review without whitespace changes
https://github.com/dotnet/roslyn-sdk/pull/977/files?diff=unified&w=1