### PR TITLE
Apply source generators to primary project only

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -1230,7 +1230,9 @@ namespace Microsoft.CodeAnalysis.Testing
 
         protected virtual async Task<(Compilation compilation, ImmutableArray<Diagnostic> generatorDiagnostics)> GetProjectCompilationAsync(Project project, IVerifier verifier, CancellationToken cancellationToken)
         {
-            var (finalProject, generatorDiagnostics) = await ApplySourceGeneratorsAsync(GetSourceGenerators().ToImmutableArray(), project, verifier, cancellationToken).ConfigureAwait(false);
+            var (finalProject, generatorDiagnostics) = project.Name == DefaultTestProjectName
+                ? await ApplySourceGeneratorsAsync(GetSourceGenerators().ToImmutableArray(), project, verifier, cancellationToken).ConfigureAwait(false)
+                : (project, ImmutableArray<Diagnostic>.Empty);
             return ((await finalProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false))!, generatorDiagnostics);
         }
 

--- a/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/SourceGeneratorTests.cs
+++ b/tests/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.UnitTests/SourceGeneratorTests.cs
@@ -346,6 +346,41 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         [Fact]
+        public async Task AddSimpleFileWithDiagnosticWithAdditionalProjects()
+        {
+            await new CSharpAnalyzerWithSourceGeneratorTest<EmptyDiagnosticAnalyzer, AddEmptyFileWithDiagnostic>
+            {
+                TestState =
+                {
+                    AdditionalProjects =
+                    {
+                        ["AdditionalProject"] =
+                        {
+                            Sources =
+                            {
+                                @"// Comment",
+                            },
+                        },
+                    },
+                    AdditionalProjectReferences = { "AdditionalProject" },
+                    Sources =
+                    {
+                        @"{|#0:|}// Comment",
+                    },
+                    GeneratedSources =
+                    {
+                        ("Microsoft.CodeAnalysis.Testing.Utilities\\Microsoft.CodeAnalysis.Testing.TestGenerators.AddEmptyFileWithDiagnostic\\EmptyGeneratedFile.cs", SourceText.From(string.Empty, Encoding.UTF8)),
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        // /0/Test0.cs(1,1): warning SG0001: Message
+                        new DiagnosticResult(AddEmptyFileWithDiagnostic.Descriptor).WithLocation(0),
+                    },
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task AddImplicitSimpleFileWithDiagnostic()
         {
             await new CSharpAnalyzerWithSourceGeneratorTest<EmptyDiagnosticAnalyzer, AddEmptyFileWithDiagnostic>


### PR DESCRIPTION
In `VerifyDiagnosticsAsync`, analyzers and generators are also applied to `AdditionalProjects`.
I don’t think this produces the intended test behavior.
More importantly, it’s inconsistent with `VerifySourceGeneratorAsync`, where generators are applied only to the primary project.

[https://github.com/dotnet/roslyn-sdk/blob/f500e81ba5596809e711a3022bf8e80a00c8371b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest%601.cs#L273C66-L283](https://github.com/dotnet/roslyn-sdk/blob/f500e81ba5596809e711a3022bf8e80a00c8371b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest%601.cs#L273C66-L283)
