### PR TITLE
Update DiffPlex version to 1.7.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,7 @@
     <MicrosoftVisualStudioProjectSystemManagedVSVersion>17.3.51-g48943e0519</MicrosoftVisualStudioProjectSystemManagedVSVersion>
     <MicrosoftVisualStudioProjectSystemSDKToolsVersion>17.3.195-pre</MicrosoftVisualStudioProjectSystemSDKToolsVersion>
     <!-- Libs -->
-    <DiffPlexVersion>1.5.0</DiffPlexVersion>
+    <DiffPlexVersion>1.7.2</DiffPlexVersion>
     <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <!-- Testing -->
     <MicrosoftCodeAnalysis2PrimaryTestVersion>2.6.1</MicrosoftCodeAnalysis2PrimaryTestVersion>


### PR DESCRIPTION
Noticed in https://github.com/dotnet/runtime/pull/96795#discussion_r1464797169

The current referenced version of DiffPlex brings netstandard1.x dependencies in which explodes the dependency graph and brings packages marked as vulnerable in. Reference a higher version which now provides a .NET Standard and .NET compatible API surface area without bringing additional package dependencies in.