### PR TITLE
Add support in AnalyzerTest to include source generators as part of the test run

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "7.0.100-preview.6.22352.1",
+    "version": "7.0.100",
     "allowPrerelease": true,
-    "rollForward": "major"
+    "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "7.0.100-preview.6.22352.1",
+    "dotnet": "7.0.100",
     "runtimes": {
       "dotnet": [
         "3.1.0"

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -150,6 +150,12 @@ namespace Microsoft.CodeAnalysis.Testing
         public Action<Diagnostic, DiagnosticResult, IVerifier>? DiagnosticVerifier { get; set; }
 
         /// <summary>
+        /// Gets a collection of transformation functions to apply to a <see cref="Compilation"/> during diagnostic or code
+        /// fix test setup.
+        /// </summary>
+        public List<Func<Compilation, Project, Compilation>> CompilationTransforms { get; } = new List<Func<Compilation, Project, Compilation>>();
+
+        /// <summary>
         /// Gets a collection of transformation functions to apply to <see cref="Workspace.Options"/> during diagnostic
         /// or code fix test setup.
         /// </summary>
@@ -922,6 +928,12 @@ namespace Microsoft.CodeAnalysis.Testing
             foreach (var project in solution.Projects)
             {
                 var compilation = await GetProjectCompilationAsync(project, verifier, cancellationToken).ConfigureAwait(false);
+
+                foreach (var transform in CompilationTransforms)
+                {
+                    compilation = transform(compilation, project);
+                }
+
                 var compilationWithAnalyzers = CreateCompilationWithAnalyzers(compilation, analyzers, GetAnalyzerOptions(project), cancellationToken);
                 var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.AnalyzerTest() -> void
+Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.CompilationTransforms.get -> System.Collections.Generic.List<System.Func<Microsoft.CodeAnalysis.Compilation, Microsoft.CodeAnalysis.Project, Microsoft.CodeAnalysis.Compilation>>
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.CompilerDiagnostics.get -> Microsoft.CodeAnalysis.Testing.CompilerDiagnostics
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.CompilerDiagnostics.set -> void
 Microsoft.CodeAnalysis.Testing.AnalyzerTest<TVerifier>.CreateProjectAsync(Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState primaryProject, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Testing.Model.EvaluatedProjectState> additionalProjects, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Project>


### PR DESCRIPTION
Implements `CompilationTransforms` so that test authors can provide additional transforms after the basic compilation has been created.

Closes #1038