### PR TITLE
Add an explicit Newtonsoft.Json reference to the M.CA.Testing libraries

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -77,6 +77,8 @@
     <XunitCombinatorialVersion>1.2.7</XunitCombinatorialVersion>
     <MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>$(MicrosoftVisualStudioExtensibilityTestingVersion)</MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>
     <MicrosoftVisualStudioExtensibilityTestingXunitVersion>$(MicrosoftVisualStudioExtensibilityTestingVersion)</MicrosoftVisualStudioExtensibilityTestingXunitVersion>
+    <!-- Needed to override the transitive 9.0.1 version brought in by the 16.1.1 Microsoft.NET.Test.Sdk -->
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <!-- Analyzers -->
     <RoslynDiagnosticsAnalyzersVersion>2.9.8</RoslynDiagnosticsAnalyzersVersion>
     <StyleCopAnalyzersVersion>1.2.0-beta.164</StyleCopAnalyzersVersion>

--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -82,6 +82,11 @@
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
+  <!-- Needed to override the transitive 9.0.1 version brought in by the 16.1.1 Microsoft.NET.Test.Sdk -->
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+
   <!-- Use a different versioning scheme for nuget packages -->
   <PropertyGroup>
     <VersionPrefix>$(NugetPackagePrefix)</VersionPrefix>


### PR DESCRIPTION
Resolves a component governance issue https://devdiv.visualstudio.com/DevDiv/_componentGovernance/112744/alert/7082179?typeId=6257816 (microsoft)