### PR TITLE
Fix Microsoft.CodeAnalysis.Analyzer.Testing nuget package dependencies for downstream clients

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -84,7 +84,7 @@
 
   <!-- Needed to override the transitive 9.0.1 version brought in by the 16.1.1 Microsoft.NET.Test.Sdk -->
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" ExcludeAssets="all" />
   </ItemGroup>
 
   <!-- Use a different versioning scheme for nuget packages -->

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -31,7 +31,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <NuGetApiVersion>5.6.0</NuGetApiVersion>
+        <NuGetApiVersion>6.3.0</NuGetApiVersion>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/tests/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -21,7 +21,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <TestTargetFrameworks>netcoreapp3.1;net472;net46</TestTargetFrameworks>
+    <TestTargetFrameworks>netcoreapp3.1;net472</TestTargetFrameworks>
     <SourceGeneratorTestTargetFrameworks>netcoreapp3.1;net472</SourceGeneratorTestTargetFrameworks>
 
     <!-- Workaround dependencies that do not yet support netcoreapp3.1 https://github.com/dotnet/roslyn/issues/45114 -->


### PR DESCRIPTION
In https://github.com/dotnet/roslyn-sdk/pull/1004 we pinned the version of `Newtonsoft.Json` to be `13.0.1` because older versions have security problems.

However, this meant that the nuget packages now also required consumers to only use that version of `Newtonsoft.Json`. This breaks downstream test runners who rely on older versions of this assembly.

This change make the nuspec look like this

Microsoft.CodeAnalysis.Analyzer.Testing.nuspec:
```diff
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <dependencies>
      <group targetFramework=".NETFramework4.7.2">
        <dependency id="DiffPlex" version="1.5.0" include="Runtime,Build,Native,ContentFiles,Analyzers,BuildTransitive" />
        <dependency id="Microsoft.CodeAnalysis.Analyzers" version="2.6.1" exclude="Build,Analyzers" />
        <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" exclude="Build,Analyzers" />
        <dependency id="Microsoft.VisualBasic" version="10.0.1" exclude="Build,Analyzers" />
        <dependency id="Microsoft.VisualStudio.Composition" version="16.1.8" exclude="Build,Analyzers" />
-       <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
        <dependency id="NuGet.Common" version="5.6.0" include="Runtime,Build,Native,ContentFiles,Analyzers,BuildTransitive" />
        <dependency id="NuGet.Packaging" version="5.6.0" include="Runtime,Build,Native,ContentFiles,Analyzers,BuildTransitive" />
        <dependency id="NuGet.Protocol" version="5.6.0" include="Runtime,Build,Native,ContentFiles,Analyzers,BuildTransitive" />
        <dependency id="NuGet.Resolver" version="5.6.0" include="Runtime,Build,Native,ContentFiles,Analyzers,BuildTransitive" />
        <dependency id="System.ValueTuple" version="4.5.0" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```

by adding `ExcludeAssets="all"` we can ensure that this does not appear in the package dependencies list.

```diff
  <!-- Needed to override the transitive 9.0.1 version brought in by the 16.1.1 Microsoft.NET.Test.Sdk -->
  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" ExcludeAssets="all" />
  </ItemGroup>
```

which should ensure that we comply with security standards while also allowing runners to use whatever version of `Newtonsoft.Json` they require.