### PR TITLE
Show embedded language classification in syntax visualizer

### DIFF
--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
@@ -207,6 +207,10 @@ namespace Roslyn.SyntaxVisualizer.Control
                         ClassifiedSpan = classifiedSpans.FirstOrDefault(s => s.TextSpan.Contains(trivia.Span));
                         break;
 
+                    case ClassifiedSpan span:
+                        ClassifiedSpan = span;
+                        break;
+
                     default:
                         ClassifiedSpan = null;
                         break;
@@ -795,7 +799,21 @@ namespace Roslyn.SyntaxVisualizer.Control
             };
 
             var item = CreateTreeViewItem(tag, $"{classifiedSpan.ClassificationType} {classifiedSpan.TextSpan}", false);
-            
+
+            item.Selected += new RoutedEventHandler((sender, e) =>
+            {
+                _isNavigatingFromTreeToSource = true;
+
+                typeTextLabel.Visibility = Visibility.Visible;
+                kindTextLabel.Visibility = Visibility.Hidden;
+                typeValueLabel.Content = classifiedSpan.GetType().Name;
+                kindValueLabel.Content = null;
+                _propertyGrid.SelectedObject = classifiedSpan;
+
+                _isNavigatingFromTreeToSource = false;
+                e.Handled = true;
+            });
+
             parentItem.Items.Add(item);
         }
 

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
@@ -13,7 +13,6 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shapes;
-using System.Xml.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
@@ -114,6 +113,9 @@ namespace Roslyn.SyntaxVisualizer.Control
         public delegate void SyntaxTokenDelegate(SyntaxToken token);
         public event SyntaxTokenDelegate? SyntaxTokenDirectedGraphRequested;
         public event SyntaxTokenDelegate? SyntaxTokenNavigationToSourceRequested;
+
+        public delegate void SyntaxClassifiedSpanDelegate(ClassifiedSpan span);
+        public event SyntaxClassifiedSpanDelegate? SyntaxClassifiedSpanNavigationToSourceRequested;
 
         public delegate void SyntaxTriviaDelegate(SyntaxTrivia trivia);
         public event SyntaxTriviaDelegate? SyntaxTriviaDirectedGraphRequested;
@@ -794,6 +796,7 @@ namespace Roslyn.SyntaxVisualizer.Control
             var tag = new SyntaxTag
             {
                 Category = SyntaxCategory.EmbeddedClassification,
+                FullSpan = classifiedSpan.TextSpan,
                 Span = classifiedSpan.TextSpan,
                 ParentItem = parentItem
             };
@@ -809,6 +812,11 @@ namespace Roslyn.SyntaxVisualizer.Control
                 typeValueLabel.Content = classifiedSpan.GetType().Name;
                 kindValueLabel.Content = null;
                 _propertyGrid.SelectedObject = classifiedSpan;
+
+                if (!_isNavigatingFromSourceToTree && SyntaxClassifiedSpanNavigationToSourceRequested != null)
+                {
+                    SyntaxClassifiedSpanNavigationToSourceRequested(classifiedSpan);
+                }
 
                 _isNavigatingFromTreeToSource = false;
                 e.Handled = true;

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/SyntaxVisualizerControl.xaml.cs
@@ -903,8 +903,12 @@ namespace Roslyn.SyntaxVisualizer.Control
 
                 if (embeddedClassifications.Count() > 1)
                 {
-                    foreach (var classifiedSpan in embeddedClassifications)
+                    foreach (var classifiedSpan in embeddedClassifications.OrderBy(cs => cs.TextSpan.Start))
                     {
+                        // skip the full span itself
+                        if (classifiedSpan.TextSpan == token.Span)
+                            continue;
+
                         AddEmbeddedClassification(item, classifiedSpan);
                     }
                 }

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml.cs
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/SyntaxVisualizerContainer.xaml.cs
@@ -65,6 +65,7 @@ namespace Roslyn.SyntaxVisualizer.Extension
 
             syntaxVisualizer.SyntaxNodeNavigationToSourceRequested += node => NavigateToSource(node?.Span);
             syntaxVisualizer.SyntaxTokenNavigationToSourceRequested += token => NavigateToSource(token.Span);
+            syntaxVisualizer.SyntaxClassifiedSpanNavigationToSourceRequested += span => NavigateToSource(span.TextSpan);
             syntaxVisualizer.SyntaxTriviaNavigationToSourceRequested += trivia => NavigateToSource(trivia.Span);
         }
 


### PR DESCRIPTION
Implements https://github.com/dotnet/roslyn/issues/63664.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/20194/187992246-413a0d03-94bc-4bd9-8286-1b49cad8b65d.png">

Working:

* Show `ClassifiedSpan`s that are children of `String` tokens as tree nodes
* Show their properties
* Allow navigating from source to such a span
* Allow navigating from such a span back to source

Not working:

* Show the classification's color. I need help with this — Visual Studio always seems to return black as the color.