### PR TITLE
Added the ability to to set the LanguageVersion and the GlobalOptions in the VB and C# source generator test classes.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/CSharpSourceGeneratorTest`2.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/CSharpSourceGeneratorTest`2.cs
@@ -24,8 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing
         /// Gets the global options to be used in <see cref="GetAnalyzerOptions"/>.
         /// This can be appended to by the user to provide additional options.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1414:Tuple types in signatures should have element names", Justification = "The tuple names in the global options are unknown.")]
-        public List<(string, string)> GlobalOptions { get; } = new();
+        public List<(string option, string val)> GlobalOptions { get; } = new();
 
         /// <summary>
         /// Gets or sets the C# language version used for the test. The default is <see cref="LanguageVersion.Default"/>.

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/ConfigOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/ConfigOptions.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Testing
+{
+    /// <summary>
+    /// Allows adding additional global options
+    /// </summary>
+    internal class ConfigOptions : AnalyzerConfigOptions
+    {
+        private readonly AnalyzerConfigOptions _workspaceOptions;
+        private readonly Dictionary<string, string> _globalOptions;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1414:Tuple types in signatures should have element names", Justification = "The tuple names in the global options are unknown.")]
+        public ConfigOptions(AnalyzerConfigOptions workspaceOptions, List<(string, string)> globalOptions)
+        {
+            _workspaceOptions = workspaceOptions;
+            _globalOptions = globalOptions.ToDictionary(t => t.Item1, t => t.Item2);
+        }
+
+        public override bool TryGetValue(string key, out string value)
+            => _workspaceOptions.TryGetValue(key, out value) || _globalOptions.TryGetValue(key, out value);
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/ConfigOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/ConfigOptions.cs
@@ -24,6 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing
         }
 
         public override bool TryGetValue(string key, out string value)
-            => _workspaceOptions.TryGetValue(key, out value) || _globalOptions.TryGetValue(key, out value);
+            => _workspaceOptions.TryGetValue(key, out value!) || _globalOptions.TryGetValue(key, out value!);
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/ConfigOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/ConfigOptions.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing
         private readonly AnalyzerConfigOptions _workspaceOptions;
         private readonly Dictionary<string, string> _globalOptions;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1414:Tuple types in signatures should have element names", Justification = "The tuple names in the global options are unknown.")]
-        public ConfigOptions(AnalyzerConfigOptions workspaceOptions, List<(string, string)> globalOptions)
+        public ConfigOptions(AnalyzerConfigOptions workspaceOptions, List<(string option, string val)> globalOptions)
         {
             _workspaceOptions = workspaceOptions;
             _globalOptions = globalOptions.ToDictionary(t => t.Item1, t => t.Item2);

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/ConfigOptions.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/ConfigOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing
         public ConfigOptions(AnalyzerConfigOptions workspaceOptions, List<(string option, string val)> globalOptions)
         {
             _workspaceOptions = workspaceOptions;
-            _globalOptions = globalOptions.ToDictionary(t => t.Item1, t => t.Item2);
+            _globalOptions = globalOptions.ToDictionary(t => t.option, t => t.val);
         }
 
         public override bool TryGetValue(string key, out string value)

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/OptionsProvider.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/OptionsProvider.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Testing
+{
+    /// <summary>
+    /// This class just passes argument through to the projects options provider and it used to provider custom global options
+    /// </summary>
+    internal class OptionsProvider : AnalyzerConfigOptionsProvider
+    {
+        private readonly AnalyzerConfigOptionsProvider _analyzerConfigOptionsProvider;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1414:Tuple types in signatures should have element names", Justification = "The tuple names in the global options are unknown.")]
+        public OptionsProvider(AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider, List<(string, string)> globalOptions)
+        {
+            _analyzerConfigOptionsProvider = analyzerConfigOptionsProvider;
+            GlobalOptions = new ConfigOptions(_analyzerConfigOptionsProvider.GlobalOptions, globalOptions);
+        }
+
+        public override AnalyzerConfigOptions GlobalOptions { get; }
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
+            => _analyzerConfigOptionsProvider.GetOptions(tree);
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
+            => _analyzerConfigOptionsProvider.GetOptions(textFile);
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/OptionsProvider.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/OptionsProvider.cs
@@ -14,8 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Testing
     {
         private readonly AnalyzerConfigOptionsProvider _analyzerConfigOptionsProvider;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1414:Tuple types in signatures should have element names", Justification = "The tuple names in the global options are unknown.")]
-        public OptionsProvider(AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider, List<(string, string)> globalOptions)
+        public OptionsProvider(AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider, List<(string option, string val)> globalOptions)
         {
             _analyzerConfigOptionsProvider = analyzerConfigOptionsProvider;
             GlobalOptions = new ConfigOptions(_analyzerConfigOptionsProvider.GlobalOptions, globalOptions);

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/PublicAPI.Unshipped.txt
@@ -7,3 +7,7 @@ override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSource
 override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.DefaultFileExt.get -> string
 override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.GetSourceGenerators() -> System.Collections.Generic.IEnumerable<System.Type>
 override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.Language.get -> string
+Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.GlobalOptions.get -> System.Collections.Generic.List<(string, string)>
+Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.LanguageVersion.get -> Microsoft.CodeAnalysis.CSharp.LanguageVersion
+Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.LanguageVersion.set -> void
+override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.GetAnalyzerOptions(Microsoft.CodeAnalysis.Project project) -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/PublicAPI.Unshipped.txt
@@ -7,7 +7,7 @@ override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSource
 override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.DefaultFileExt.get -> string
 override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.GetSourceGenerators() -> System.Collections.Generic.IEnumerable<System.Type>
 override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.Language.get -> string
-Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.GlobalOptions.get -> System.Collections.Generic.List<(string, string)>
+Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.GlobalOptions.get -> System.Collections.Generic.List<(string option, string val)>
 Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.LanguageVersion.get -> Microsoft.CodeAnalysis.CSharp.LanguageVersion
 Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.LanguageVersion.set -> void
 override Microsoft.CodeAnalysis.CSharp.Testing.CSharpSourceGeneratorTest<TSourceGenerator, TVerifier>.GetAnalyzerOptions(Microsoft.CodeAnalysis.Project project) -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/IGeneratorTestBase.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/IGeneratorTestBase.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Testing
+{
+    /// <summary>
+    /// This type is mainly used for declaring that a SourceGeneratorTest has global options set.
+    ///
+    /// It is also used for end users to be able to define their own generic generator
+    /// test run method inside of their unit test projects to more easily run tests for their source generator.
+    /// </summary>
+    public interface IGeneratorTestBase
+    {
+        /// <summary>
+        /// Gets the additional global options that will appear in the context.AnalyzerConfigOptions.GlobalOptions object.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1414:Tuple types in signatures should have element names", Justification = "The tuple names in the global options are unknown.")]
+        public List<(string, string)> GlobalOptions { get; }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/IGeneratorTestBase.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/IGeneratorTestBase.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <summary>
         /// Gets the additional global options that will appear in the context.AnalyzerConfigOptions.GlobalOptions object.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1414:Tuple types in signatures should have element names", Justification = "The tuple names in the global options are unknown.")]
-        public List<(string, string)> GlobalOptions { get; }
+        public List<(string option, string val)> GlobalOptions { get; }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/PublicAPI.Unshipped.txt
@@ -8,3 +8,5 @@ Microsoft.CodeAnalysis.Testing.SourceGeneratorVerifier<TSourceGenerator, TTest, 
 Microsoft.CodeAnalysis.Testing.SourceGeneratorVerifier<TSourceGenerator, TTest, TVerifier>.SourceGeneratorVerifier() -> void
 override Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.GetDiagnosticAnalyzers() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer>
 override abstract Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.GetSourceGenerators() -> System.Collections.Generic.IEnumerable<System.Type>
+Microsoft.CodeAnalysis.Testing.IGeneratorTestBase
+Microsoft.CodeAnalysis.Testing.IGeneratorTestBase.GlobalOptions.get -> System.Collections.Generic.List<(string, string)>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.SourceGenerators.Testing/PublicAPI.Unshipped.txt
@@ -9,4 +9,4 @@ Microsoft.CodeAnalysis.Testing.SourceGeneratorVerifier<TSourceGenerator, TTest, 
 override Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.GetDiagnosticAnalyzers() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer>
 override abstract Microsoft.CodeAnalysis.Testing.SourceGeneratorTest<TVerifier>.GetSourceGenerators() -> System.Collections.Generic.IEnumerable<System.Type>
 Microsoft.CodeAnalysis.Testing.IGeneratorTestBase
-Microsoft.CodeAnalysis.Testing.IGeneratorTestBase.GlobalOptions.get -> System.Collections.Generic.List<(string, string)>
+Microsoft.CodeAnalysis.Testing.IGeneratorTestBase.GlobalOptions.get -> System.Collections.Generic.List<(string option, string val)>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/ConfigOptions.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/ConfigOptions.vb
@@ -1,0 +1,20 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Diagnostics
+
+Friend Class ConfigOptions
+    Inherits AnalyzerConfigOptions
+
+    Private ReadOnly _workspaceOptions As AnalyzerConfigOptions
+    Private ReadOnly _globalOptions As Dictionary(Of String, String)
+
+    Public Sub New(workspaceOptions As AnalyzerConfigOptions, globalOptions As List(Of (String, String)))
+        _workspaceOptions = workspaceOptions
+        _globalOptions = globalOptions.ToDictionary(Function(pair) pair.Item1, Function(pair) pair.Item2)
+    End Sub
+
+    Public Overrides Function TryGetValue(key As String, ByRef value As String) As Boolean
+        Return _workspaceOptions.TryGetValue(key, value) Or _globalOptions.TryGetValue(key, value)
+    End Function
+
+End Class

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/OptionsProvider.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/OptionsProvider.vb
@@ -1,0 +1,30 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Diagnostics
+
+Friend Class OptionsProvider
+    Inherits AnalyzerConfigOptionsProvider
+
+    Private ReadOnly _analyzerConfigOptionsProvider As AnalyzerConfigOptionsProvider
+    Private ReadOnly _globalOptions As AnalyzerConfigOptions
+
+    Public Sub New(analyzerConfigOptionsProvider As AnalyzerConfigOptionsProvider, globalOptions As List(Of (String, String)))
+        _analyzerConfigOptionsProvider = analyzerConfigOptionsProvider
+        _globalOptions = New ConfigOptions(_analyzerConfigOptionsProvider.GlobalOptions, globalOptions)
+    End Sub
+
+    Public Overrides ReadOnly Property GlobalOptions As AnalyzerConfigOptions
+        Get
+            Return _globalOptions
+        End Get
+    End Property
+
+    Public Overrides Function GetOptions(tree As SyntaxTree) As AnalyzerConfigOptions
+        Return _analyzerConfigOptionsProvider.GetOptions(tree)
+    End Function
+
+    Public Overrides Function GetOptions(additionalFile As AdditionalText) As AnalyzerConfigOptions
+        Return _analyzerConfigOptionsProvider.GetOptions(additionalFile)
+    End Function
+
+End Class

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/PublicAPI.Unshipped.txt
@@ -7,3 +7,7 @@ Overrides Microsoft.CodeAnalysis.VisualBasic.Testing.VisualBasicSourceGeneratorT
 Overrides Microsoft.CodeAnalysis.VisualBasic.Testing.VisualBasicSourceGeneratorTest(Of TSourceGenerator, TVerifier).DefaultFileExt() -> String
 Overrides Microsoft.CodeAnalysis.VisualBasic.Testing.VisualBasicSourceGeneratorTest(Of TSourceGenerator, TVerifier).GetSourceGenerators() -> System.Collections.Generic.IEnumerable(Of System.Type)
 Overrides Microsoft.CodeAnalysis.VisualBasic.Testing.VisualBasicSourceGeneratorTest(Of TSourceGenerator, TVerifier).Language() -> String
+Microsoft.CodeAnalysis.VisualBasic.Testing.VisualBasicSourceGeneratorTest(Of TSourceGenerator, TVerifier).GlobalOptions() -> System.Collections.Generic.List(Of (String, String))
+Microsoft.CodeAnalysis.VisualBasic.Testing.VisualBasicSourceGeneratorTest(Of TSourceGenerator, TVerifier).LanguageVersion() -> Microsoft.CodeAnalysis.VisualBasic.LanguageVersion
+Microsoft.CodeAnalysis.VisualBasic.Testing.VisualBasicSourceGeneratorTest(Of TSourceGenerator, TVerifier).LanguageVersion(value As Microsoft.CodeAnalysis.VisualBasic.LanguageVersion) -> Void
+Overrides Microsoft.CodeAnalysis.VisualBasic.Testing.VisualBasicSourceGeneratorTest(Of TSourceGenerator, TVerifier).GetAnalyzerOptions(project As Microsoft.CodeAnalysis.Project) -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/VisualBasicSourceGeneratorTest`2.vb
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing/VisualBasicSourceGeneratorTest`2.vb
@@ -1,12 +1,14 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Testing
 
 Public Class VisualBasicSourceGeneratorTest(Of TSourceGenerator As New, TVerifier As {IVerifier, New})
     Inherits SourceGeneratorTest(Of TVerifier)
 
-    Private Shared ReadOnly DefaultLanguageVersion As LanguageVersion =
-        If([Enum].TryParse("Default", DefaultLanguageVersion), DefaultLanguageVersion, LanguageVersion.VisualBasic14)
+    Private _GlobalOptions As List(Of (String, String))
+    Private _LanguageVersion As LanguageVersion =
+        If([Enum].TryParse("Default", _LanguageVersion), _LanguageVersion, LanguageVersion.VisualBasic14)
 
     Public Overrides ReadOnly Property Language As String
         Get
@@ -20,15 +22,47 @@ Public Class VisualBasicSourceGeneratorTest(Of TSourceGenerator As New, TVerifie
         End Get
     End Property
 
+    ''' <summary>
+    ''' Gets the global options to be used in <see cref="GetAnalyzerOptions"/>.
+    ''' This can be appended to by the user to provide additional options.
+    ''' </summary>
+    Public ReadOnly Property GlobalOptions As List(Of (String, String))
+        Get
+            If _GlobalOptions Is Nothing Then
+                _GlobalOptions = New List(Of (String, String))()
+            End If
+            Return _GlobalOptions
+        End Get
+    End Property
+
+    ''' <summary>
+    ''' Gets Or sets the Visual Basic language version used for the test. The default Is <see cref="LanguageVersion.Default"/>.
+    ''' </summary>
+    Public Property LanguageVersion As LanguageVersion
+        Get
+            Return CType(_LanguageVersion, LanguageVersion)
+        End Get
+        Set(value As LanguageVersion)
+            _LanguageVersion = value
+        End Set
+    End Property
+
     Protected Overrides Function CreateCompilationOptions() As CompilationOptions
         Return New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
     End Function
 
     Protected Overrides Function CreateParseOptions() As ParseOptions
-        Return New VisualBasicParseOptions(DefaultLanguageVersion, DocumentationMode.Diagnose)
+        Return New VisualBasicParseOptions(LanguageVersion, DocumentationMode.Diagnose)
     End Function
 
     Protected Overrides Function GetSourceGenerators() As IEnumerable(Of Type)
         Return New Type() {GetType(TSourceGenerator)}
     End Function
+
+    Protected Overrides Function GetAnalyzerOptions(project As Project) As AnalyzerOptions
+        Return New AnalyzerOptions(
+            project.AnalyzerOptions.AdditionalFiles,
+            New OptionsProvider(project.AnalyzerOptions.AnalyzerConfigOptionsProvider, GlobalOptions))
+    End Function
+
 End Class


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-sdk/issues/1239.