### PR TITLE
feat: Added ConfigFile to simplify AnalyzerConfigFile creation.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# roslyn-sdk Agent Context
+
+This file gives Codex and other agents enough repository context to work safely and to support later portfolio analysis.
+
+<!-- BEGIN GENERATED PORTFOLIO CONTEXT -->
+
+## Generated Repository Context
+
+This section was generated from the GitHub repository inventory and local checkout to support future Codex work and portfolio analysis.
+
+### Repository Metadata
+- Remote: https://github.com/HavenDV/roslyn-sdk
+- Visibility: public
+- Type: fork; active
+- Primary language: C#
+- Topics: None detected
+- Last pushed: 2022-04-20T23:16:24Z
+- Local path: /Users/havendv/GitHub/HavenDV/roslyn-sdk
+- Local note: standard checkout
+- Classification: Fork/reference workspace
+
+### Working Summary
+| Branch | Status | |:------:|:------:| |dev16.0.x|![Build Status](https://dnceng.visualstudio.com/public/_build/latest?definitionId=137&branchName=dev16.0.x)| |main|![Build Status](https://dnceng.visualstudio.com/public/_build/latest?definitionId=137&branchName=main)|
+
+### Detected Structure
+- Top-level items: `.github/`, `eng/`, `samples/`, `src/`, `tests/`, `.editorconfig`, `.gitattributes`, `.gitignore`, `.vsts-ci.yml`, `.vsts-pr.yaml`, `build.cmd`, `CODE-OF-CONDUCT.md`, `CONTRIBUTING.md`
+- Sampled file count: 1071
+- Common extensions: .cs (347), .vb (134), .xlf (104), .csproj (88), .txt (81), .vbproj (60), .ps1 (44), .yml (29)
+
+### Manifests And Commands
+- Roslyn-SDK.sln
+- Samples.sln
+- samples/CSharp/SourceGenerators/SourceGenerators.sln
+- samples/VisualBasic/SourceGenerators/SourceGenerators.sln
+
+Suggested commands:
+- dotnet build Roslyn-SDK.sln
+- dotnet test
+
+Testing signal:
+- 93 .NET test project(s) detected
+
+### Portfolio Signals
+- Skills: .NET, Roslyn source generators, NuGet packaging, SDK design, C#
+- Portfolio angle: Use as evidence of ecosystem study, patch/reference work, or upstream contribution only after checking actual commits.
+
+### Agent Notes
+- Prefer README and manifest instructions over generated assumptions when they disagree.
+- Keep generated context current when build tooling, test commands, or project scope changes.
+- Review private or client-specific details before copying portfolio claims into public material.
+
+<!-- END GENERATED PORTFOLIO CONTEXT -->

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
@@ -42,7 +42,8 @@ namespace Microsoft.CodeAnalysis.Testing
             return @$"
 {ToString(Preamble)}
 
-{ToString(Sections)}";
+{ToString(Sections)}
+";
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
@@ -8,22 +8,18 @@ using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Testing
 {
-    public class ConfigFile
+    public class ConfigFile : Dictionary<string, Dictionary<string, string>>
     {
         public string FileName { get; }
 
         public Dictionary<string, string> Preamble { get; }
 
-        public Dictionary<string, Dictionary<string, string>> Sections { get; }
-
         public ConfigFile(
             string fileName,
-            Dictionary<string, string>? preamble = null,
-            Dictionary<string, Dictionary<string, string>>? sections = null)
+            Dictionary<string, string>? preamble = null)
         {
             FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
             Preamble = preamble ?? new Dictionary<string, string>();
-            Sections = sections ?? new Dictionary<string, Dictionary<string, string>>();
         }
 
         private static string ToString(Dictionary<string, string> dictionary)
@@ -46,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Testing
             return @$"
 {ToString(Preamble)}
 
-{ToString(Sections)}
+{ToString(this)}
 ";
         }
     }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
