### PR TITLE
Replace Classic NUnit Assertions with Constraints Model to Support NUnit 4

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit.csproj
@@ -15,6 +15,10 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.0.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit.csproj
@@ -15,10 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit/NUnitVerifier.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.NUnit/NUnitVerifier.cs
@@ -27,18 +27,18 @@ namespace Microsoft.CodeAnalysis.Testing.Verifiers
 
         public virtual void Empty<T>(string collectionName, IEnumerable<T> collection)
         {
-            Assert.IsEmpty(collection, CreateMessage($"Expected '{collectionName}' to be empty, contains '{collection?.Count()}' elements"));
+            Assert.That(collection, Is.Empty, CreateMessage($"Expected '{collectionName}' to be empty, contains '{collection?.Count()}' elements"));
         }
 
         public virtual void Equal<T>(T expected, T actual, string? message = null)
         {
             if (message is null && Context.IsEmpty)
             {
-                Assert.AreEqual(expected, actual);
+                Assert.That(actual, Is.EqualTo(expected));
             }
             else
             {
-                Assert.AreEqual(expected, actual, CreateMessage(message));
+                Assert.That(actual, Is.EqualTo(expected), CreateMessage(message));
             }
         }
 
@@ -46,11 +46,11 @@ namespace Microsoft.CodeAnalysis.Testing.Verifiers
         {
             if (message is null && Context.IsEmpty)
             {
-                Assert.IsTrue(assert);
+                Assert.That(assert);
             }
             else
             {
-                Assert.IsTrue(assert, CreateMessage(message));
+                Assert.That(assert, CreateMessage(message));
             }
         }
 
@@ -58,11 +58,11 @@ namespace Microsoft.CodeAnalysis.Testing.Verifiers
         {
             if (message is null && Context.IsEmpty)
             {
-                Assert.IsFalse(assert);
+                Assert.That(assert, Is.False);
             }
             else
             {
-                Assert.IsFalse(assert, CreateMessage(message));
+                Assert.That(assert, Is.False, CreateMessage(message));
             }
         }
 
@@ -83,12 +83,12 @@ namespace Microsoft.CodeAnalysis.Testing.Verifiers
 
         public virtual void LanguageIsSupported(string language)
         {
-            Assert.IsFalse(language != LanguageNames.CSharp && language != LanguageNames.VisualBasic, CreateMessage($"Unsupported Language: '{language}'"));
+            Assert.That(language != LanguageNames.CSharp && language != LanguageNames.VisualBasic, Is.False, CreateMessage($"Unsupported Language: '{language}'"));
         }
 
         public virtual void NotEmpty<T>(string collectionName, IEnumerable<T> collection)
         {
-            Assert.IsNotEmpty(collection, CreateMessage($"expected '{collectionName}' to be non-empty, contains"));
+            Assert.That(collection, Is.Not.Empty, CreateMessage($"expected '{collectionName}' to be non-empty, contains"));
         }
 
         public virtual void SequenceEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T>? equalityComparer = null, string? message = null)
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Testing.Verifiers
 
         public virtual IVerifier PushContext(string context)
         {
-            Assert.AreEqual(typeof(NUnitVerifier), GetType());
+            Assert.That(GetType(), Is.EqualTo(typeof(NUnitVerifier)));
             return new NUnitVerifier(Context.Push(context));
         }
 


### PR DESCRIPTION
Using NUnit analyzer to automate the conversion from classic NUnit assertions to constraints model assertions as [suggested in the migration guide to NUnit 4.0](https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html#convert-classic-assert-to-constraint-model). This is required to support using the test classes in source generator consuming projects that want to upgrade to NUnit 4.0.

Should fix #1127.