### PR TITLE
Document architectural constraints, so they are visible to the public

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -112,3 +112,9 @@ dotnet_style_qualification_for_field = false:none
 dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none
 dotnet_style_qualification_for_event = false:none
+
+# StyleCop rules that will fail the CI-Build should generate errors already while editing
+dotnet_analyzer_diagnostic.category-StyleCop.CSharp.LayoutRules.severity = error
+dotnet_analyzer_diagnostic.category-StyleCop.CSharp.SpacingRules.severity = error
+dotnet_analyzer_diagnostic.category-StyleCop.CSharp.MaintainabilityRules.severity = error
+dotnet_analyzer_diagnostic.category-StyleCop.CSharp.ReadabilityRules.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -113,8 +113,6 @@ dotnet_style_qualification_for_property = false:none
 dotnet_style_qualification_for_method = false:none
 dotnet_style_qualification_for_event = false:none
 
-# StyleCop rules that will fail the CI-Build should generate errors already while editing
-dotnet_analyzer_diagnostic.category-StyleCop.CSharp.LayoutRules.severity = error
-dotnet_analyzer_diagnostic.category-StyleCop.CSharp.SpacingRules.severity = error
-dotnet_analyzer_diagnostic.category-StyleCop.CSharp.MaintainabilityRules.severity = error
-dotnet_analyzer_diagnostic.category-StyleCop.CSharp.ReadabilityRules.severity = error
+# No diagnostic should be set to a severity greater than warning except for compiler errors where it is impossible to produce a correct binary.
+# Artificially raising the severity of diagnostics to error interferes with the developer inner loop for things like red/green development while running tests.
+# CI sets the Treat Warnings as Errors flag to ensure that any diagnostics that slip through are caught before merge.


### PR DESCRIPTION
Fix #1076: StyleCop rules that will fail the CI-Build should generate errors already while editing