@@ -12,14 +12,37 @@ namespace Microsoft.CodeAnalysis.Testing
     {
         public string FileName { get; }
 
-        public Dictionary<string, string> Preamble { get; }
+        public Dictionary<string, string> Preamble { get; } = new Dictionary<string, string>();
 
-        public ConfigFile(
-            string fileName,
-            Dictionary<string, string>? preamble = null)
+        public ConfigFile(string fileName)
         {
             FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
-            Preamble = preamble ?? new Dictionary<string, string>();
+        }
+
+        public new string this[string globalKey]
+        {
+            get
+            {
+                return Preamble[globalKey];
+            }
+
+            set
+            {
+                Preamble[globalKey] = value;
+            }
+        }
+
+        public string this[string sectionKey, string key]
+        {
+            get
+            {
+                return base[sectionKey][key];
+            }
+
+            set
+            {
+                base[sectionKey][key] = value;
+            }
         }
 
         private static string ToString(Dictionary<string, string> dictionary)

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
@@ -10,14 +10,18 @@ namespace Microsoft.CodeAnalysis.Testing
 {
     public class ConfigFile
     {
+        public string FileName { get; }
+
         public Dictionary<string, string> Preamble { get; }
 
         public Dictionary<string, Dictionary<string, string>> Sections { get; }
 
         public ConfigFile(
+            string fileName,
             Dictionary<string, string>? preamble = null,
             Dictionary<string, Dictionary<string, string>>? sections = null)
         {
+            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
             Preamble = preamble ?? new Dictionary<string, string>();
             Sections = sections ?? new Dictionary<string, Dictionary<string, string>>();
         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
@@ -36,13 +36,41 @@ namespace Microsoft.CodeAnalysis.Testing
         {
             get
             {
-                return base[sectionKey][key];
+                if (!TryGetValue(sectionKey, out var values))
+                {
+                    values = new Dictionary<string, string>();
+                    base[sectionKey] = values;
+                }
+
+                return values[key];
             }
 
             set
             {
-                base[sectionKey][key] = value;
+                if (!TryGetValue(sectionKey, out var values))
+                {
+                    values = new Dictionary<string, string>();
+                    base[sectionKey] = values;
+                }
+
+                values[key] = value;
             }
+        }
+
+        public void Add(string globalKey, string value)
+        {
+            Preamble.Add(globalKey, value);
+        }
+
+        public void Add(string sectionKey, string key, string value)
+        {
+            if (!TryGetValue(sectionKey, out var values))
+            {
+                values = new Dictionary<string, string>();
+                base[sectionKey] = values;
+            }
+
+            values.Add(key, value);
         }
 
         private static string ToString(Dictionary<string, string> dictionary)

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFile.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    public class ConfigFile
+    {
+        public Dictionary<string, string> Preamble { get; }
+
+        public Dictionary<string, Dictionary<string, string>> Sections { get; }
+
+        public ConfigFile(
+            Dictionary<string, string>? preamble = null,
+            Dictionary<string, Dictionary<string, string>>? sections = null)
+        {
+            Preamble = preamble ?? new Dictionary<string, string>();
+            Sections = sections ?? new Dictionary<string, Dictionary<string, string>>();
+        }
+
+        private static string ToString(Dictionary<string, string> dictionary)
+        {
+            return string.Join(
+                Environment.NewLine,
+                dictionary.Select(pair => $@"{pair.Key} = {pair.Value}"));
+        }
+
+        private static string ToString(Dictionary<string, Dictionary<string, string>> dictionary)
+        {
+            return string.Join(
+                Environment.NewLine,
+                dictionary.Select(pair => $@"[{pair.Key}]
+{ToString(pair.Value)}"));
+        }
+
+        public override string ToString()
+        {
+            return @$"
+{ToString(Preamble)}
+
+{ToString(Sections)}";
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFileCollection.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFileCollection.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis.Testing
 {
     public class ConfigFileCollection : SourceFileCollection
     {
-        public void Add((string filename, ConfigFile configFile) file)
+        public void Add(ConfigFile file)
         {
-            Add((file.filename, SourceText.From(file.configFile.ToString(), Encoding.UTF8)));
+            Add((file.FileName, SourceText.From(file.ToString(), Encoding.UTF8)));
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFileCollection.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ConfigFileCollection.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    public class ConfigFileCollection : SourceFileCollection
+    {
+        public void Add((string filename, ConfigFile configFile) file)
+        {
+            Add((file.filename, SourceText.From(file.configFile.ToString(), Encoding.UTF8)));
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/EditorConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/EditorConfigFile.cs
@@ -9,9 +9,8 @@ namespace Microsoft.CodeAnalysis.Testing
     public class EditorConfigFile : ConfigFile
     {
         public EditorConfigFile(
-            Dictionary<string, string>? preamble = null,
-            Dictionary<string, Dictionary<string, string>>? sections = null)
-            : base("/.editorconfig", preamble, sections)
+            Dictionary<string, string>? preamble = null)
+            : base("/.editorconfig", preamble)
         {
         }
     }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/EditorConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/EditorConfigFile.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    public class EditorConfigFile : ConfigFile
+    {
+        public EditorConfigFile(
+            Dictionary<string, string>? preamble = null,
+            Dictionary<string, Dictionary<string, string>>? sections = null)
+            : base("/.editorconfig", preamble, sections)
+        {
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/EditorConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/EditorConfigFile.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-
 namespace Microsoft.CodeAnalysis.Testing
 {
     public class EditorConfigFile : ConfigFile
     {
-        public EditorConfigFile(
-            Dictionary<string, string>? preamble = null)
-            : base("/.editorconfig", preamble)
+        public EditorConfigFile()
+            : base("/.editorconfig")
         {
         }
     }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/GlobalConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/GlobalConfigFile.cs
@@ -2,15 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-
 namespace Microsoft.CodeAnalysis.Testing
 {
     public class GlobalConfigFile : ConfigFile
     {
-        public GlobalConfigFile(
-            Dictionary<string, string>? preamble = null)
-            : base("/.globalconfig", preamble)
+        public GlobalConfigFile()
+            : base("/.globalconfig")
         {
         }
     }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/GlobalConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/GlobalConfigFile.cs
@@ -9,9 +9,8 @@ namespace Microsoft.CodeAnalysis.Testing
     public class GlobalConfigFile : ConfigFile
     {
         public GlobalConfigFile(
-            Dictionary<string, string>? preamble = null,
-            Dictionary<string, Dictionary<string, string>>? sections = null)
-            : base("/.globalconfig", preamble, sections)
+            Dictionary<string, string>? preamble = null)
+            : base("/.globalconfig", preamble)
         {
         }
     }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/GlobalConfigFile.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/GlobalConfigFile.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    public class GlobalConfigFile : ConfigFile
+    {
+        public GlobalConfigFile(
+            Dictionary<string, string>? preamble = null,
+            Dictionary<string, Dictionary<string, string>>? sections = null)
+            : base("/.globalconfig", preamble, sections)
+        {
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ProjectState.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ProjectState.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Testing
 
         public SourceFileCollection AdditionalFiles { get; } = new SourceFileCollection();
 
-        public SourceFileCollection AnalyzerConfigFiles { get; } = new SourceFileCollection();
+        public ConfigFileCollection AnalyzerConfigFiles { get; } = new ConfigFileCollection();
 
         public List<Func<IEnumerable<(string filename, SourceText content)>>> AdditionalFilesFactories { get; } = new List<Func<IEnumerable<(string filename, SourceText content)>>>();
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -53,6 +53,9 @@ Microsoft.CodeAnalysis.Testing.ConfigFile
 Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
 Microsoft.CodeAnalysis.Testing.ConfigFile.Preamble.get -> System.Collections.Generic.Dictionary<string, string>
 Microsoft.CodeAnalysis.Testing.ConfigFile.Sections.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>
+Microsoft.CodeAnalysis.Testing.ConfigFileCollection
+Microsoft.CodeAnalysis.Testing.ConfigFileCollection.Add((string filename, Microsoft.CodeAnalysis.Testing.ConfigFile configFile) file) -> void
+Microsoft.CodeAnalysis.Testing.ConfigFileCollection.ConfigFileCollection() -> void
 Microsoft.CodeAnalysis.Testing.DefaultVerifier
 Microsoft.CodeAnalysis.Testing.DefaultVerifier.Context.get -> System.Collections.Immutable.ImmutableStack<string>
 Microsoft.CodeAnalysis.Testing.DefaultVerifier.DefaultVerifier() -> void
@@ -157,7 +160,7 @@ Microsoft.CodeAnalysis.Testing.ProjectState.AdditionalFiles.get -> Microsoft.Cod
 Microsoft.CodeAnalysis.Testing.ProjectState.AdditionalFilesFactories.get -> System.Collections.Generic.List<System.Func<System.Collections.Generic.IEnumerable<(string filename, Microsoft.CodeAnalysis.Text.SourceText content)>>>
 Microsoft.CodeAnalysis.Testing.ProjectState.AdditionalProjectReferences.get -> System.Collections.Generic.List<string>
 Microsoft.CodeAnalysis.Testing.ProjectState.AdditionalReferences.get -> Microsoft.CodeAnalysis.Testing.MetadataReferenceCollection
-Microsoft.CodeAnalysis.Testing.ProjectState.AnalyzerConfigFiles.get -> Microsoft.CodeAnalysis.Testing.SourceFileCollection
+Microsoft.CodeAnalysis.Testing.ProjectState.AnalyzerConfigFiles.get -> Microsoft.CodeAnalysis.Testing.ConfigFileCollection
 Microsoft.CodeAnalysis.Testing.ProjectState.AssemblyName.get -> string
 Microsoft.CodeAnalysis.Testing.ProjectState.DocumentationMode.get -> Microsoft.CodeAnalysis.DocumentationMode?
 Microsoft.CodeAnalysis.Testing.ProjectState.DocumentationMode.set -> void
@@ -222,7 +225,6 @@ Microsoft.CodeAnalysis.Testing.SolutionState.WithProcessedMarkup(Microsoft.CodeA
 Microsoft.CodeAnalysis.Testing.SourceFileCollection
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((System.Type sourceGeneratorType, string filename, Microsoft.CodeAnalysis.Text.SourceText content) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((System.Type sourceGeneratorType, string filename, string content) file) -> void
-Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((string filename, Microsoft.CodeAnalysis.Testing.ConfigFile configFile) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((string filename, string content) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.SourceFileCollection() -> void
 Microsoft.CodeAnalysis.Testing.SourceFileList

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -50,9 +50,13 @@ Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.None = 0 -> Microsoft.CodeAna
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Suggestions = 3 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Warnings = 2 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.ConfigFile
-Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(string fileName, System.Collections.Generic.Dictionary<string, string> preamble = null) -> void
+Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(string fileName) -> void
 Microsoft.CodeAnalysis.Testing.ConfigFile.FileName.get -> string
 Microsoft.CodeAnalysis.Testing.ConfigFile.Preamble.get -> System.Collections.Generic.Dictionary<string, string>
+Microsoft.CodeAnalysis.Testing.ConfigFile.this[string globalKey].get -> string
+Microsoft.CodeAnalysis.Testing.ConfigFile.this[string globalKey].set -> void
+Microsoft.CodeAnalysis.Testing.ConfigFile.this[string sectionKey, string key].get -> string
+Microsoft.CodeAnalysis.Testing.ConfigFile.this[string sectionKey, string key].set -> void
 Microsoft.CodeAnalysis.Testing.ConfigFileCollection
 Microsoft.CodeAnalysis.Testing.ConfigFileCollection.Add(Microsoft.CodeAnalysis.Testing.ConfigFile file) -> void
 Microsoft.CodeAnalysis.Testing.ConfigFileCollection.ConfigFileCollection() -> void
@@ -105,11 +109,11 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(Microsoft.CodeAnalysis.
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(int startLine, int startColumn, int endLine, int endColumn) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(string path, int startLine, int startColumn, int endLine, int endColumn) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.EditorConfigFile
-Microsoft.CodeAnalysis.Testing.EditorConfigFile.EditorConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null) -> void
+Microsoft.CodeAnalysis.Testing.EditorConfigFile.EditorConfigFile() -> void
 Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer
 Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer.EmptyDiagnosticAnalyzer() -> void
 Microsoft.CodeAnalysis.Testing.GlobalConfigFile
-Microsoft.CodeAnalysis.Testing.GlobalConfigFile.GlobalConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null) -> void
+Microsoft.CodeAnalysis.Testing.GlobalConfigFile.GlobalConfigFile() -> void
 Microsoft.CodeAnalysis.Testing.IVerifier
 Microsoft.CodeAnalysis.Testing.IVerifier.Empty<T>(string collectionName, System.Collections.Generic.IEnumerable<T> collection) -> void
 Microsoft.CodeAnalysis.Testing.IVerifier.Equal<T>(T expected, T actual, string message = null) -> void

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -50,6 +50,8 @@ Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.None = 0 -> Microsoft.CodeAna
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Suggestions = 3 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Warnings = 2 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.ConfigFile
+Microsoft.CodeAnalysis.Testing.ConfigFile.Add(string globalKey, string value) -> void
+Microsoft.CodeAnalysis.Testing.ConfigFile.Add(string sectionKey, string key, string value) -> void
 Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(string fileName) -> void
 Microsoft.CodeAnalysis.Testing.ConfigFile.FileName.get -> string
 Microsoft.CodeAnalysis.Testing.ConfigFile.Preamble.get -> System.Collections.Generic.Dictionary<string, string>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -50,10 +50,9 @@ Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.None = 0 -> Microsoft.CodeAna
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Suggestions = 3 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Warnings = 2 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.ConfigFile
-Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(string fileName, System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
+Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(string fileName, System.Collections.Generic.Dictionary<string, string> preamble = null) -> void
 Microsoft.CodeAnalysis.Testing.ConfigFile.FileName.get -> string
 Microsoft.CodeAnalysis.Testing.ConfigFile.Preamble.get -> System.Collections.Generic.Dictionary<string, string>
-Microsoft.CodeAnalysis.Testing.ConfigFile.Sections.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>
 Microsoft.CodeAnalysis.Testing.ConfigFileCollection
 Microsoft.CodeAnalysis.Testing.ConfigFileCollection.Add(Microsoft.CodeAnalysis.Testing.ConfigFile file) -> void
 Microsoft.CodeAnalysis.Testing.ConfigFileCollection.ConfigFileCollection() -> void
@@ -106,11 +105,11 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(Microsoft.CodeAnalysis.
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(int startLine, int startColumn, int endLine, int endColumn) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(string path, int startLine, int startColumn, int endLine, int endColumn) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.EditorConfigFile
-Microsoft.CodeAnalysis.Testing.EditorConfigFile.EditorConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
+Microsoft.CodeAnalysis.Testing.EditorConfigFile.EditorConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null) -> void
 Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer
 Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer.EmptyDiagnosticAnalyzer() -> void
 Microsoft.CodeAnalysis.Testing.GlobalConfigFile
-Microsoft.CodeAnalysis.Testing.GlobalConfigFile.GlobalConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
+Microsoft.CodeAnalysis.Testing.GlobalConfigFile.GlobalConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null) -> void
 Microsoft.CodeAnalysis.Testing.IVerifier
 Microsoft.CodeAnalysis.Testing.IVerifier.Empty<T>(string collectionName, System.Collections.Generic.IEnumerable<T> collection) -> void
 Microsoft.CodeAnalysis.Testing.IVerifier.Equal<T>(T expected, T actual, string message = null) -> void

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -49,6 +49,10 @@ Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Errors = 1 -> Microsoft.CodeA
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.None = 0 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Suggestions = 3 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Warnings = 2 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
+Microsoft.CodeAnalysis.Testing.ConfigFile
+Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
+Microsoft.CodeAnalysis.Testing.ConfigFile.Preamble.get -> System.Collections.Generic.Dictionary<string, string>
+Microsoft.CodeAnalysis.Testing.ConfigFile.Sections.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>
 Microsoft.CodeAnalysis.Testing.DefaultVerifier
 Microsoft.CodeAnalysis.Testing.DefaultVerifier.Context.get -> System.Collections.Immutable.ImmutableStack<string>
 Microsoft.CodeAnalysis.Testing.DefaultVerifier.DefaultVerifier() -> void
@@ -218,6 +222,7 @@ Microsoft.CodeAnalysis.Testing.SolutionState.WithProcessedMarkup(Microsoft.CodeA
 Microsoft.CodeAnalysis.Testing.SourceFileCollection
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((System.Type sourceGeneratorType, string filename, Microsoft.CodeAnalysis.Text.SourceText content) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((System.Type sourceGeneratorType, string filename, string content) file) -> void
+Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((string filename, Microsoft.CodeAnalysis.Testing.ConfigFile configFile) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.Add((string filename, string content) file) -> void
 Microsoft.CodeAnalysis.Testing.SourceFileCollection.SourceFileCollection() -> void
 Microsoft.CodeAnalysis.Testing.SourceFileList
@@ -240,6 +245,7 @@ abstract Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.DefaultFileExt.g
 abstract Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.GetDiagnosticAnalyzers() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer>
 abstract Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.Language.get -> string
 abstract Microsoft.CodeAnalysis.Testing.CodeActionTest<TVerifier>.SyntaxKindType.get -> System.Type
+override Microsoft.CodeAnalysis.Testing.ConfigFile.ToString() -> string
 override Microsoft.CodeAnalysis.Testing.DiagnosticResult.ToString() -> string
 override Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext context) -> void
 override Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -50,11 +50,12 @@ Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.None = 0 -> Microsoft.CodeAna
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Suggestions = 3 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.CompilerDiagnostics.Warnings = 2 -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.ConfigFile
-Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
+Microsoft.CodeAnalysis.Testing.ConfigFile.ConfigFile(string fileName, System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
+Microsoft.CodeAnalysis.Testing.ConfigFile.FileName.get -> string
 Microsoft.CodeAnalysis.Testing.ConfigFile.Preamble.get -> System.Collections.Generic.Dictionary<string, string>
 Microsoft.CodeAnalysis.Testing.ConfigFile.Sections.get -> System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>
 Microsoft.CodeAnalysis.Testing.ConfigFileCollection
-Microsoft.CodeAnalysis.Testing.ConfigFileCollection.Add((string filename, Microsoft.CodeAnalysis.Testing.ConfigFile configFile) file) -> void
+Microsoft.CodeAnalysis.Testing.ConfigFileCollection.Add(Microsoft.CodeAnalysis.Testing.ConfigFile file) -> void
 Microsoft.CodeAnalysis.Testing.ConfigFileCollection.ConfigFileCollection() -> void
 Microsoft.CodeAnalysis.Testing.DefaultVerifier
 Microsoft.CodeAnalysis.Testing.DefaultVerifier.Context.get -> System.Collections.Immutable.ImmutableStack<string>
@@ -104,8 +105,12 @@ Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(Microsoft.CodeAnalysis.
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(Microsoft.CodeAnalysis.FileLinePositionSpan span, Microsoft.CodeAnalysis.Testing.DiagnosticLocationOptions options) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(int startLine, int startColumn, int endLine, int endColumn) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
 Microsoft.CodeAnalysis.Testing.DiagnosticResult.WithSpan(string path, int startLine, int startColumn, int endLine, int endColumn) -> Microsoft.CodeAnalysis.Testing.DiagnosticResult
+Microsoft.CodeAnalysis.Testing.EditorConfigFile
+Microsoft.CodeAnalysis.Testing.EditorConfigFile.EditorConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
 Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer
 Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer.EmptyDiagnosticAnalyzer() -> void
+Microsoft.CodeAnalysis.Testing.GlobalConfigFile
+Microsoft.CodeAnalysis.Testing.GlobalConfigFile.GlobalConfigFile(System.Collections.Generic.Dictionary<string, string> preamble = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> sections = null) -> void
 Microsoft.CodeAnalysis.Testing.IVerifier
 Microsoft.CodeAnalysis.Testing.IVerifier.Empty<T>(string collectionName, System.Collections.Generic.IEnumerable<T> collection) -> void
 Microsoft.CodeAnalysis.Testing.IVerifier.Equal<T>(T expected, T actual, string message = null) -> void

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SourceFileCollection.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SourceFileCollection.cs
@@ -29,5 +29,10 @@ namespace Microsoft.CodeAnalysis.Testing
             var generatedPath = Path.Combine(file.sourceGeneratorType.GetTypeInfo().Assembly.GetName().Name ?? string.Empty, file.sourceGeneratorType.FullName!, file.filename);
             Add((generatedPath, file.content));
         }
+
+        public void Add((string filename, ConfigFile configFile) file)
+        {
+            Add((file.filename, SourceText.From(file.configFile.ToString(), Encoding.UTF8)));
+        }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SourceFileCollection.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/SourceFileCollection.cs
@@ -29,10 +29,5 @@ namespace Microsoft.CodeAnalysis.Testing
             var generatedPath = Path.Combine(file.sourceGeneratorType.GetTypeInfo().Assembly.GetName().Name ?? string.Empty, file.sourceGeneratorType.FullName!, file.filename);
             Add((generatedPath, file.content));
         }
-
-        public void Add((string filename, ConfigFile configFile) file)
-        {
-            Add((file.filename, SourceText.From(file.configFile.ToString(), Encoding.UTF8)));
-        }
     }
 }

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
@@ -5,6 +5,7 @@
 #if !NETCOREAPP1_1 && !NET46
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
 using System.Threading.Tasks;
@@ -117,6 +118,32 @@ key = {|Literal:value|}
                     MarkupHandling = MarkupMode.None,
                 },
             }.RunAsync();
+        }
+
+        [Fact]
+        public void AnalyzerConfigFileEquivalentToManualCreation()
+        {
+            var expected = @"
+root = true
+
+[*]
+key = {|Literal:value|}
+";
+
+            var actual = new ConfigFile(
+                preamble: new Dictionary<string, string>
+                {
+                    ["root"] = "true",
+                },
+                sections: new Dictionary<string, Dictionary<string, string>>
+                {
+                    ["*"] = new Dictionary<string, string>
+                    {
+                        ["key"] = "{|Literal:value|}",
+                    },
+                }).ToString();
+
+            Assert.Equal(expected, actual);
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
@@ -98,13 +98,6 @@ key = value
         [Fact]
         public async Task TestDiagnosticInAnalyzerConfigFileBraceNotTreatedAsMarkup()
         {
-            var editorConfig = @"
-root = true
-
-[*]
-key = {|Literal:value|}
-";
-
             await new CSharpTest
             {
                 TestState =
@@ -113,7 +106,11 @@ key = {|Literal:value|}
                     ExpectedDiagnostics = { new DiagnosticResult(HighlightBracesIfAnalyzerConfigMissingAnalyzer.Descriptor).WithLocation(1, 23) },
                     AnalyzerConfigFiles =
                     {
-                        ("/.editorconfig", SourceText.From(editorConfig, Encoding.UTF8)),
+                        new EditorConfigFile
+                        {
+                            ["root"] = "true",
+                            ["*", "key"] = "{|Literal:value|}",
+                        },
                     },
                     MarkupHandling = MarkupMode.None,
                 },
@@ -121,7 +118,7 @@ key = {|Literal:value|}
         }
 
         [Fact]
-        public void AnalyzerConfigFileEquivalentToManualCreation()
+        public void AnalyzerConfigFileViaDictionarySyntaxEquivalentToManualCreation()
         {
             var expected = @"
 root = true
@@ -134,6 +131,31 @@ key = {|Literal:value|}
             {
                 ["root"] = "true",
                 ["*", "key"] = "{|Literal:value|}",
+            }.ToString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void AnalyzerConfigFileViaAddSyntaxEquivalentToManualCreation()
+        {
+            var expected = @"
+root = true
+
+[*]
+key = {|Literal:value|}
+";
+
+            var actual = new EditorConfigFile
+            {
+                { "root", "true" },
+                {
+                    "*", new Dictionary<string, string>
+                    {
+                        ["key"] = "{|Literal:value|}",
+                    }
+                },
+                { "*", "key", "{|Literal:value|}" },
             }.ToString();
 
             Assert.Equal(expected, actual);

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
@@ -130,16 +130,10 @@ root = true
 key = {|Literal:value|}
 ";
 
-            var actual = new EditorConfigFile(
-                preamble: new Dictionary<string, string>
-                {
-                    ["root"] = "true",
-                })
+            var actual = new EditorConfigFile
             {
-                ["*"] = new Dictionary<string, string>
-                {
-                    ["key"] = "{|Literal:value|}",
-                },
+                ["root"] = "true",
+                ["*", "key"] = "{|Literal:value|}",
             }.ToString();
 
             Assert.Equal(expected, actual);

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
@@ -130,7 +130,7 @@ root = true
 key = {|Literal:value|}
 ";
 
-            var actual = new ConfigFile(
+            var actual = new EditorConfigFile(
                 preamble: new Dictionary<string, string>
                 {
                     ["root"] = "true",

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/AnalyzerConfigFilesTests.cs
@@ -134,14 +134,13 @@ key = {|Literal:value|}
                 preamble: new Dictionary<string, string>
                 {
                     ["root"] = "true",
-                },
-                sections: new Dictionary<string, Dictionary<string, string>>
+                })
+            {
+                ["*"] = new Dictionary<string, string>
                 {
-                    ["*"] = new Dictionary<string, string>
-                    {
-                        ["key"] = "{|Literal:value|}",
-                    },
-                }).ToString();
+                    ["key"] = "{|Literal:value|}",
+                },
+            }.ToString();
 
             Assert.Equal(expected, actual);
         }


### PR DESCRIPTION
I recently got acquainted with your package and for me creating a configuration file was problematic until I found an example. I think this can simplify the entry threshold because it adds a specific Add method that will be used intuitively.