### PR TITLE
Avoid unnecessary M.VisualBasic and S.ValueTuple dependencies

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -49,10 +49,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.0.1" />
-    <PackageReference Include="Microsoft.VisualBasic" Version="10.0.1" />
+    <PackageReference Include="Microsoft.VisualBasic" Version="10.0.1" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.1.8" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="'$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'net452' or '$(TargetFramework)' == 'net46'" />
 
     <!-- Use PrivateAssets=compile to avoid exposing our NuGet dependencies downstream as public API. -->
     <PackageReference Include="NuGet.Common" Version="$(NuGetApiVersion)" PrivateAssets="compile" />


### PR DESCRIPTION
Found in https://github.com/dotnet/runtime/pull/96795#discussion_r1464797169

These packages shouldn't be referenced on modern TFMs as the types are already provided inbox by the framework.

---

FWIW, I'm not sure why roslyn-sdk targets out-of-support TFMs like net452 or net46: https://learn.microsoft.com/de-de/lifecycle/products/microsoft-net-framework. That goes against what Tactics agreed on in November. See https://github.com/dotnet/designs-microsoft/pull/74 for more details.