### PR TITLE
Fix duplicate PackageReference in Restore

### DIFF
--- a/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/Roslyn.SDK.Template.Wizard.csproj
+++ b/src/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/Roslyn.SDK.Template.Wizard.csproj
@@ -17,8 +17,6 @@
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="$(MicrosoftVisualStudioTemplateWizardInterfaceVersion)" />
     <PackageReference Include="Microsoft.Visualstudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
-    <!-- Explicit reference to avoid missing package warning -->
-    <PackageReference Include="VSLangProj" Version="$(VSLangProjVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fix duplicate PackageReference in restore that is breaking the build in other PRs and local builds.

Fixes the build in #1001.