### PR TITLE
Remove Syntax Visualizer from Help -> About

### DIFF
--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerExtensionPackage.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerExtensionPackage.cs
@@ -21,7 +21,6 @@ namespace Roslyn.SyntaxVisualizer.Extension
     /// register itself and its components with the shell.
     /// </summary>
     [PackageRegistration(UseManagedResourcesOnly = true)] // This attribute tells the PkgDef creation utility (CreatePkgDef.exe) that this class is a package.
-    [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // This attribute is used to register the information needed to show this package in the Help / About dialog of Visual Studio.
     [ProvideMenuResource("Menus.ctmenu", 1)] // This attribute is needed to let the shell know that this package exposes some menus.
     [ProvideToolWindow(typeof(SyntaxVisualizerToolWindow))] // This attribute registers a tool window exposed by this package.
     [Guid(GuidList.GuidSyntaxVisualizerExtensionPkgString)]

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/VSPackage.resx
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/VSPackage.resx
@@ -117,16 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="110" xml:space="preserve">
-    <value>Syntax Visualizer</value>
-  </data>
-  <data name="112" xml:space="preserve">
-    <value>An extension for visualizing Roslyn SyntaxTrees.</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>SyntaxTree.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
   <data name="500" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SyntaxTree.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.cs.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.cs.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Rozšíření pro vizualizaci stromů Roslyn SyntaxTree</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.de.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.de.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Eine Erweiterung zur Visualisierung von Roslyn-SyntaxTrees.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.es.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.es.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Una extensión para visualizar Roslyn SyntaxTrees.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.fr.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.fr.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Extension de visualisation des SyntaxTrees Roslyn.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.it.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.it.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Estensione per visualizzare alberi della sintassi di Roslyn.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.ja.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.ja.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Roslyn 構文ツリーを可視化するための拡張機能。</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.ko.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.ko.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Roslyn SyntaxTrees를 시각화하기 위한 확장입니다.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.pl.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.pl.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Rozszerzenie do wizualizacji elementów Roslyn SyntaxTree.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.pt-BR.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.pt-BR.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Uma extensão para visualizar SyntaxTrees do Roslyn.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.ru.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.ru.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Расширение для визуализации деревьев синтаксиса Roslyn.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.tr.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.tr.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">Roslyn SyntaxTrees’i görselleştirmek için bir uzantı.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.zh-Hans.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.zh-Hans.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">用于可视化 Roslyn SyntaxTrees 的扩展。</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.zh-Hant.xlf
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/xlf/VSPackage.zh-Hant.xlf
@@ -1,17 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VSPackage.resx">
-    <body>
-      <trans-unit id="110">
-        <source>Syntax Visualizer</source>
-        <target state="translated">Syntax Visualizer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="112">
-        <source>An extension for visualizing Roslyn SyntaxTrees.</source>
-        <target state="translated">用於將 Roslyn SyntaxTrees 視覺化的延伸模組。</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>


### PR DESCRIPTION
Help -> About is for top level extensions ("C#", "VB", etc).