### PR TITLE
Update NuGet.* versions and add .NET 8 TFM

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- This repo version -->
     <VersionPrefix>4.0.0</VersionPrefix>
-    <NugetPackagePrefix>1.1.3</NugetPackagePrefix>
+    <NugetPackagePrefix>1.1.4</NugetPackagePrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
     <!-- Opt-in repo features -->
     <UsingToolVSSDK>true</UsingToolVSSDK>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,8 @@
     <MicrosoftVisualStudioValidationVersion>17.0.64</MicrosoftVisualStudioValidationVersion>
     <NuGetSolutionRestoreManagerInteropVersion>5.6.0</NuGetSolutionRestoreManagerInteropVersion>
     <StreamJsonRpcVersion>2.12.27</StreamJsonRpcVersion>
-    <SystemFormatsAsn1Version>6.0.1</SystemFormatsAsn1Version>
+    <SystemFormatsAsn1Version Condition="'$(TargetFramework)' == 'net8.0'">9.0.6</SystemFormatsAsn1Version>
+    <SystemFormatsAsn1Version Condition="'$(TargetFramework)' != 'net8.0'">6.0.1</SystemFormatsAsn1Version>
     <SystemTextJsonVersion>6.0.10</SystemTextJsonVersion>
     <VSLangProjVersion>$(MicrosoftVisualStudioShellPackagesVersion)</VSLangProjVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>17.0.0-preview-1-30928-1111</MicrosoftVisualStudioTemplateWizardInterfaceVersion>

--- a/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Testing/Directory.Build.props
@@ -11,10 +11,11 @@
 
   <PropertyGroup>
     <!--
+      net8.0: Modern .NET target with current NuGet APIs
       netcoreapp3.1: Ensures full support for nullable reference types
       netstandard2.0/net472: Roslyn 3.x
     -->
