### PR TITLE
Add ReferenceAssemblies.Net.Net90

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/PublicAPI.Unshipped.txt
@@ -280,6 +280,13 @@ static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80MacOS.get -> 
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80TvOS.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80Windows.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net80iOS.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90Android.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90MacCatalyst.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90MacOS.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90TvOS.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90Windows.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
+static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Net.Net90iOS.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp10.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp11.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies
 static Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetCore.NetCoreApp20.get -> Microsoft.CodeAnalysis.Testing.ReferenceAssemblies

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
@@ -1072,6 +1072,59 @@ namespace Microsoft.CodeAnalysis.Testing
                         ImmutableArray.Create(
                             new PackageIdentity("Microsoft.tvOS.Ref", "17.0.8478"))));
 
+            private static readonly Lazy<ReferenceAssemblies> _lazyNet90 =
+                new Lazy<ReferenceAssemblies>(() =>
+                {
+                    if (!NuGetFramework.Parse("net9.0").IsPackageBased)
+                    {
+                        // The NuGet version provided at runtime does not recognize the 'net9.0' target framework
+                        throw new NotSupportedException("The 'net9.0' target framework is not supported by this version of NuGet.");
+                    }
+
+                    return new ReferenceAssemblies(
+                        "net9.0",
+                        new PackageIdentity(
+                            "Microsoft.NETCore.App.Ref",
+                            "9.0.0-preview.1.24080.9"),
+                        Path.Combine("ref", "net9.0"));
+                });
+
+            private static readonly Lazy<ReferenceAssemblies> _lazyNet90Windows =
+                new Lazy<ReferenceAssemblies>(() =>
+                    Net90.AddPackages(
+                        ImmutableArray.Create(
+                            new PackageIdentity("Microsoft.WindowsDesktop.App.Ref", "9.0.0-preview.1.24081.3"))));
+
+            private static readonly Lazy<ReferenceAssemblies> _lazyNet90MacOS =
+                new Lazy<ReferenceAssemblies>(() =>
+                    Net90.AddPackages(
+                        ImmutableArray.Create(
+                            new PackageIdentity("Microsoft.macOS.Ref", "14.2.9088-net9-p1"))));
+
+            private static readonly Lazy<ReferenceAssemblies> _lazyNet90Android =
+                new Lazy<ReferenceAssemblies>(() =>
+                    Net90.AddPackages(
+                        ImmutableArray.Create(
+                            new PackageIdentity("Microsoft.Android.Ref.34", "34.99.0-preview.1.151"))));
+
+            private static readonly Lazy<ReferenceAssemblies> _lazyNet90iOS =
+                new Lazy<ReferenceAssemblies>(() =>
+                    Net90.AddPackages(
+                        ImmutableArray.Create(
+                            new PackageIdentity("Microsoft.iOS.Ref", "17.2.9088-net9-p1"))));
+
+            private static readonly Lazy<ReferenceAssemblies> _lazyNet90MacCatalyst =
+                new Lazy<ReferenceAssemblies>(() =>
+                    Net90.AddPackages(
+                        ImmutableArray.Create(
+                            new PackageIdentity("Microsoft.MacCatalyst.Ref", "17.2.9088-net9-p1"))));
+
+            private static readonly Lazy<ReferenceAssemblies> _lazyNet90TvOS =
+                new Lazy<ReferenceAssemblies>(() =>
+                    Net90.AddPackages(
+                        ImmutableArray.Create(
+                            new PackageIdentity("Microsoft.tvOS.Ref", "17.2.9088-net9-p1"))));
+
             public static ReferenceAssemblies Net50 => _lazyNet50.Value;
 
             public static ReferenceAssemblies Net60 => _lazyNet60.Value;
@@ -1115,6 +1168,20 @@ namespace Microsoft.CodeAnalysis.Testing
             public static ReferenceAssemblies Net80MacCatalyst => _lazyNet80MacCatalyst.Value;
 
             public static ReferenceAssemblies Net80TvOS => _lazyNet80TvOS.Value;
+
+            public static ReferenceAssemblies Net90 => _lazyNet90.Value;
+
+            public static ReferenceAssemblies Net90Windows => _lazyNet90Windows.Value;
+
+            public static ReferenceAssemblies Net90Android => _lazyNet90Android.Value;
+
+            public static ReferenceAssemblies Net90iOS => _lazyNet90iOS.Value;
+
+            public static ReferenceAssemblies Net90MacOS => _lazyNet90MacOS.Value;
+
+            public static ReferenceAssemblies Net90MacCatalyst => _lazyNet90MacCatalyst.Value;
+
+            public static ReferenceAssemblies Net90TvOS => _lazyNet90TvOS.Value;
         }
 
         public static class NetStandard

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/MetadataReferenceTests.cs
@@ -615,6 +615,13 @@ namespace Microsoft.CodeAnalysis.Testing
         [InlineData("net8.0-macos")]
         [InlineData("net8.0-maccatalyst")]
         [InlineData("net8.0-tvos")]
+        [InlineData("net9.0")]
+        [InlineData("net9.0-windows")]
+        [InlineData("net9.0-android")]
+        [InlineData("net9.0-ios")]
+        [InlineData("net9.0-macos")]
+        [InlineData("net9.0-maccatalyst")]
+        [InlineData("net9.0-tvos")]
 #endif
         [InlineData("netstandard1.0")]
         [InlineData("netstandard1.1")]
@@ -687,6 +694,13 @@ class TestClass {
                 "net8.0-macos" => ReferenceAssemblies.Net.Net80MacOS,
                 "net8.0-maccatalyst" => ReferenceAssemblies.Net.Net80MacCatalyst,
                 "net8.0-tvos" => ReferenceAssemblies.Net.Net80TvOS,
+                "net9.0" => ReferenceAssemblies.Net.Net90,
+                "net9.0-windows" => ReferenceAssemblies.Net.Net90Windows,
+                "net9.0-android" => ReferenceAssemblies.Net.Net90Android,
+                "net9.0-ios" => ReferenceAssemblies.Net.Net90iOS,
+                "net9.0-macos" => ReferenceAssemblies.Net.Net90MacOS,
+                "net9.0-maccatalyst" => ReferenceAssemblies.Net.Net90MacCatalyst,
+                "net9.0-tvos" => ReferenceAssemblies.Net.Net90TvOS,
                 "netstandard1.0" => ReferenceAssemblies.NetStandard.NetStandard10,
                 "netstandard1.1" => ReferenceAssemblies.NetStandard.NetStandard11,
                 "netstandard1.2" => ReferenceAssemblies.NetStandard.NetStandard12,


### PR DESCRIPTION
I want to use an API (https://github.com/dotnet/runtime/issues/60393) introduced in .NET 9 for an analyzer that I am writing (https://github.com/dotnet/roslyn-analyzers/pull/6967).

If preview 1 is too early to add it here, I could add it temporarily in roslyn-analyzer (and remove it when Net90 is added later).