### PR TITLE
run integration tests in separate job

### DIFF
--- a/.vsts-pr.yaml
+++ b/.vsts-pr.yaml
@@ -34,16 +34,8 @@ jobs:
         _args: -test
         _configuration: Debug
         _solution: Roslyn-SDK
-      SDK Debug Integration Test:
-        _args: -integrationTest
-        _configuration: Debug
-        _solution: Roslyn-SDK
       SDK Release Test:
         _args: -test
-        _configuration: Release
-        _solution: Roslyn-SDK
-      SDK Release Integration Test:
-        _args: -integrationTest
         _configuration: Release
         _solution: Roslyn-SDK
       SDK Pack:
@@ -54,7 +46,7 @@ jobs:
         _args: -sign
         _configuration: Release
         _solution: Roslyn-SDK
-  timeoutInMinutes: 120
+  timeoutInMinutes: 90
 
   steps:
     - script: |

--- a/.vsts-pr.yaml
+++ b/.vsts-pr.yaml
@@ -31,11 +31,19 @@ jobs:
         _configuration: Release
         _solution: Samples
       SDK Debug Test:
-        _args: -test -integrationTest
+        _args: -test
+        _configuration: Debug
+        _solution: Roslyn-SDK
+      SDK Debug Integration Test:
+        _args: -integrationTest
         _configuration: Debug
         _solution: Roslyn-SDK
       SDK Release Test:
-        _args: -test -integrationTest
+        _args: -test
+        _configuration: Release
+        _solution: Roslyn-SDK
+      SDK Release Integration Test:
+        _args: -integrationTest
         _configuration: Release
         _solution: Roslyn-SDK
       SDK Pack:
@@ -46,7 +54,7 @@ jobs:
         _args: -sign
         _configuration: Release
         _solution: Roslyn-SDK
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
 
   steps:
     - script: |


### PR DESCRIPTION
Integration tests are regularly taking longer than the timeout. Want to split them out