-    <TestingLibraryTargetFrameworks>netcoreapp3.1;netstandard2.0;net461;net472</TestingLibraryTargetFrameworks>
+    <TestingLibraryTargetFrameworks>net8.0;netcoreapp3.1;netstandard2.0;net461;net472</TestingLibraryTargetFrameworks>
 
     <!--
       netcoreapp3.1: Ensures full support for nullable reference types

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/AnalyzerTest`1.cs
@@ -1311,6 +1311,7 @@ namespace Microsoft.CodeAnalysis.Testing
                                              let parameterTypes = method.GetParameters().Select(parameter => parameter.ParameterType).ToArray()
                                              where parameterTypes.SequenceEqual(new[] { iincrementalGeneratorType })
                                              select method).SingleOrDefault();
+                    verifier.True(asGeneratorMethod is not null, "Failed to locate AsSourceGenerator method");
                     convertedSourceGeneratorsArray.SetValue(asGeneratorMethod.Invoke(null, new[] { sourceGenerators[i] }), i);
                 }
             }
@@ -1320,6 +1321,7 @@ namespace Microsoft.CodeAnalysis.Testing
                                      let parameterTypes = method.GetParameters().Select(static parameter => parameter.ParameterType).ToArray()
                                      where parameterTypes.Length == 1 && parameterTypes[0].GetGenericTypeDefinition() == typeof(IEnumerable<>)
                                      select method).SingleOrDefault();
+            verifier.True(createRangeMethod is not null, "Failed to locate ImmutableArray.CreateRange method");
             var convertedSourceGenerators = createRangeMethod.MakeGenericMethod(isourceGeneratorType).Invoke(null, new object[] { convertedSourceGeneratorsArray });
 
             var analyzerOptions = GetAnalyzerOptions(project);

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/CodeActionTest`1.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/CodeActionTest`1.cs
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.Testing
 
                 if (x.content is null || y.content is null)
                 {
-                    return ReferenceEquals(x, y);
+                    return ReferenceEquals(x.content, y.content);
                 }
 
                 return x.content.Encoding == y.content.Encoding

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Lightup/LightupHelpers.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Lightup/LightupHelpers.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Testing.Lightup
             }
 
             var property = type.GetTypeInfo().GetDeclaredProperty(propertyName);
-            if (property == null)
+            if (property is null or { GetMethod: null })
             {
                 return CreateFallbackAccessor<T, TResult>(defaultValue);
             }

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/Microsoft.CodeAnalysis.Analyzer.Testing.csproj
@@ -19,6 +19,12 @@
         <NuGetApiVersion>5.11.6</NuGetApiVersion>
       </PropertyGroup>
     </When>
+    <When Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net8.0'">
+      <PropertyGroup>
+        <NuGetApiVersion>7.0.3</NuGetApiVersion>
+        <DefineConstants>$(DefineConstants);NUGET_SIGNING</DefineConstants>
+      </PropertyGroup>
+    </When>
     <Otherwise>
       <PropertyGroup>
         <NuGetApiVersion>6.3.4</NuGetApiVersion>

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies+FileSystemSemaphore.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies+FileSystemSemaphore.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Testing
             {
                 _path = path ?? throw new ArgumentNullException(nameof(path));
 
-                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                Directory.CreateDirectory(Path.GetDirectoryName(path) ?? throw new InvalidOperationException("The path does not have a valid directory."));
             }
 
             internal async Task<Releaser> WaitAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
+++ b/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Analyzer.Testing/ReferenceAssemblies.cs
@@ -96,6 +96,8 @@ namespace Microsoft.CodeAnalysis.Testing
                 return NetFramework.Net472.Default;
 #elif NETCOREAPP3_1
                 return NetCore.NetCoreApp31;
+#elif NET8_0_OR_GREATER
+                return Net.Net80;
 #endif
             }
         }
@@ -271,7 +273,9 @@ namespace Microsoft.CodeAnalysis.Testing
         /// <seealso href="https://martinbjorkstrom.com/posts/2018-09-19-revisiting-nuget-client-libraries"/>
         private async Task<ImmutableArray<MetadataReference>> ResolveCoreAsync(string language, CancellationToken cancellationToken)
         {
-            var settings = string.IsNullOrEmpty(NuGetConfigFilePath) ? Settings.LoadDefaultSettings(root: null) : Settings.LoadSpecificSettings(root: null, NuGetConfigFilePath);
+            // Nullable annotation is incorrect on root: https://github.com/NuGet/NuGet.Client/pull/7407.
+            // The NuGetConfigPath parameter warns on net472 as string.IsNullOrEmpty is not annotated on that platform.
+            var settings = string.IsNullOrEmpty(NuGetConfigFilePath) ? Settings.LoadDefaultSettings(root: null) : Settings.LoadSpecificSettings(root: null!, NuGetConfigFilePath!);
             var sourceRepositoryProvider = new SourceRepositoryProvider(new PackageSourceProvider(settings), Repository.Provider.GetCoreV3());
             var targetFramework = NuGetFramework.ParseFolder(TargetFramework);
             var logger = NullLogger.Instance;
@@ -520,7 +524,11 @@ namespace Microsoft.CodeAnalysis.Testing
                         var assembliesByPrecedence = assemblyNameGroup
                             .Select(static name => (name, framework: GetFrameworkNameFromPath(name)))
                             .OrderBy(static x => x.framework, comparer)
+#if NET8_0_OR_GREATER || NET472
+                            .ThenByDescending(static x => x.framework, NuGetFrameworkSorter.Instance)
+#else
                             .ThenByDescending(static x => x.framework, new NuGetFrameworkSorter())
+#endif
                             .ToArray();
                         for (var i = 1; i < assembliesByPrecedence.Length; i++)
                         {
@@ -1572,6 +1580,7 @@ namespace Microsoft.CodeAnalysis.Testing
         }
 
         private sealed class ImmutableDictionaryWithImmutableArrayValuesEqualityComparer<TKey, TValue> : IEqualityComparer<ImmutableDictionary<TKey, ImmutableArray<TValue>>?>
+            where TKey : notnull
         {
             public static readonly ImmutableDictionaryWithImmutableArrayValuesEqualityComparer<TKey, TValue> Instance = new();
 


### PR DESCRIPTION
The newest versions of the NuGet.* libraries have a breaking change that impacts consumers. When a consumer updates those packages to a newer version to avoid CVE alerts, the testing SDK breaks. We update the versions we use, address a few nullable warnings introduced, and add an explicit .NET 8 TFM for support of this new version.