### PR TITLE
Remove the ISourceGenerator type constraint

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.MSTest/SourceGeneratorVerifier.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.MSTest/SourceGeneratorVerifier.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing.MSTest
     public static class SourceGeneratorVerifier
     {
         public static SourceGeneratorVerifier<TSourceGenerator> Create<TSourceGenerator>()
-            where TSourceGenerator : ISourceGenerator, new()
+            where TSourceGenerator : new()
         {
             return new SourceGeneratorVerifier<TSourceGenerator>();
         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.MSTest/SourceGeneratorVerifier`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.MSTest/SourceGeneratorVerifier`1.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Testing.Verifiers;
 namespace Microsoft.CodeAnalysis.CSharp.Testing.MSTest
 {
     public class SourceGeneratorVerifier<TSourceGenerator> : CSharpSourceGeneratorVerifier<TSourceGenerator, MSTestVerifier>
-        where TSourceGenerator : ISourceGenerator, new()
+        where TSourceGenerator : new()
     {
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.NUnit/SourceGeneratorVerifier.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.NUnit/SourceGeneratorVerifier.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing.NUnit
     public static class SourceGeneratorVerifier
     {
         public static SourceGeneratorVerifier<TSourceGenerator> Create<TSourceGenerator>()
-            where TSourceGenerator : ISourceGenerator, new()
+            where TSourceGenerator : new()
         {
             return new SourceGeneratorVerifier<TSourceGenerator>();
         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.NUnit/SourceGeneratorVerifier`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.NUnit/SourceGeneratorVerifier`1.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Testing.Verifiers;
 namespace Microsoft.CodeAnalysis.CSharp.Testing.NUnit
 {
     public class SourceGeneratorVerifier<TSourceGenerator> : CSharpSourceGeneratorVerifier<TSourceGenerator, NUnitVerifier>
-        where TSourceGenerator : ISourceGenerator, new()
+        where TSourceGenerator : new()
     {
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit/SourceGeneratorVerifier.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit/SourceGeneratorVerifier.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing.XUnit
     public static class SourceGeneratorVerifier
     {
         public static SourceGeneratorVerifier<TSourceGenerator> Create<TSourceGenerator>()
-            where TSourceGenerator : ISourceGenerator, new()
+            where TSourceGenerator : new()
         {
             return new SourceGeneratorVerifier<TSourceGenerator>();
         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit/SourceGeneratorVerifier`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit/SourceGeneratorVerifier`1.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Testing.Verifiers;
 namespace Microsoft.CodeAnalysis.CSharp.Testing.XUnit
 {
     public class SourceGeneratorVerifier<TSourceGenerator> : CSharpSourceGeneratorVerifier<TSourceGenerator, XUnitVerifier>
-        where TSourceGenerator : ISourceGenerator, new()
+        where TSourceGenerator : new()
     {
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/CSharpSourceGeneratorTest`2.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/CSharpSourceGeneratorTest`2.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Testing;
 namespace Microsoft.CodeAnalysis.CSharp.Testing
 {
     public class CSharpSourceGeneratorTest<TSourceGenerator, TVerifier> : SourceGeneratorTest<TVerifier>
-        where TSourceGenerator : ISourceGenerator, new()
+        where TSourceGenerator : new()
         where TVerifier : IVerifier, new()
     {
         private static readonly LanguageVersion DefaultLanguageVersion =

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/CSharpSourceGeneratorVerifier`2.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/CSharpSourceGeneratorVerifier`2.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Testing;
 namespace Microsoft.CodeAnalysis.CSharp.Testing
 {
     public class CSharpSourceGeneratorVerifier<TSourceGenerator, TVerifier> : SourceGeneratorVerifier<TSourceGenerator, CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>, TVerifier>
-        where TSourceGenerator : ISourceGenerator, new()
+        where TSourceGenerator : new()
         where TVerifier : IVerifier, new()
     {
     }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorTest`1.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <summary>
         /// Returns the source generators being tested - to be implemented in non-abstract class.
         /// </summary>
-        /// <returns>The <see cref="ISourceGenerator"/> to be used.</returns>
+        /// <returns>The <see cref="ISourceGenerator"/> and/or <see cref="T:Microsoft.CodeAnalysis.IIncrementalGenerator"/> to be used.</returns>
         protected override abstract IEnumerable<Type> GetSourceGenerators();
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorVerifier`3.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/SourceGeneratorVerifier`3.cs
@@ -7,11 +7,11 @@ namespace Microsoft.CodeAnalysis.Testing
     /// <summary>
     /// A default verifier for source generators.
     /// </summary>
-    /// <typeparam name="TSourceGenerator">The <see cref="ISourceGenerator"/> to test.</typeparam>
+    /// <typeparam name="TSourceGenerator">The <see cref="ISourceGenerator"/> or <see cref="T:Microsoft.CodeAnalysis.IIncrementalGenerator"/> to test.</typeparam>
     /// <typeparam name="TTest">The test implementation to use.</typeparam>
     /// <typeparam name="TVerifier">The type of verifier to use.</typeparam>
     public class SourceGeneratorVerifier<TSourceGenerator, TTest, TVerifier>
-           where TSourceGenerator : ISourceGenerator, new()
+           where TSourceGenerator : new()
            where TTest : SourceGeneratorTest<TVerifier>, new()
            where TVerifier : IVerifier, new()
     {

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.MSTest/SourceGeneratorVerifier.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.MSTest/SourceGeneratorVerifier.vb
@@ -1,7 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Module SourceGeneratorVerifier
-    Public Function Create(Of TSourceGenerator As {ISourceGenerator, New})() As SourceGeneratorVerifier(Of TSourceGenerator)
+    Public Function Create(Of TSourceGenerator As New)() As SourceGeneratorVerifier(Of TSourceGenerator)
         Return New SourceGeneratorVerifier(Of TSourceGenerator)
     End Function
 End Module

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.MSTest/SourceGeneratorVerifier`1.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.MSTest/SourceGeneratorVerifier`1.vb
@@ -2,6 +2,6 @@
 
 Imports Microsoft.CodeAnalysis.Testing.Verifiers
 
-Public Class SourceGeneratorVerifier(Of TSourceGenerator As {ISourceGenerator, New})
+Public Class SourceGeneratorVerifier(Of TSourceGenerator As New)
     Inherits VisualBasicSourceGeneratorVerifier(Of TSourceGenerator, MSTestVerifier)
 End Class

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.NUnit/SourceGeneratorVerifier.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.NUnit/SourceGeneratorVerifier.vb
@@ -1,7 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Module SourceGeneratorVerifier
-    Public Function Create(Of TSourceGenerator As {ISourceGenerator, New})() As SourceGeneratorVerifier(Of TSourceGenerator)
+    Public Function Create(Of TSourceGenerator As New)() As SourceGeneratorVerifier(Of TSourceGenerator)
         Return New SourceGeneratorVerifier(Of TSourceGenerator)
     End Function
 End Module

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.NUnit/SourceGeneratorVerifier`1.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.NUnit/SourceGeneratorVerifier`1.vb
@@ -2,6 +2,6 @@
 
 Imports Microsoft.CodeAnalysis.Testing.Verifiers
 
-Public Class SourceGeneratorVerifier(Of TSourceGenerator As {ISourceGenerator, New})
+Public Class SourceGeneratorVerifier(Of TSourceGenerator As New)
     Inherits VisualBasicSourceGeneratorVerifier(Of TSourceGenerator, NUnitVerifier)
 End Class

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit/SourceGeneratorVerifier.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit/SourceGeneratorVerifier.vb
@@ -1,7 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Module SourceGeneratorVerifier
-    Public Function Create(Of TSourceGenerator As {ISourceGenerator, New})() As SourceGeneratorVerifier(Of TSourceGenerator)
+    Public Function Create(Of TSourceGenerator As New)() As SourceGeneratorVerifier(Of TSourceGenerator)
         Return New SourceGeneratorVerifier(Of TSourceGenerator)
     End Function
 End Module

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit/SourceGeneratorVerifier`1.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit/SourceGeneratorVerifier`1.vb
@@ -2,6 +2,6 @@
 
 Imports Microsoft.CodeAnalysis.Testing.Verifiers
 
-Public Class SourceGeneratorVerifier(Of TSourceGenerator As {ISourceGenerator, New})
+Public Class SourceGeneratorVerifier(Of TSourceGenerator As New)
     Inherits VisualBasicSourceGeneratorVerifier(Of TSourceGenerator, XUnitVerifier)
 End Class

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/VisualBasicSourceGeneratorTest`2.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/VisualBasicSourceGeneratorTest`2.vb
@@ -2,7 +2,7 @@
 
 Imports Microsoft.CodeAnalysis.Testing
 
-Public Class VisualBasicSourceGeneratorTest(Of TSourceGenerator As {ISourceGenerator, New}, TVerifier As {IVerifier, New})
+Public Class VisualBasicSourceGeneratorTest(Of TSourceGenerator As New, TVerifier As {IVerifier, New})
     Inherits SourceGeneratorTest(Of TVerifier)
 
     Private Shared ReadOnly DefaultLanguageVersion As LanguageVersion =

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/VisualBasicSourceGeneratorVerifier`2.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/VisualBasicSourceGeneratorVerifier`2.vb
@@ -2,6 +2,6 @@
 
 Imports Microsoft.CodeAnalysis.Testing
 
-Public Class VisualBasicSourceGeneratorVerifier(Of TSourceGenerator As {ISourceGenerator, New}, TVerifier As {IVerifier, New})
+Public Class VisualBasicSourceGeneratorVerifier(Of TSourceGenerator As New, TVerifier As {IVerifier, New})
     Inherits SourceGeneratorVerifier(Of TSourceGenerator, VisualBasicSourceGeneratorTest(Of TSourceGenerator, TVerifier), TVerifier)
 End Class


### PR DESCRIPTION
This change simplifies the pattern for testing `IIncrementalGenerator` without removing the ability to test `ISourceGenerator` with Roslyn 3.x.