### PR TITLE
[Proposal] Performance/usability improvements for analyzer tests

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -16,7 +16,7 @@
       netstandard1.6/net46: Roslyn 2.x
       netstandard2.0/net472: Roslyn 3.x
     -->
-    <TestingLibraryTargetFrameworks>netcoreapp3.1;netstandard1.6;netstandard2.0;net452;net46;net472</TestingLibraryTargetFrameworks>
+    <TestingLibraryTargetFrameworks>net7.0;netcoreapp3.1;netstandard1.6;netstandard2.0;net452;net46;net472</TestingLibraryTargetFrameworks>
 
     <!--
       netcoreapp3.1: Ensures full support for nullable reference types

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
@@ -103,6 +103,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 return NetFramework.Net472.Default;
 #elif NETCOREAPP3_1
                 return NetCore.NetCoreApp31;
+#elif NET7_0
+                return Net.Net70;
 #endif
             }
         }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/CSharpAnalyzerTest`2.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/CSharpAnalyzerTest`2.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Microsoft.CodeAnalysis.CSharp.Testing
 {
-    public class CSharpAnalyzerTest<TAnalyzer, TVerifier> : AnalyzerTest<TVerifier>
+    public partial class CSharpAnalyzerTest<TAnalyzer, TVerifier> : AnalyzerTest<TVerifier>
         where TAnalyzer : DiagnosticAnalyzer, new()
         where TVerifier : IVerifier, new()
     {

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/CSharpAnalyzerTest`2.net7.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/CSharpAnalyzerTest`2.net7.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing;
 
 public partial class CSharpAnalyzerTest<TAnalyzer, TVerifier>
 {
+    // For net9.0 the second parameter could be 'params ReadOnlySpan<DiagnosticResult> expectedDiagnostics'
     public static CSharpAnalyzerTest<TAnalyzer, TVerifier> Create([StringSyntax("C#-test")] string source, params DiagnosticResult[] expectedDiagnostics)
     {
         var test = new CSharpAnalyzerTest<TAnalyzer, TVerifier> { TestCode = source };

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/CSharpAnalyzerTest`2.net7.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/CSharpAnalyzerTest`2.net7.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.CodeAnalysis.CSharp.Testing;
+
+public partial class CSharpAnalyzerTest<TAnalyzer, TVerifier>
+{
+    public static CSharpAnalyzerTest<TAnalyzer, TVerifier> Create([StringSyntax("C#-test")] string source, params DiagnosticResult[] expectedDiagnostics)
+    {
+        var test = new CSharpAnalyzerTest<TAnalyzer, TVerifier> { TestCode = source };
+        test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
+
+        return test;
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/Extensions/CSharpAnalyzerTestExtensions.net7.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/Extensions/CSharpAnalyzerTestExtensions.net7.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.CodeAnalysis.CSharp.Testing;
+
+public static class CSharpAnalyzerTestExtensions
+{
+    public static CSharpAnalyzerTest<TAnalyzer, TVerifier> WithSource<TAnalyzer, TVerifier>(this CSharpAnalyzerTest<TAnalyzer, TVerifier> test, [StringSyntax("C#-test")] string source)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+        where TVerifier : IVerifier, new()
+    {
+        test.TestState.Sources.Add(source);
+        return test;
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing/Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.csproj
@@ -14,6 +14,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="CSharpAnalyzerTest`2.net7.cs" />
+    <Compile Remove="Extensions/CSharpAnalyzerTestExtensions.net7.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
+    <Compile Include="CSharpAnalyzerTest`2.net7.cs" />
+    <Compile Include="Extensions/CSharpAnalyzerTestExtensions.net7.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
I would like to propose some improvements for code analyzer tests.

I have worked with analyzers in a few .NET repos, running and verifying a test often looks like this:

```cs
public async Task Test()
{
    var source = "...";
    var expectedDiagnostics = new[] { ... };
    await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics); // VerifyCS is a type alias
}
```

**Proposal**

I believe that a factory method that creates a `CSharpAnalyzerTest<TAnalyzer, TVerifier>` could improve both usability and performance of tests:

```cs
public partial class CSharpAnalyzerTest<TAnalyzer, TVerifier> : AnalyzerTest<TVerifier>
{
    // For net9.0 the second parameter could be 'params ReadOnlySpan<DiagnosticResult> expectedDiagnostics'
    public static CSharpAnalyzerTest<TAnalyzer, TVerifier> Create([StringSyntax("C#-test")] string source, params DiagnosticResult[] expectedDiagnostics);
}

public static class CSharpAnalyzerTestExtensions
{
    public static CSharpAnalyzerTest<TAnalyzer, TVerifier> WithSource<TAnalyzer, TVerifier>(this CSharpAnalyzerTest<TAnalyzer, TVerifier> test, [StringSyntax("C#-test")] string source);
}
```

Using such helper methods could have some benefits:

- It could improve performance of tests in .NET 9 if diagnostics are passed as `params ReadOnlySpan<DiagnosticResult>` that avoids array allocation. This is not possible with the async `VerifyAnalyzerAsync` method.

  > I tried to use `<LangVersion Condition="<if net9.0 or greater>">13</LangVersion>` in the project, but this results build error "error CS1617: Invalid option '13' for /langversion" (is this an msbuild/compiler bug?).

- The `[SyntaxAttribute("C#-test")]` attribute applied to `source` parameter will enable syntax highlighting for test source code in Visual Studio. Please see description of PR [#63642](https://github.com/dotnet/aspnetcore/pull/63642) that I submitted to ASP.NET Core repo.

  > `SyntaxAttribute` is available starting from .NET 7, this is why I added this target framework in `Directory.Build.props`. 

- This allows to use additional helper methods that can be used to customize the test, to provide additional sources or test configuration if needed. For example, if each test needs some common code, test source code can be split into multiple 'files' and additional source can be provided using `WithSource` extension:

  ```cs
  private const string Program = """
      public class Program
      {
          public static void Main() { }
      }
      """;

  public async Task Test()
  {
      var source = "...";
      var test = CSTest.Create(source, CreateDiagnostic()).WithSource(Program); // CSTest is type alias
      await test.RunAsync();
  }
  ```

- This will avoid the need to create 'local' helper methods in analyzer test classes that need to customize a test in some way.

**Examples**

Please see PR [#63657](https://github.com/dotnet/aspnetcore/pull/63657) where I included tests using the suggested approach.
I also suggested such changes in PR [#63684](https://github.com/dotnet/aspnetcore/pull/63684) in ASP.NET Core repo.