### PR TITLE
Build for .NET 5, 6, 7, 8, 9 & 10 and ReferenceAssemblies.Default to locate each respective runtime

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,6 +64,7 @@
     <NuGetSolutionRestoreManagerInteropVersion>5.6.0</NuGetSolutionRestoreManagerInteropVersion>
     <StreamJsonRpcVersion>2.12.27</StreamJsonRpcVersion>
     <SystemFormatsAsn1Version>6.0.1</SystemFormatsAsn1Version>
+    <SystemResourcesExtensionsVersion>9.0.0</SystemResourcesExtensionsVersion>
     <SystemTextJsonVersion>6.0.10</SystemTextJsonVersion>
     <VSLangProjVersion>$(MicrosoftVisualStudioShellPackagesVersion)</VSLangProjVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>17.0.0-preview-1-30928-1111</MicrosoftVisualStudioTemplateWizardInterfaceVersion>

--- a/global.json
+++ b/global.json
@@ -1,18 +1,18 @@
 {
   "sdk": {
-    "version": "8.0.125",
+    "version": "10.0.100",
     "allowPrerelease": false,
     "rollForward": "latestPatch"
   },
   "tools": {
-    "dotnet": "8.0.125",
+    "dotnet": "10.0.100",
     "runtimes": {
       "dotnet": [
         "3.1.0"
       ]
     },
     "vs": {
-      "version": "17.8.0"
+      "version": "17.12.0"
     },
     "xcopy-msbuild": "17.8.1-2"
   },

--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -10,17 +10,16 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <!--
-      netcoreapp3.1: Ensures full support for nullable reference types
-      netstandard2.0/net472: Roslyn 3.x
-    -->
-    <TestingLibraryTargetFrameworks>netcoreapp3.1;netstandard2.0;net461;net472</TestingLibraryTargetFrameworks>
+    <!-- Required for the .NET 10 SDK to build out-of-support target frameworks -->
+    <CheckNotRecommendedTargetFramework>false</CheckNotRecommendedTargetFramework>
+
+    <TestingLibraryTargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netstandard1.6;netstandard2.0;net452;net46;net461;net472</TestingLibraryTargetFrameworks>
 
     <!--
       netcoreapp3.1: Ensures full support for nullable reference types
       netstandard2.0/net472: Roslyn 3.x, starting with 3.8.0
     -->
-    <TestingLibrarySourceGeneratorTargetFrameworks>netcoreapp3.1;netstandard2.0;net472</TestingLibrarySourceGeneratorTargetFrameworks>
+    <TestingLibrarySourceGeneratorTargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netstandard2.0;net472</TestingLibrarySourceGeneratorTargetFrameworks>
   </PropertyGroup>
   
   <Choose>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
@@ -88,8 +88,26 @@ namespace Microsoft.CodeAnalysis.Testing
         {
             get
             {
-#if NETSTANDARD2_0
+#if NET10_0_OR_GREATER
+                return Net.Net100;
+#elif NET9_0_OR_GREATER
+                return Net.Net90;
+#elif NET8_0_OR_GREATER
+                return Net.Net80;
+#elif NET7_0_OR_GREATER
+                return Net.Net70;
+#elif NET6_0_OR_GREATER
+                return Net.Net60;
+#elif NET5_0_OR_GREATER
+                return Net.Net50;
+#elif NETSTANDARD1_6
+                return NetStandard.NetStandard16;
+#elif NETSTANDARD2_0
                 return NetStandard.NetStandard20;
+#elif NET452
+                return NetFramework.Net452.Default;
+#elif NET46
+                return NetFramework.Net46.Default;
 #elif NET461
                 return NetFramework.Net461.Default;
 #elif NET472

--- a/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" Version="$(MicrosoftVisualStudioProjectSystemSDKToolsVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="$(MicrosoftVisualStudioShellPackagesVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="$(MicrosoftVisualStudioShellPackagesVersion)" PrivateAssets="all" />
+    <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageReference Include="System.Threading.Tasks.DataFlow" Version="$(SystemThreadingTasksDataflowVersion)" />
   </ItemGroup>

--- a/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/Roslyn.SyntaxVisualizer.Extension.csproj
+++ b/src/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/Roslyn.SyntaxVisualizer.Extension.csproj
@@ -16,6 +16,7 @@
     <Ngen>false</Ngen>
     <UseCodeBase>true</UseCodeBase>
     <SetupProductArch>Neutral</SetupProductArch>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <!-- References -->
@@ -46,6 +47,7 @@
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <!-- Explicit reference to avoid missing package warning -->
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropVersion)" />
+    <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsVersion)" />
   </ItemGroup>
 
   <!-- Project References -->


### PR DESCRIPTION
## Summary

- Add `net5.0` through `net10.0` to `TestingLibraryTargetFrameworks` and `TestingLibrarySourceGeneratorTargetFrameworks`, enabling the testing libraries to be built for each modern .NET runtime
- Update `ReferenceAssemblies.Default` to return the correct reference assemblies for the target framework being compiled against (e.g. `Net.Net100` on .NET 10, `Net.Net90` on .NET 9, etc.) via conditional compilation
- Update `global.json` to .NET 10 SDK to support building `net10.0` targets
- Add `System.Resources.Extensions` package reference to fix VSSDK1012 build error with newer SDK versions
- Add `CheckNotRecommendedTargetFramework=false` to allow building .NET Standard 1.6 with the .NET 10 SDK